### PR TITLE
Add watch mode for automatic pipeline re-execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.0",
     "pygtrie>=2.5.0",
     "pyyaml>=6.0",
+    "watchfiles>=1.0",
     "xxhash>=3.0",
 ]
 

--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -21,6 +21,7 @@ Example:
 
 from pivot import dvc_compat as dvc_compat
 from pivot import outputs as outputs
+from pivot import state as state
 from pivot.outputs import BaseOut as BaseOut
 from pivot.outputs import Metric as Metric
 from pivot.outputs import Out as Out

--- a/src/pivot/cli.py
+++ b/src/pivot/cli.py
@@ -5,14 +5,26 @@ Provides commands to run and manage pipelines from the command line.
 
 import logging
 import pathlib
-from typing import Any
 
 import click
 
-from pivot import executor
-from pivot.registry import REGISTRY
+from pivot import executor, registry
+from pivot.executor import ExecutionSummary
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_stages(stages_list: list[str] | None, single_stage: bool) -> None:
+    """Validate stage arguments and options."""
+    if single_stage and not stages_list:
+        raise click.ClickException("--single-stage requires at least one stage name")
+
+    if stages_list:
+        graph = registry.REGISTRY.build_dag(validate=True)
+        registered = set(graph.nodes())
+        unknown = [s for s in stages_list if s not in registered]
+        if unknown:
+            raise click.ClickException(f"Unknown stage(s): {', '.join(unknown)}")
 
 
 @click.group()
@@ -26,25 +38,66 @@ def cli(ctx: click.Context, verbose: bool) -> None:
 
 
 @cli.command()
-@click.option("--stages", "-s", multiple=True, metavar="STAGE", help="Specific stages to run")
+@click.argument("stages", nargs=-1)
+@click.option(
+    "--single-stage",
+    "-s",
+    is_flag=True,
+    help="Run only the specified stages (in provided order), not their dependencies",
+)
 @click.option("--cache-dir", type=click.Path(path_type=pathlib.Path), help="Cache directory")
 @click.option("--dry-run", "-n", is_flag=True, help="Show what would run without executing")
+@click.option(
+    "--watch",
+    "-w",
+    is_flag=False,
+    flag_value="",
+    default=None,
+    metavar="GLOBS",
+    help="Watch for file changes and re-run. Optionally specify comma-separated glob patterns.",
+)
+@click.option("--debounce", type=int, default=300, help="Debounce delay in milliseconds")
 @click.pass_context
 def run(
     ctx: click.Context,
     stages: tuple[str, ...],
+    single_stage: bool,
     cache_dir: pathlib.Path | None,
     dry_run: bool,
+    watch: str | None,
+    debounce: int,
 ) -> None:
-    """Execute pipeline stages."""
+    """Execute pipeline stages.
+
+    If STAGES are provided, runs those stages and their dependencies.
+    Use --single-stage to run only the specified stages without dependencies.
+    """
+    stages_list = list(stages) if stages else None
+    _validate_stages(stages_list, single_stage)
+
     if dry_run:
-        ctx.invoke(dry_run_cmd, stages=stages, cache_dir=cache_dir)
+        ctx.invoke(dry_run_cmd, stages=stages, single_stage=single_stage, cache_dir=cache_dir)
+        return
+
+    if watch is not None:
+        from pivot import watch as watch_module
+
+        # Parse comma-separated globs if provided
+        watch_globs = [g.strip() for g in watch.split(",") if g.strip()] if watch else None
+
+        watch_module.run_watch_loop(
+            stages=stages_list,
+            single_stage=single_stage,
+            cache_dir=cache_dir,
+            watch_globs=watch_globs,
+            debounce_ms=debounce,
+        )
         return
 
     try:
-        stage_list = list(stages) if stages else None
         results = executor.run(
-            stages=stage_list,
+            stages=stages_list,
+            single_stage=single_stage,
             cache_dir=cache_dir,
         )
         _print_results(results)
@@ -53,16 +106,26 @@ def run(
 
 
 @cli.command("dry-run")
-@click.option("--stages", "-s", multiple=True, metavar="STAGE", help="Specific stages to run")
+@click.argument("stages", nargs=-1)
+@click.option(
+    "--single-stage",
+    "-s",
+    is_flag=True,
+    help="Run only the specified stages (in provided order), not their dependencies",
+)
 @click.option("--cache-dir", type=click.Path(path_type=pathlib.Path), help="Cache directory")
-def dry_run_cmd(stages: tuple[str, ...], cache_dir: pathlib.Path | None) -> None:
+def dry_run_cmd(
+    stages: tuple[str, ...], single_stage: bool, cache_dir: pathlib.Path | None
+) -> None:
     """Show what would run without executing."""
     from pivot import dag, lock, project
 
+    stages_list = list(stages) if stages else None
+    _validate_stages(stages_list, single_stage)
+
     try:
-        graph = REGISTRY.build_dag(validate=True)
-        stage_list = list(stages) if stages else None
-        execution_order = dag.get_execution_order(graph, stage_list)
+        graph = registry.REGISTRY.build_dag(validate=True)
+        execution_order = dag.get_execution_order(graph, stages_list, single_stage=single_stage)
 
         if not execution_order:
             click.echo("No stages to run")
@@ -72,7 +135,7 @@ def dry_run_cmd(stages: tuple[str, ...], cache_dir: pathlib.Path | None) -> None
 
         click.echo("Would run:")
         for stage_name in execution_order:
-            stage_info = REGISTRY.get(stage_name)
+            stage_info = registry.REGISTRY.get(stage_name)
             stage_lock = lock.StageLock(stage_name, cache_path)
 
             current_fingerprint = stage_info["fingerprint"]
@@ -99,7 +162,7 @@ def dry_run_cmd(stages: tuple[str, ...], cache_dir: pathlib.Path | None) -> None
 def status(ctx: click.Context) -> None:
     """Show pipeline status."""
     verbose = ctx.obj.get("verbose", False)
-    stage_list = REGISTRY.list_stages()
+    stage_list = registry.REGISTRY.list_stages()
 
     if not stage_list:
         click.echo("No stages registered")
@@ -107,16 +170,16 @@ def status(ctx: click.Context) -> None:
 
     click.echo(f"Registered stages ({len(stage_list)}):")
     for name in stage_list:
-        info = REGISTRY.get(name)
-        deps = info.get("deps", [])
-        outs = info.get("outs_paths", [])
+        info = registry.REGISTRY.get(name)
+        deps = info["deps"]
+        outs = info["outs_paths"]
         click.echo(f"  {name}")
         if verbose:
             click.echo(f"    deps: {deps}")
             click.echo(f"    outs: {outs}")
 
 
-def _print_results(results: dict[str, dict[str, Any]]) -> None:
+def _print_results(results: dict[str, ExecutionSummary]) -> None:
     """Print execution results in a readable format."""
     ran = 0
     skipped = 0

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -1,8 +1,3 @@
-"""Pivot exceptions."""
-
-import enum
-
-
 class PivotError(Exception):
     """Base exception for Pivot errors."""
 
@@ -13,13 +8,6 @@ class ValidationError(PivotError):
     """Raised when stage validation fails."""
 
     pass
-
-
-class ValidationMode(enum.StrEnum):
-    """Validation strictness levels."""
-
-    ERROR = "error"  # Raise exception on validation failure
-    WARN = "warn"  # Log warning, allow registration
 
 
 class OutputDuplicationError(ValidationError):
@@ -84,5 +72,23 @@ class ExportError(DVCCompatError):
 
 class DVCImportError(DVCCompatError):
     """Raised when dvc.yaml import fails."""
+
+    pass
+
+
+class CacheError(PivotError):
+    """Base class for cache-related errors."""
+
+    pass
+
+
+class OutputMissingError(CacheError):
+    """Raised when a stage did not produce a declared output."""
+
+    pass
+
+
+class CacheRestoreError(CacheError):
+    """Raised when restoring outputs from cache fails."""
 
     pass

--- a/src/pivot/state.py
+++ b/src/pivot/state.py
@@ -1,0 +1,77 @@
+"""SQLite-backed cache for file metadata to hash mappings."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING, Self
+
+if TYPE_CHECKING:
+    import os
+    import pathlib
+
+
+class StateDB:
+    """SQLite cache of (inode, mtime, size) -> hash to skip rehashing unchanged files."""
+
+    def __init__(self, db_path: pathlib.Path) -> None:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: sqlite3.Connection = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._create_schema()
+
+    def _create_schema(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS state (
+                path TEXT PRIMARY KEY,
+                mtime REAL,
+                size INTEGER,
+                inode INTEGER,
+                hash TEXT
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_state_hash ON state(hash)")
+        self._conn.commit()
+
+    def get(self, path: pathlib.Path, fs_stat: os.stat_result) -> str | None:
+        """Return cached hash if file metadata matches, else None."""
+        abs_path = str(path.resolve())
+        cursor = self._conn.execute(
+            "SELECT hash FROM state WHERE path = ? AND mtime = ? AND size = ? AND inode = ?",
+            (abs_path, fs_stat.st_mtime, fs_stat.st_size, fs_stat.st_ino),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def save(self, path: pathlib.Path, fs_stat: os.stat_result, file_hash: str) -> None:
+        """Cache file metadata and hash."""
+        abs_path = str(path.resolve())
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO state (path, mtime, size, inode, hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (abs_path, fs_stat.st_mtime, fs_stat.st_size, fs_stat.st_ino, file_hash),
+        )
+        self._conn.commit()
+
+    def save_many(self, entries: list[tuple[pathlib.Path, os.stat_result, str]]) -> None:
+        """Batch save multiple entries."""
+        data = [(str(p.resolve()), s.st_mtime, s.st_size, s.st_ino, h) for p, s, h in entries]
+        self._conn.executemany(
+            """
+            INSERT OR REPLACE INTO state (path, mtime, size, inode, hash)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            data,
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -41,12 +41,38 @@ class StageResult(TypedDict):
     output_lines: list[tuple[str, bool]]
 
 
+class FileHash(TypedDict):
+    """Hash info for a single file."""
+
+    hash: str
+
+
+class DirManifestEntry(TypedDict, total=False):
+    """Entry in directory manifest."""
+
+    relpath: str
+    hash: str
+    size: int
+    isexec: bool
+
+
+class DirHash(TypedDict):
+    """Hash info for a directory with full manifest."""
+
+    hash: str
+    manifest: list[DirManifestEntry]
+
+
+OutputHash = FileHash | DirHash | None
+
+
 class LockData(TypedDict, total=False):
     """Data stored in stage lock files."""
 
     code_manifest: dict[str, str]
     params: dict[str, Any]
     dep_hashes: dict[str, str]
+    output_hashes: dict[str, OutputHash]
 
 
 # Type alias for output queue messages: (stage_name, line, is_stderr) or None for shutdown

--- a/src/pivot/watch.py
+++ b/src/pivot/watch.py
@@ -1,0 +1,186 @@
+"""Watch mode for automatic pipeline re-execution on file changes."""
+
+import fnmatch
+import logging
+import pathlib
+from typing import TYPE_CHECKING
+
+import watchfiles
+
+from pivot import console, dag, executor, project, registry
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Set
+
+    from watchfiles import Change
+
+
+def run_watch_loop(
+    stages: list[str] | None = None,
+    single_stage: bool = False,
+    cache_dir: pathlib.Path | None = None,
+    watch_globs: list[str] | None = None,
+    debounce_ms: int = 300,
+) -> int:
+    """Run pipeline in watch mode, returning number of re-runs."""
+    # Determine which stages will actually be executed
+    graph = registry.REGISTRY.build_dag(validate=True)
+    stages_to_run = dag.get_execution_order(graph, stages, single_stage=single_stage)
+
+    watch_paths = _collect_watch_paths(stages_to_run)
+    con = console.get_console()
+    reloads = 0
+
+    con.watch_start(watch_paths)
+
+    while True:
+        try:
+            _run_pipeline_safely(con, stages, single_stage, cache_dir)
+            con.watch_waiting()
+
+            # Recreate filter each iteration to capture any new outputs from registry
+            # Only filter outputs from stages that are actually being run
+            watch_filter = _create_output_filter(stages_to_run, watch_globs)
+            changes = _wait_for_changes(watch_paths, watch_filter, debounce_ms)
+            con.watch_changes_detected(changes)
+
+            # Wait for quiet period to ensure no more rapid changes are incoming
+            _wait_for_quiet_period(watch_paths, watch_filter, debounce_ms)
+            reloads += 1
+
+        except KeyboardInterrupt:
+            con.watch_stopped()
+            return reloads
+
+
+def _run_pipeline_safely(
+    con: console.Console,
+    stages: list[str] | None,
+    single_stage: bool,
+    cache_dir: pathlib.Path | None,
+) -> None:
+    """Run pipeline, logging errors without exiting."""
+    try:
+        executor.run(stages=stages, single_stage=single_stage, cache_dir=cache_dir)
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        con.error(f"Pipeline failed: {e}")
+
+
+def _wait_for_changes(
+    watch_paths: list[pathlib.Path],
+    watch_filter: "Callable[[Change, str], bool]",
+    debounce_ms: int,
+) -> "Set[tuple[Change, str]]":
+    """Block until file changes detected, return change set."""
+    for changes in watchfiles.watch(
+        *watch_paths,
+        watch_filter=watch_filter,
+        raise_interrupt=False,
+        debounce=debounce_ms,
+    ):
+        return changes
+    return set()  # Unreachable, but satisfies type checker
+
+
+def _wait_for_quiet_period(
+    watch_paths: list[pathlib.Path],
+    watch_filter: "Callable[[Change, str], bool]",
+    debounce_ms: int,
+) -> None:
+    """Wait until no more changes occur within the debounce window."""
+    # Use non-blocking check with short timeout to see if more changes are pending
+    timeout_seconds = debounce_ms / 1000.0
+    while True:
+        more_changes = list(
+            watchfiles.watch(
+                *watch_paths,
+                watch_filter=watch_filter,
+                raise_interrupt=False,
+                debounce=debounce_ms,
+                yield_on_timeout=True,
+                rust_timeout=int(timeout_seconds * 1000),
+            )
+        )
+        # If we got an empty yield (timeout with no changes), the quiet period is over
+        if not more_changes or not more_changes[0]:
+            break
+        # More changes detected, continue waiting
+
+
+def _collect_watch_paths(stages: list[str]) -> list[pathlib.Path]:
+    """Collect paths: project root + dependency directories for specified stages."""
+    root = project.get_project_root()
+    paths = {root}
+    for name in stages:
+        try:
+            info = registry.REGISTRY.get(name)
+        except KeyError:
+            logger.warning(f"Stage '{name}' not found in registry, skipping watch paths")
+            continue
+        for dep in info["deps"]:
+            dep_path = pathlib.Path(dep)
+            if dep_path.exists():
+                paths.add(dep_path.parent if dep_path.is_file() else dep_path)
+    return list(paths)
+
+
+def _resolve_path(path: str) -> pathlib.Path:
+    """Resolve path to canonical form (resolves symlinks, normalizes case)."""
+    return pathlib.Path(path).resolve()
+
+
+def _get_output_paths_for_stages(stages: list[str]) -> set[str]:
+    """Get output paths for specific stages only."""
+    result = set[str]()
+    for name in stages:
+        try:
+            info = registry.REGISTRY.get(name)
+        except KeyError:
+            logger.warning(f"Stage '{name}' not found in registry, skipping output filtering")
+            continue
+        for out_path in info["outs_paths"]:
+            result.add(str(out_path))
+    return result
+
+
+def _create_output_filter(
+    stages_to_run: list[str],
+    watch_globs: list[str] | None = None,
+) -> "Callable[[Change, str], bool]":
+    """Create filter excluding outputs from stages being run (prevents infinite loops)."""
+    # Only filter outputs from stages that will actually execute
+    # This allows changes to outputs from NON-running stages to trigger re-runs
+    # (e.g., in single-stage mode, upstream outputs should trigger re-runs)
+    outputs_to_filter = {_resolve_path(p) for p in _get_output_paths_for_stages(stages_to_run)}
+
+    def watch_filter(change: "Change", path: str) -> bool:
+        _ = change
+
+        # Always filter Python bytecode
+        if path.endswith((".pyc", ".pyo")) or "__pycache__" in path:
+            return False
+
+        # Resolve incoming path for consistent comparison
+        resolved_path = _resolve_path(path)
+
+        # Check if path is an output of a stage being run, or inside such an output directory
+        for out in outputs_to_filter:
+            if resolved_path == out or out in resolved_path.parents:
+                return False
+
+        # Apply glob filters if specified
+        if watch_globs:
+            filename = resolved_path.name
+            rel_path = path  # Could make this relative to project root if needed
+            return any(
+                fnmatch.fnmatch(filename, glob) or fnmatch.fnmatch(rel_path, glob)
+                for glob in watch_globs
+            )
+
+        return True
+
+    return watch_filter

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_cli_run_help(runner: click.testing.CliRunner) -> None:
     """Run subcommand should show its own help."""
     result = runner.invoke(cli.cli, ["run", "--help"])
     assert result.exit_code == 0
-    assert "--stages" in result.output
+    assert "--single-stage" in result.output
     assert "--dry-run" in result.output
 
 
@@ -165,10 +165,10 @@ def test_cli_dry_run_no_stages(runner: click.testing.CliRunner, tmp_path: pathli
         assert "No stages" in result.output
 
 
-def test_cli_dry_run_specific_stages(
+def test_cli_dry_run_specific_stage(
     runner: click.testing.CliRunner, tmp_path: pathlib.Path
 ) -> None:
-    """Dry-run with --stages only shows specified stages."""
+    """Dry-run with stage argument only shows specified stage and dependencies."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
         pathlib.Path("input.txt").write_text("data")
@@ -181,7 +181,7 @@ def test_cli_dry_run_specific_stages(
         def stage_b() -> None:
             pass
 
-        result = runner.invoke(cli.cli, ["run", "--dry-run", "--stages", "stage_a"])
+        result = runner.invoke(cli.cli, ["run", "--dry-run", "stage_a"])
 
         assert result.exit_code == 0
         assert "stage_a" in result.output
@@ -218,7 +218,7 @@ def test_cli_run_exception_shows_error(
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["run", "--stages", "nonexistent"])
+        result = runner.invoke(cli.cli, ["run", "nonexistent"])
 
         assert result.exit_code != 0
         assert "nonexistent" in result.output.lower() or "error" in result.output.lower()
@@ -231,7 +231,7 @@ def test_cli_dry_run_exception_shows_error(
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["run", "--dry-run", "--stages", "nonexistent"])
+        result = runner.invoke(cli.cli, ["run", "--dry-run", "nonexistent"])
 
         assert result.exit_code != 0
 

--- a/tests/test_path_overlap.py
+++ b/tests/test_path_overlap.py
@@ -9,6 +9,7 @@ These tests check if our current implementation correctly handles:
 import pytest
 
 from pivot import registry
+from pivot.exceptions import ValidationError
 
 
 def test_directory_output_vs_file_output_conflict() -> None:
@@ -32,7 +33,7 @@ def test_directory_output_vs_file_output_conflict() -> None:
     reg.register(stage_a, name="stage_a", deps=[], outs=["data/"])
 
     # Stage B outputs file inside that directory - should conflict
-    with pytest.raises(registry.ValidationError, match="conflict|overlap"):
+    with pytest.raises(ValidationError, match="conflict|overlap"):
         reg.register(stage_b, name="stage_b", deps=[], outs=["data/train.csv"])
 
 
@@ -57,7 +58,7 @@ def test_parent_directory_output_vs_child_directory_output() -> None:
     reg.register(stage_a, name="stage_a", deps=[], outs=["data/"])
 
     # Stage B outputs child directory - should conflict
-    with pytest.raises(registry.ValidationError, match="conflict|overlap"):
+    with pytest.raises(ValidationError, match="conflict|overlap"):
         reg.register(stage_b, name="stage_b", deps=[], outs=["data/raw/"])
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,208 @@
+"""Tests for SQLite-backed file metadata state cache."""
+
+import os
+import pathlib
+import time
+
+from pivot import state
+
+
+def test_state_cache_hit(tmp_path: pathlib.Path) -> None:
+    """Unchanged mtime/size/inode returns cached hash."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, file_stat, "abc123")
+
+    result = db.get(test_file, file_stat)
+
+    assert result == "abc123"
+
+
+def test_state_cache_miss_mtime(tmp_path: pathlib.Path) -> None:
+    """Changed mtime triggers cache miss."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    old_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, old_stat, "abc123")
+
+    time.sleep(0.01)
+    test_file.write_text("content")
+    new_stat = test_file.stat()
+
+    result = db.get(test_file, new_stat)
+
+    assert result is None
+
+
+def test_state_cache_miss_size(tmp_path: pathlib.Path) -> None:
+    """Changed size triggers cache miss."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("short")
+    old_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, old_stat, "abc123")
+
+    test_file.write_text("much longer content")
+    os.utime(test_file, (old_stat.st_mtime, old_stat.st_mtime))
+    new_stat = test_file.stat()
+
+    result = db.get(test_file, new_stat)
+
+    assert result is None
+
+
+def test_state_cache_miss_inode(tmp_path: pathlib.Path) -> None:
+    """Changed inode triggers cache miss."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    old_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, old_stat, "abc123")
+
+    test_file.unlink()
+    test_file.write_text("content")
+    new_stat = test_file.stat()
+
+    result = db.get(test_file, new_stat)
+
+    assert result is None
+
+
+def test_state_save_many(tmp_path: pathlib.Path) -> None:
+    """Batch save works correctly."""
+    db_path = tmp_path / "state.db"
+    files = list[tuple[pathlib.Path, os.stat_result]]()
+    entries = list[tuple[pathlib.Path, os.stat_result, str]]()
+
+    for i in range(5):
+        f = tmp_path / f"file_{i}.txt"
+        f.write_text(f"content {i}")
+        stat = f.stat()
+        files.append((f, stat))
+        entries.append((f, stat, f"hash_{i}"))
+
+    db = state.StateDB(db_path)
+    db.save_many(entries)
+
+    for i, (f, stat) in enumerate(files):
+        result = db.get(f, stat)
+        assert result == f"hash_{i}"
+
+
+def test_state_db_persistence(tmp_path: pathlib.Path) -> None:
+    """State survives process restart (new instance)."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db1 = state.StateDB(db_path)
+    db1.save(test_file, file_stat, "persistent_hash")
+    del db1
+
+    db2 = state.StateDB(db_path)
+    result = db2.get(test_file, file_stat)
+
+    assert result == "persistent_hash"
+
+
+def test_state_get_missing_path(tmp_path: pathlib.Path) -> None:
+    """Getting uncached path returns None."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+
+    result = db.get(test_file, file_stat)
+
+    assert result is None
+
+
+def test_state_update_existing(tmp_path: pathlib.Path) -> None:
+    """Saving same path updates the cached hash."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, file_stat, "old_hash")
+    db.save(test_file, file_stat, "new_hash")
+
+    result = db.get(test_file, file_stat)
+
+    assert result == "new_hash"
+
+
+def test_state_db_creates_parent_dirs(tmp_path: pathlib.Path) -> None:
+    """StateDB creates parent directories if needed."""
+    db_path = tmp_path / "nested" / "deep" / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, file_stat, "hash")
+
+    assert db_path.exists()
+
+
+def test_state_close(tmp_path: pathlib.Path) -> None:
+    """StateDB can be closed and reopened."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file, file_stat, "hash")
+    db.close()
+
+    db2 = state.StateDB(db_path)
+    result = db2.get(test_file, file_stat)
+
+    assert result == "hash"
+
+
+def test_state_context_manager(tmp_path: pathlib.Path) -> None:
+    """StateDB works as context manager."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    with state.StateDB(db_path) as db:
+        db.save(test_file, file_stat, "hash")
+
+    with state.StateDB(db_path) as db:
+        result = db.get(test_file, file_stat)
+
+    assert result == "hash"
+
+
+def test_state_absolute_paths(tmp_path: pathlib.Path) -> None:
+    """Paths are stored as absolute for consistency."""
+    db_path = tmp_path / "state.db"
+    test_file = tmp_path / "file.txt"
+    test_file.write_text("content")
+    file_stat = test_file.stat()
+
+    db = state.StateDB(db_path)
+    db.save(test_file.resolve(), file_stat, "hash")
+
+    result = db.get(test_file.resolve(), file_stat)
+
+    assert result == "hash"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,6 +7,7 @@ and detection of conflicts like duplicate stage names or output conflicts.
 import pytest
 
 from pivot import registry
+from pivot.exceptions import ValidationError
 
 
 def test_duplicate_stage_name_raises_error() -> None:
@@ -21,7 +22,7 @@ def test_duplicate_stage_name_raises_error() -> None:
 
     reg.register(stage1, name="process", deps=list[str](), outs=list[str](), params_cls=None)
 
-    with pytest.raises(registry.ValidationError, match="already registered"):
+    with pytest.raises(ValidationError, match="already registered"):
         reg.register(stage2, name="process", deps=list[str](), outs=list[str](), params_cls=None)
 
 
@@ -51,7 +52,7 @@ def test_invalid_dep_path_with_parent_traversal() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="path traversal"):
+    with pytest.raises(ValidationError, match="path traversal"):
         reg.register(
             stage1,
             name="process",
@@ -68,7 +69,7 @@ def test_invalid_out_path_with_parent_traversal() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="path traversal"):
+    with pytest.raises(ValidationError, match="path traversal"):
         reg.register(
             stage1,
             name="process",
@@ -85,7 +86,7 @@ def test_invalid_path_with_null_byte() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="null byte"):
+    with pytest.raises(ValidationError, match="null byte"):
         reg.register(
             stage1,
             name="process",
@@ -102,7 +103,7 @@ def test_invalid_path_with_newline() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="newline"):
+    with pytest.raises(ValidationError, match="newline"):
         reg.register(
             stage1,
             name="process",
@@ -124,7 +125,7 @@ def test_output_conflict_raises_error() -> None:
 
     reg.register(stage1, name="process1", deps=list[str](), outs=["output.txt"], params_cls=None)
 
-    with pytest.raises(registry.ValidationError, match="produced by both"):
+    with pytest.raises(ValidationError, match="produced by both"):
         reg.register(
             stage2, name="process2", deps=list[str](), outs=["output.txt"], params_cls=None
         )
@@ -153,7 +154,7 @@ def test_empty_stage_name_raises_error() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="cannot be empty"):
+    with pytest.raises(ValidationError, match="cannot be empty"):
         reg.register(stage1, name="", deps=list[str](), outs=list[str](), params_cls=None)
 
 
@@ -164,7 +165,7 @@ def test_whitespace_only_stage_name_raises_error() -> None:
     def stage1() -> None:
         pass
 
-    with pytest.raises(registry.ValidationError, match="cannot be empty"):
+    with pytest.raises(ValidationError, match="cannot be empty"):
         reg.register(stage1, name="   ", deps=list[str](), outs=list[str](), params_cls=None)
 
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,369 @@
+"""Tests for watch mode functionality."""
+
+import pathlib
+from unittest import mock
+
+import pytest
+from watchfiles import Change
+
+from pivot import watch
+from pivot.registry import REGISTRY, stage
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Set up a temporary pipeline directory."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pivot.yaml").write_text("version: 1\n")
+    REGISTRY.clear()
+    return tmp_path
+
+
+# _collect_watch_paths tests
+
+
+def test_collect_watch_paths_includes_project_root(pipeline_dir: pathlib.Path) -> None:
+    """Project root should always be in watch paths."""
+    paths = watch._collect_watch_paths([])
+    assert pipeline_dir in paths
+
+
+def test_collect_watch_paths_includes_dependency_directories(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Dependency file directories should be included."""
+    data_dir = pipeline_dir / "data"
+    data_dir.mkdir()
+    (data_dir / "input.csv").write_text("a,b\n1,2")
+
+    @stage(deps=["data/input.csv"], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    paths = watch._collect_watch_paths(["process"])
+    assert data_dir in paths
+
+
+def test_collect_watch_paths_handles_missing_stage(pipeline_dir: pathlib.Path) -> None:
+    """Should handle missing stage gracefully."""
+    paths = watch._collect_watch_paths(["nonexistent_stage"])
+    assert pipeline_dir in paths
+
+
+def test_collect_watch_paths_handles_nonexistent_dep_path(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Should not include paths for dependencies that don't exist."""
+
+    @stage(deps=["nonexistent/file.txt"], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    paths = watch._collect_watch_paths(["process"])
+    assert len(paths) == 1
+    assert pipeline_dir in paths
+
+
+# _create_output_filter tests
+
+
+def test_output_filter_filters_exact_output_match(pipeline_dir: pathlib.Path) -> None:
+    """Should filter out exact output file paths."""
+    output_path = pipeline_dir / "output.txt"
+
+    @stage(deps=[], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["process"])
+
+    assert watch_filter(Change.modified, str(output_path)) is False
+
+
+def test_output_filter_filters_files_under_output_directory(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Should filter out files under output directories."""
+    output_dir = pipeline_dir / "models"
+    output_dir.mkdir()
+
+    @stage(deps=[], outs=["models/"])
+    def train() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["train"])
+
+    assert watch_filter(Change.modified, str(output_dir / "checkpoint.pt")) is False
+
+
+def test_output_filter_filters_directory_itself(pipeline_dir: pathlib.Path) -> None:
+    """Should filter out the output directory itself (without trailing slash)."""
+    output_dir = pipeline_dir / "models"
+    output_dir.mkdir()
+
+    @stage(deps=[], outs=["models/"])
+    def train() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["train"])
+
+    # Directory reported without trailing slash should still be filtered
+    assert watch_filter(Change.modified, str(output_dir)) is False
+
+
+def test_output_filter_allows_source_files(pipeline_dir: pathlib.Path) -> None:
+    """Should allow source files that are not outputs."""
+    source_path = pipeline_dir / "src" / "main.py"
+
+    @stage(deps=[], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["process"])
+
+    assert watch_filter(Change.modified, str(source_path)) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/some/path/file.pyc",
+        "/some/path/__pycache__/file.py",
+        "/some/path/file.pyo",
+    ],
+)
+def test_output_filter_filters_python_bytecode(pipeline_dir: pathlib.Path, path: str) -> None:
+    """Should filter out .pyc, .pyo, and __pycache__ files."""
+    watch_filter = watch._create_output_filter([])
+    assert watch_filter(Change.modified, path) is False
+
+
+def test_output_filter_resolves_symlinks(pipeline_dir: pathlib.Path) -> None:
+    """Should filter symlinked paths that resolve to outputs."""
+    # Create output directory
+    output_dir = pipeline_dir / "real_output"
+    output_dir.mkdir()
+
+    # Create symlink to output directory
+    link_path = pipeline_dir / "link_to_output"
+    link_path.symlink_to(output_dir)
+
+    @stage(deps=[], outs=["real_output/"])
+    def process() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["process"])
+
+    # Path via symlink should be filtered (resolves to same location)
+    assert watch_filter(Change.modified, str(link_path / "file.txt")) is False
+    # Direct path should also be filtered
+    assert watch_filter(Change.modified, str(output_dir / "file.txt")) is False
+
+
+# Glob filter tests
+
+
+def test_output_filter_with_glob_matches_filename(pipeline_dir: pathlib.Path) -> None:
+    """Glob filter should match by filename."""
+    watch_filter = watch._create_output_filter([], watch_globs=["*.py"])
+
+    assert watch_filter(Change.modified, "/some/path/script.py") is True
+    assert watch_filter(Change.modified, "/some/path/data.csv") is False
+
+
+def test_output_filter_with_glob_matches_path_pattern(pipeline_dir: pathlib.Path) -> None:
+    """Glob filter should match full path patterns."""
+    watch_filter = watch._create_output_filter([], watch_globs=["*/src/*"])
+
+    assert watch_filter(Change.modified, "/project/src/main.py") is True
+    assert watch_filter(Change.modified, "/project/tests/test.py") is False
+
+
+def test_output_filter_with_multiple_globs(pipeline_dir: pathlib.Path) -> None:
+    """Multiple globs should be OR'd together."""
+    watch_filter = watch._create_output_filter([], watch_globs=["*.py", "*.txt"])
+
+    assert watch_filter(Change.modified, "/path/script.py") is True
+    assert watch_filter(Change.modified, "/path/readme.txt") is True
+    assert watch_filter(Change.modified, "/path/data.csv") is False
+
+
+def test_output_filter_glob_still_filters_outputs(pipeline_dir: pathlib.Path) -> None:
+    """Glob filter should still exclude stage outputs."""
+    output_path = pipeline_dir / "output.py"
+
+    @stage(deps=[], outs=["output.py"])
+    def process() -> None:
+        pass
+
+    watch_filter = watch._create_output_filter(["process"], watch_globs=["*.py"])
+
+    # Even though it matches *.py, it should be filtered as an output
+    assert watch_filter(Change.modified, str(output_path)) is False
+
+
+def test_output_filter_excludes_intermediate_files(pipeline_dir: pathlib.Path) -> None:
+    """Intermediate files (output of one stage, dependency of another) should be filtered."""
+    intermediate_path = pipeline_dir / "intermediate.txt"
+
+    @stage(deps=[], outs=["intermediate.txt"])
+    def stage_a() -> None:
+        pass
+
+    @stage(deps=["intermediate.txt"], outs=["final.txt"])
+    def stage_b() -> None:
+        pass
+
+    # Both stages running - intermediate.txt is filtered as output of stage_a
+    watch_filter = watch._create_output_filter(["stage_a", "stage_b"])
+
+    # intermediate.txt is an OUTPUT of stage_a, so it should be filtered
+    # even though it's also a dependency of stage_b
+    assert watch_filter(Change.modified, str(intermediate_path)) is False
+
+
+# _resolve_path tests
+
+
+def test_resolve_path_returns_realpath(pipeline_dir: pathlib.Path) -> None:
+    """_resolve_path should resolve symlinks."""
+    real_file = pipeline_dir / "real.txt"
+    real_file.write_text("content")
+    link_file = pipeline_dir / "link.txt"
+    link_file.symlink_to(real_file)
+
+    resolved = watch._resolve_path(str(link_file))
+    assert resolved == real_file.resolve()
+
+
+def test_resolve_path_handles_nonexistent_path() -> None:
+    """_resolve_path should handle non-existent paths gracefully."""
+    result = watch._resolve_path("/nonexistent/path/file.txt")
+    # Should return a Path, not crash
+    assert isinstance(result, pathlib.Path)
+
+
+# run_watch_loop tests
+
+
+def test_watch_loop_exits_on_keyboard_interrupt_during_wait(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Watch loop should exit cleanly on KeyboardInterrupt while waiting."""
+    (pipeline_dir / "input.txt").write_text("data")
+
+    @stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        pathlib.Path("output.txt").write_text("done")
+
+    def mock_wait(*args: object, **kwargs: object) -> None:
+        raise KeyboardInterrupt
+
+    with (
+        mock.patch.object(watch, "executor") as mock_executor,
+        mock.patch.object(watch, "_wait_for_changes", mock_wait),
+    ):
+        reloads = watch.run_watch_loop()
+
+        assert reloads == 0
+        assert mock_executor.run.call_count == 1
+
+
+def test_watch_loop_exits_on_keyboard_interrupt_during_pipeline(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Watch loop should exit cleanly on KeyboardInterrupt during pipeline execution."""
+    (pipeline_dir / "input.txt").write_text("data")
+
+    @stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    with mock.patch.object(watch, "executor") as mock_executor:
+        mock_executor.run.side_effect = KeyboardInterrupt
+
+        reloads = watch.run_watch_loop()
+
+        assert reloads == 0
+        assert mock_executor.run.call_count == 1
+
+
+def test_watch_loop_continues_on_pipeline_error(pipeline_dir: pathlib.Path) -> None:
+    """Watch loop should continue watching after pipeline error."""
+    (pipeline_dir / "input.txt").write_text("data")
+
+    @stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    call_count = 0
+
+    def run_side_effect(*args: object, **kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("Pipeline failed")
+        raise KeyboardInterrupt
+
+    def mock_wait(*args: object, **kwargs: object) -> set[tuple[Change, str]]:
+        return {(Change.modified, str(pipeline_dir / "input.txt"))}
+
+    def mock_quiet(*args: object, **kwargs: object) -> None:
+        pass
+
+    with (
+        mock.patch.object(watch, "executor") as mock_executor,
+        mock.patch.object(watch, "_wait_for_changes", mock_wait),
+        mock.patch.object(watch, "_wait_for_quiet_period", mock_quiet),
+    ):
+        mock_executor.run.side_effect = run_side_effect
+
+        reloads = watch.run_watch_loop()
+
+        assert mock_executor.run.call_count == 2
+        assert reloads == 1, "Should have reloaded once after detecting changes"
+
+
+def test_watch_loop_passes_globs_to_filter(pipeline_dir: pathlib.Path) -> None:
+    """Watch loop should pass watch_globs to the output filter."""
+    (pipeline_dir / "input.txt").write_text("data")
+
+    @stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        pass
+
+    def mock_wait(*args: object, **kwargs: object) -> None:
+        raise KeyboardInterrupt
+
+    with (
+        mock.patch.object(watch, "executor"),
+        mock.patch.object(watch, "_wait_for_changes", mock_wait),
+        mock.patch.object(watch, "_create_output_filter") as mock_create_filter,
+    ):
+        mock_create_filter.return_value = lambda c, p: True  # pyright: ignore[reportUnknownLambdaType]
+
+        watch.run_watch_loop(watch_globs=["*.py", "*.txt"])
+
+        # First arg is stages_to_run, second is watch_globs
+        mock_create_filter.assert_called_with(["process"], ["*.py", "*.txt"])
+
+
+# get_all_output_paths tests
+
+
+def test_registry_get_all_output_paths(pipeline_dir: pathlib.Path) -> None:
+    """REGISTRY.get_all_output_paths() should return all registered output paths."""
+
+    @stage(deps=[], outs=["output1.txt"])
+    def stage1() -> None:
+        pass
+
+    @stage(deps=[], outs=["models/"])
+    def stage2() -> None:
+        pass
+
+    paths = REGISTRY.get_all_output_paths()
+
+    assert len(paths) == 2
+    assert any("output1.txt" in p for p in paths)
+    assert any("models" in p for p in paths)

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
 
 [[package]]
+name = "anyio"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1173,6 +1185,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pygtrie" },
     { name = "pyyaml" },
+    { name = "watchfiles" },
     { name = "xxhash" },
 ]
 
@@ -1201,6 +1214,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygtrie", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "watchfiles", specifier = ">=1.0" },
     { name = "xxhash", specifier = ">=3.0" },
 ]
 provides-extras = ["dvc"]
@@ -1931,6 +1945,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #2 
Closes #3 

## Summary

- Adds watch mode (`--watch`/`-w`) for automatic pipeline re-execution when source files change
- Restructures CLI to match DVC behavior with positional stage arguments and `--single-stage` flag
- Adds mutex groups to prevent concurrent execution of stages that share resources
- Improves type safety with `RegistryStageInfo` TypedDict throughout the codebase

## Features

### Watch Mode
- `pivot run --watch` monitors files and re-runs the pipeline on changes
- Optional glob filtering: `pivot run --watch "*.py,*.csv"` to watch specific patterns
- Configurable debounce: `pivot run --watch --debounce 500` (default 300ms)
- Smart output filtering prevents infinite loops by ignoring changes to stage outputs
- Graceful error handling - pipeline errors don't exit watch mode

### CLI Restructuring (DVC-compatible)
- `pivot run` - runs all stages
- `pivot run stage1 stage2` - runs specified stages and their dependencies  
- `pivot run stage1 --single-stage` - runs only specified stages (in provided order), skipping dependencies
- Stage validation before execution with clear error messages for unknown stages

### Mutex Groups
- Stages can declare mutex groups to prevent concurrent execution
- Useful for stages that share limited resources (GPU, database connections)
- Warning logged if a mutex group contains only one stage (likely typo)

### Type Safety Improvements
- `RegistryStageInfo` TypedDict for stage info dictionaries
- `ExecutionSummary` and `WorkerStageInfo` TypedDicts moved to executor module
- Direct dictionary key access instead of `.get()` where keys are guaranteed
- `pathlib` used consistently instead of `os.path` operations

## Files Changed

| File | Changes |
|------|---------|
| `src/pivot/watch.py` | **New** - Watch mode implementation using `watchfiles` |
| `src/pivot/cli.py` | Restructured CLI with `--watch`, `--single-stage`, positional args |
| `src/pivot/executor.py` | Mutex group support, TypedDict improvements |
| `src/pivot/registry.py` | `RegistryStageInfo` TypedDict, mutex field |
| `src/pivot/dag.py` | Updated to use `RegistryStageInfo`, documented `--single-stage` order |
| `src/pivot/dvc_compat.py` | Fixed deps export, updated to use module-level registry access |
| `src/pivot/console.py` | Watch mode console output methods |
| `tests/test_watch.py` | **New** - Comprehensive watch mode tests |

## Test plan

- [x] All 382 tests pass
- [x] 92%+ code coverage maintained
- [x] Type checking passes (basedpyright)
- [x] Linting passes (ruff)
- [ ] Manual testing of watch mode with real pipeline
- [ ] Test mutex groups with GPU-bound stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)