### PR TITLE
feat: Content-addressable cache with symlinks for stage outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,13 @@ ruff check .        # Lint
 basedpyright .      # Type check
 ```
 
+## Pull Requests
+
+- Use the PR template at `.github/pull_request_template.md`
+- Include: Overview, Issue link, Approach/Alternatives, Testing, Checklist
+- Highlight review focus areas (complex logic, edge cases, design decisions)
+- Mark breaking changes and known limitations
+
 ## Before Returning to User (Critical)
 
 - Must run all four: `ruff format .`, `ruff check .`, `basedpyright .`, `pytest tests/`

--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -19,10 +19,12 @@ Example:
     ...     # Train model...
 """
 
+from pivot import cache as cache
 from pivot import dvc_compat as dvc_compat
 from pivot import outputs as outputs
 from pivot import state as state
 from pivot.outputs import BaseOut as BaseOut
+from pivot.outputs import IncrementalOut as IncrementalOut
 from pivot.outputs import Metric as Metric
 from pivot.outputs import Out as Out
 from pivot.outputs import Plot as Plot

--- a/src/pivot/cache.py
+++ b/src/pivot/cache.py
@@ -1,0 +1,319 @@
+"""Content-addressable cache for stage outputs."""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import errno
+import json
+import os
+import pathlib
+import shutil
+import stat
+import tempfile
+from typing import TYPE_CHECKING
+
+import xxhash
+
+from pivot import exceptions
+from pivot.types import DirHash, DirManifestEntry, FileHash, OutputHash
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pivot import state as state_mod
+
+CHUNK_SIZE = 1024 * 1024  # 1MB chunks for hashing
+
+
+def atomic_write_file(
+    dest: pathlib.Path,
+    write_fn: Callable[[int], None],
+    mode: int = 0o644,
+) -> None:
+    """Atomically write to dest using temp file + rename pattern.
+
+    Args:
+        dest: Target file path.
+        write_fn: Function that receives the file descriptor and writes content.
+                  MUST close fd (typically via os.fdopen which takes ownership).
+        mode: File permissions (default 0o644).
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
+    tmp = pathlib.Path(tmp_path)
+    fd_closed = False
+    try:
+        write_fn(fd)
+        fd_closed = True  # write_fn took ownership via os.fdopen
+        os.chmod(tmp_path, mode)
+        tmp.replace(dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    finally:
+        # Only close fd if write_fn didn't (e.g., exception before os.fdopen)
+        if not fd_closed:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+class LinkMode(enum.StrEnum):
+    """Strategy for linking workspace files to cache."""
+
+    SYMLINK = "symlink"
+    HARDLINK = "hardlink"
+    COPY = "copy"
+
+
+def hash_file(path: pathlib.Path, state_db: state_mod.StateDB | None = None) -> str:
+    """Compute xxhash64 of file contents, using state cache if available."""
+    file_stat = path.stat()
+
+    if state_db is not None:
+        cached = state_db.get(path, file_stat)
+        if cached is not None:
+            return cached
+
+    hasher = xxhash.xxh64()
+    with open(path, "rb") as f:
+        while chunk := f.read(CHUNK_SIZE):
+            hasher.update(chunk)
+    file_hash = hasher.hexdigest()
+
+    if state_db is not None:
+        state_db.save(path, file_stat, file_hash)
+
+    return file_hash
+
+
+def hash_directory(
+    path: pathlib.Path, state_db: state_mod.StateDB | None = None
+) -> tuple[str, list[DirManifestEntry]]:
+    """Compute tree hash of directory, returning hash and manifest.
+
+    Note: Symlinks are skipped to prevent infinite loops and ensure consistent hashing.
+    """
+    manifest = list[DirManifestEntry]()
+    resolved_base = path.resolve()
+
+    for file_path in sorted(path.rglob("*")):
+        # Skip symlinks to prevent loops and ensure reproducibility
+        if file_path.is_symlink():
+            continue
+        if file_path.is_file():
+            # Verify file is still within the directory (paranoid check)
+            if not file_path.resolve().is_relative_to(resolved_base):
+                continue
+            rel = file_path.relative_to(path)
+            file_stat = file_path.stat()
+            entry: DirManifestEntry = {
+                "relpath": str(rel),
+                "hash": hash_file(file_path, state_db),
+                "size": file_stat.st_size,
+            }
+            if file_stat.st_mode & stat.S_IXUSR:
+                entry["isexec"] = True
+            manifest.append(entry)
+
+    manifest_json = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    tree_hash = xxhash.xxh64(manifest_json.encode()).hexdigest()
+
+    return tree_hash, manifest
+
+
+def _get_cache_path(cache_dir: pathlib.Path, file_hash: str) -> pathlib.Path:
+    """Get cache path for a hash (XX/XXXX... structure)."""
+    return cache_dir / file_hash[:2] / file_hash[2:]
+
+
+def _remove_path(path: pathlib.Path) -> None:
+    """Remove file, directory, or symlink if it exists."""
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _copy_to_cache(src: pathlib.Path, cache_path: pathlib.Path) -> None:
+    """Atomically copy file to cache with read-only permissions."""
+    if cache_path.exists():
+        return
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
+    tmp = pathlib.Path(tmp_path)
+    try:
+        os.close(fd)
+        shutil.copy2(src, tmp_path)
+        os.chmod(tmp_path, 0o444)
+        tmp.replace(cache_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _link_from_cache(
+    path: pathlib.Path,
+    cache_path: pathlib.Path,
+    link_mode: LinkMode,
+) -> None:
+    """Create link from workspace path to cache."""
+    _remove_path(path)
+
+    if link_mode == LinkMode.SYMLINK:
+        path.symlink_to(cache_path.resolve())
+    elif link_mode == LinkMode.HARDLINK:
+        try:
+            os.link(cache_path, path)
+        except OSError as e:
+            # Fall back to copy if hardlink fails (e.g., cross-device)
+            if e.errno == errno.EXDEV:
+                shutil.copy2(cache_path, path)
+                os.chmod(path, 0o644)
+            else:
+                raise
+    else:
+        shutil.copy2(cache_path, path)
+        os.chmod(path, 0o644)
+
+
+def save_to_cache(
+    path: pathlib.Path,
+    cache_dir: pathlib.Path,
+    state_db: state_mod.StateDB | None = None,
+    link_mode: LinkMode = LinkMode.SYMLINK,
+) -> OutputHash:
+    """Save file or directory to cache, replace with link, return hash info."""
+    if path.is_dir():
+        return _save_directory_to_cache(path, cache_dir, state_db, link_mode)
+    return _save_file_to_cache(path, cache_dir, state_db, link_mode)
+
+
+def _save_file_to_cache(
+    path: pathlib.Path,
+    cache_dir: pathlib.Path,
+    state_db: state_mod.StateDB | None,
+    link_mode: LinkMode,
+) -> FileHash:
+    """Save single file to cache."""
+    file_hash = hash_file(path, state_db)
+    cache_path = _get_cache_path(cache_dir, file_hash)
+
+    _copy_to_cache(path, cache_path)
+    _link_from_cache(path, cache_path, link_mode)
+
+    return {"hash": file_hash}
+
+
+def _save_directory_to_cache(
+    path: pathlib.Path,
+    cache_dir: pathlib.Path,
+    state_db: state_mod.StateDB | None,
+    link_mode: LinkMode,
+) -> DirHash:
+    """Save directory to cache."""
+    tree_hash, manifest = hash_directory(path, state_db)
+
+    for entry in manifest:
+        file_path = path / entry["relpath"]
+        cache_path = _get_cache_path(cache_dir, entry["hash"])
+        _copy_to_cache(file_path, cache_path)
+
+    if link_mode == LinkMode.SYMLINK:
+        cache_dir_path = _get_cache_path(cache_dir, tree_hash)
+        if not cache_dir_path.exists():
+            cache_dir_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(path, cache_dir_path)
+            for f in cache_dir_path.rglob("*"):
+                # Skip symlinks to avoid changing permissions on target files outside cache
+                if f.is_file() and not f.is_symlink():
+                    os.chmod(f, 0o444)
+            os.chmod(cache_dir_path, 0o555)
+
+        shutil.rmtree(path)
+        path.symlink_to(cache_dir_path.resolve())
+
+    return {"hash": tree_hash, "manifest": manifest}
+
+
+def restore_from_cache(
+    path: pathlib.Path,
+    output_hash: OutputHash,
+    cache_dir: pathlib.Path,
+    link_mode: LinkMode = LinkMode.SYMLINK,
+) -> bool:
+    """Restore file or directory from cache. Returns True if successful."""
+    if output_hash is None:
+        return False
+
+    if "manifest" in output_hash:
+        return _restore_directory_from_cache(path, output_hash, cache_dir, link_mode)
+    return _restore_file_from_cache(path, output_hash, cache_dir, link_mode)
+
+
+def _restore_file_from_cache(
+    path: pathlib.Path,
+    output_hash: FileHash,
+    cache_dir: pathlib.Path,
+    link_mode: LinkMode,
+) -> bool:
+    """Restore single file from cache."""
+    cache_path = _get_cache_path(cache_dir, output_hash["hash"])
+    if not cache_path.exists():
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _link_from_cache(path, cache_path, link_mode)
+    return True
+
+
+def _restore_directory_from_cache(
+    path: pathlib.Path,
+    output_hash: DirHash,
+    cache_dir: pathlib.Path,
+    link_mode: LinkMode,
+) -> bool:
+    """Restore directory from cache."""
+    cache_dir_path = _get_cache_path(cache_dir, output_hash["hash"])
+
+    if link_mode == LinkMode.SYMLINK and cache_dir_path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _remove_path(path)
+        path.symlink_to(cache_dir_path.resolve())
+        return True
+
+    path.mkdir(parents=True, exist_ok=True)
+    resolved_base = path.resolve()
+    for entry in output_hash["manifest"]:
+        file_cache_path = _get_cache_path(cache_dir, entry["hash"])
+        if not file_cache_path.exists():
+            return False
+        file_path = path / entry["relpath"]
+        # Validate no path traversal (e.g., "../../../etc/passwd")
+        if not file_path.resolve().is_relative_to(resolved_base):
+            raise exceptions.PathTraversalError(
+                f"Manifest contains path traversal: {entry['relpath']!r}"
+            )
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        _link_from_cache(file_path, file_cache_path, link_mode)
+
+    return True
+
+
+def remove_output(path: pathlib.Path) -> None:
+    """Remove output file or directory before execution."""
+    _remove_path(path)
+
+
+def protect(path: pathlib.Path) -> None:
+    """Make file read-only (mode 0o444)."""
+    os.chmod(path, 0o444)
+
+
+def unprotect(path: pathlib.Path) -> None:
+    """Restore write permission to file."""
+    current = path.stat().st_mode
+    os.chmod(path, current | stat.S_IWUSR)

--- a/src/pivot/dvc_compat.py
+++ b/src/pivot/dvc_compat.py
@@ -171,11 +171,16 @@ def _build_out_entry(out: outputs.BaseOut, rel_path: str) -> str | dict[str, Any
         options["cache"] = False
     elif isinstance(out, outputs.Metric) and out.cache is True:
         options["cache"] = True
-    elif isinstance(out, outputs.Plot) and out.cache is False:
+    elif (
+        isinstance(out, outputs.Plot)
+        and out.cache is False
+        or isinstance(out, outputs.IncrementalOut)
+        and out.cache is False
+    ):
         options["cache"] = False
 
-    # Add persist if set
-    if out.persist:
+    # IncrementalOut always exports with persist: true (DVC won't delete it between runs)
+    if isinstance(out, outputs.IncrementalOut) or out.persist:
         options["persist"] = True
 
     # Add plot-specific options

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -92,3 +92,15 @@ class CacheRestoreError(CacheError):
     """Raised when restoring outputs from cache fails."""
 
     pass
+
+
+class PathTraversalError(CacheError):
+    """Raised when a manifest contains path traversal attempt."""
+
+    pass
+
+
+class UncachedIncrementalOutputError(CacheError):
+    """Raised when an IncrementalOut file exists but is not in cache."""
+
+    pass

--- a/src/pivot/lock.py
+++ b/src/pivot/lock.py
@@ -16,19 +16,37 @@ Atomic Write Pattern:
 import os
 import pathlib
 import re
-import tempfile
-from typing import Any, cast
+from typing import Any, TypeGuard, cast
 
 import yaml
+
+from pivot import cache
+from pivot.types import LockData
+
+# Use union types to avoid type: ignore on fallback assignment
+_Loader: type[yaml.SafeLoader] | type[yaml.CSafeLoader]
+_Dumper: type[yaml.SafeDumper] | type[yaml.CSafeDumper]
 
 try:
     _Loader = yaml.CSafeLoader
     _Dumper = yaml.CSafeDumper
 except AttributeError:
-    _Loader = yaml.SafeLoader  # type: ignore[assignment]
-    _Dumper = yaml.SafeDumper  # type: ignore[assignment]
+    # CSafeLoader unavailable (no libyaml); SafeLoader is API-compatible
+    _Loader = yaml.SafeLoader
+    _Dumper = yaml.SafeDumper
 
 _VALID_STAGE_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+_MAX_STAGE_NAME_LEN = 200  # Leave room for ".lock" suffix within filesystem NAME_MAX (255)
+_VALID_LOCK_KEYS = frozenset({"code_manifest", "params", "dep_hashes", "output_hashes"})
+
+
+def _is_lock_data(data: object) -> TypeGuard[LockData]:
+    """Validate that parsed YAML has valid LockData structure."""
+    if not isinstance(data, dict):
+        return False
+    # All keys in LockData are optional, but reject unknown keys
+    # YAML dicts have string keys; cast for type checker after isinstance
+    return all(key in _VALID_LOCK_KEYS for key in cast("dict[str, object]", data))
 
 
 class StageLock:
@@ -40,32 +58,30 @@ class StageLock:
     def __init__(self, stage_name: str, cache_dir: pathlib.Path) -> None:
         if not stage_name or not _VALID_STAGE_NAME.match(stage_name):
             raise ValueError(f"Invalid stage name: {stage_name!r}")
+        if len(stage_name) > _MAX_STAGE_NAME_LEN:
+            raise ValueError(f"Stage name too long ({len(stage_name)} > {_MAX_STAGE_NAME_LEN})")
         self.stage_name = stage_name
         self.path = cache_dir / "stages" / f"{stage_name}.lock"
 
-    def read(self) -> dict[str, Any] | None:
+    def read(self) -> LockData | None:
         """Read lock file, return None if missing or corrupted."""
         try:
             with open(self.path) as f:
                 data: object = yaml.load(f, Loader=_Loader)
-            if data is None or not isinstance(data, dict):
-                return None  # Treat corrupted file as missing
-            return cast("dict[str, Any]", data)
+            if not _is_lock_data(data):
+                return None  # Treat corrupted/invalid file as missing
+            return data
         except (FileNotFoundError, UnicodeDecodeError, yaml.YAMLError):
             return None
 
-    def write(self, data: dict[str, Any]) -> None:
+    def write(self, data: LockData) -> None:
         """Write lock file atomically."""
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(dir=self.path.parent, suffix=".tmp")
-        tmp = pathlib.Path(tmp_path)
-        try:
+
+        def write_yaml(fd: int) -> None:
             with os.fdopen(fd, "w") as f:
                 yaml.dump(data, f, Dumper=_Dumper, sort_keys=False)
-            tmp.replace(self.path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+
+        cache.atomic_write_file(self.path, write_yaml)
 
     def is_changed(
         self,
@@ -84,6 +100,7 @@ class StageLock:
             ("dep_hashes", dep_hashes, "Input dependencies changed"),
         ]
         for key, current, reason in checks:
+            # Use `or {}` to treat both missing keys AND explicit None as empty dict
             if (lock_data.get(key) or {}) != current:
                 return True, reason
 

--- a/src/pivot/outputs.py
+++ b/src/pivot/outputs.py
@@ -36,6 +36,11 @@ class Plot(BaseOut):
     template: str | None = None
 
 
+@dataclasses.dataclass(frozen=True)
+class IncrementalOut(BaseOut):
+    """Incremental output - restored from cache before stage runs."""
+
+
 type OutSpec = str | BaseOut
 
 

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -85,12 +85,13 @@ class stage:
     outs: Sequence[outputs.OutSpec] = ()
     params_cls: type[BaseModel] | None = None
     mutex: Sequence[str] = ()
+    name: str | None = None  # Optional custom name (enables loop-based registration)
 
     def __call__(self, func: F) -> F:
         """Register function as a stage (returns original function unmodified)."""
         REGISTRY.register(
             func,
-            name=func.__name__,
+            name=self.name or func.__name__,
             deps=self.deps,
             outs=self.outs,
             params_cls=self.params_cls,

--- a/src/pivot/state.py
+++ b/src/pivot/state.py
@@ -3,27 +3,40 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from typing import TYPE_CHECKING, Self
 
 if TYPE_CHECKING:
     import os
     import pathlib
 
+# Timeout for acquiring database lock (seconds)
+_DB_TIMEOUT = 5.0
+
 
 class StateDB:
-    """SQLite cache of (inode, mtime, size) -> hash to skip rehashing unchanged files."""
+    """SQLite cache of (inode, mtime, size) -> hash to skip rehashing unchanged files.
+
+    Thread-safe: all operations are protected by a lock.
+    """
+
+    _conn: sqlite3.Connection
+    _lock: threading.Lock
+    _closed: bool
 
     def __init__(self, db_path: pathlib.Path) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn: sqlite3.Connection = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn = sqlite3.connect(db_path, timeout=_DB_TIMEOUT, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
+        self._lock = threading.Lock()
+        self._closed = False
         self._create_schema()
 
     def _create_schema(self) -> None:
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS state (
                 path TEXT PRIMARY KEY,
-                mtime REAL,
+                mtime_ns INTEGER,
                 size INTEGER,
                 inode INTEGER,
                 hash TEXT
@@ -32,43 +45,62 @@ class StateDB:
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_state_hash ON state(hash)")
         self._conn.commit()
 
+    def _check_closed(self) -> None:
+        """Raise if database is closed."""
+        if self._closed:
+            raise RuntimeError("Cannot operate on closed StateDB")
+
     def get(self, path: pathlib.Path, fs_stat: os.stat_result) -> str | None:
         """Return cached hash if file metadata matches, else None."""
+        self._check_closed()
         abs_path = str(path.resolve())
-        cursor = self._conn.execute(
-            "SELECT hash FROM state WHERE path = ? AND mtime = ? AND size = ? AND inode = ?",
-            (abs_path, fs_stat.st_mtime, fs_stat.st_size, fs_stat.st_ino),
-        )
-        row = cursor.fetchone()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT hash FROM state WHERE path = ? AND mtime_ns = ? AND size = ? AND inode = ?",
+                (abs_path, fs_stat.st_mtime_ns, fs_stat.st_size, fs_stat.st_ino),
+            )
+            row = cursor.fetchone()
         return row[0] if row else None
 
     def save(self, path: pathlib.Path, fs_stat: os.stat_result, file_hash: str) -> None:
         """Cache file metadata and hash."""
+        self._check_closed()
         abs_path = str(path.resolve())
-        self._conn.execute(
-            """
-            INSERT OR REPLACE INTO state (path, mtime, size, inode, hash)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (abs_path, fs_stat.st_mtime, fs_stat.st_size, fs_stat.st_ino, file_hash),
-        )
-        self._conn.commit()
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO state (path, mtime_ns, size, inode, hash)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    abs_path,
+                    fs_stat.st_mtime_ns,
+                    fs_stat.st_size,
+                    fs_stat.st_ino,
+                    file_hash,
+                ),
+            )
+            self._conn.commit()
 
     def save_many(self, entries: list[tuple[pathlib.Path, os.stat_result, str]]) -> None:
-        """Batch save multiple entries."""
-        data = [(str(p.resolve()), s.st_mtime, s.st_size, s.st_ino, h) for p, s, h in entries]
-        self._conn.executemany(
-            """
-            INSERT OR REPLACE INTO state (path, mtime, size, inode, hash)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            data,
-        )
-        self._conn.commit()
+        """Batch save multiple entries with atomic transaction."""
+        self._check_closed()
+        data = [(str(p.resolve()), s.st_mtime_ns, s.st_size, s.st_ino, h) for p, s, h in entries]
+        with self._lock, self._conn:  # Atomic transaction - rolls back on error
+            self._conn.executemany(
+                """
+                    INSERT OR REPLACE INTO state (path, mtime_ns, size, inode, hash)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                data,
+            )
 
     def close(self) -> None:
         """Close the database connection."""
-        self._conn.close()
+        with self._lock:
+            if not self._closed:
+                self._conn.close()
+                self._closed = True
 
     def __enter__(self) -> Self:
         return self

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class StageStatus(enum.StrEnum):
@@ -47,13 +47,13 @@ class FileHash(TypedDict):
     hash: str
 
 
-class DirManifestEntry(TypedDict, total=False):
+class DirManifestEntry(TypedDict):
     """Entry in directory manifest."""
 
     relpath: str
     hash: str
     size: int
-    isexec: bool
+    isexec: NotRequired[bool]
 
 
 class DirHash(TypedDict):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,401 @@
+"""Tests for content-addressable cache module."""
+
+import pathlib
+import stat
+from typing import TYPE_CHECKING
+
+from pivot import cache, state
+
+if TYPE_CHECKING:
+    from pivot.types import FileHash
+
+
+class TestHashFile:
+    """Tests for file hashing."""
+
+    def test_hash_file(self, tmp_path: pathlib.Path) -> None:
+        """hash_file returns consistent xxhash64 hash."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("hello world")
+
+        hash1 = cache.hash_file(test_file)
+        hash2 = cache.hash_file(test_file)
+
+        assert hash1 == hash2
+        assert len(hash1) == 16  # xxhash64 hex is 16 chars
+
+    def test_hash_file_different_content(self, tmp_path: pathlib.Path) -> None:
+        """Different content produces different hash."""
+        file1 = tmp_path / "file1.txt"
+        file2 = tmp_path / "file2.txt"
+        file1.write_text("hello")
+        file2.write_text("world")
+
+        assert cache.hash_file(file1) != cache.hash_file(file2)
+
+    def test_hash_file_uses_state_cache(self, tmp_path: pathlib.Path) -> None:
+        """hash_file uses state cache to skip rehashing."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        db_path = tmp_path / "state.db"
+
+        with state.StateDB(db_path) as db:
+            cache.hash_file(test_file, state_db=db)  # First hash populates cache
+            db.save(test_file, test_file.stat(), "cached_hash")
+            hash2 = cache.hash_file(test_file, state_db=db)
+
+        assert hash2 == "cached_hash"
+
+    def test_hash_file_binary(self, tmp_path: pathlib.Path) -> None:
+        """hash_file works with binary content."""
+        test_file = tmp_path / "binary.bin"
+        test_file.write_bytes(b"\x00\x01\x02\xff\xfe")
+
+        file_hash = cache.hash_file(test_file)
+
+        assert len(file_hash) == 16
+
+
+class TestHashDirectory:
+    """Tests for directory hashing."""
+
+    def test_hash_directory(self, tmp_path: pathlib.Path) -> None:
+        """hash_directory returns hash and manifest."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "a.txt").write_text("content a")
+        (test_dir / "b.txt").write_text("content b")
+
+        tree_hash, manifest = cache.hash_directory(test_dir)
+
+        assert len(tree_hash) == 16
+        assert len(manifest) == 2
+
+    def test_hash_directory_relative_paths(self, tmp_path: pathlib.Path) -> None:
+        """Manifest contains relative paths only."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+        subdir = test_dir / "subdir"
+        subdir.mkdir()
+        (subdir / "nested.txt").write_text("nested")
+
+        _, manifest = cache.hash_directory(test_dir)
+
+        relpaths = [e["relpath"] for e in manifest]
+        assert "file.txt" in relpaths
+        assert "subdir/nested.txt" in relpaths
+        assert not any(str(tmp_path) in p for p in relpaths)
+
+    def test_hash_directory_sorted_manifest(self, tmp_path: pathlib.Path) -> None:
+        """Manifest is sorted by relpath."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "z.txt").write_text("z")
+        (test_dir / "a.txt").write_text("a")
+        (test_dir / "m.txt").write_text("m")
+
+        _, manifest = cache.hash_directory(test_dir)
+
+        relpaths = [e["relpath"] for e in manifest]
+        assert relpaths == sorted(relpaths)
+
+    def test_hash_directory_deterministic(self, tmp_path: pathlib.Path) -> None:
+        """Same directory content produces same hash."""
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        for d in [dir1, dir2]:
+            d.mkdir()
+            (d / "file.txt").write_text("same content")
+
+        hash1, _ = cache.hash_directory(dir1)
+        hash2, _ = cache.hash_directory(dir2)
+
+        assert hash1 == hash2
+
+    def test_hash_directory_includes_size(self, tmp_path: pathlib.Path) -> None:
+        """Manifest entries include file size."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("hello")
+
+        _, manifest = cache.hash_directory(test_dir)
+
+        assert manifest[0]["size"] == 5
+
+    def test_hash_directory_skips_symlinks(self, tmp_path: pathlib.Path) -> None:
+        """Symlinks in directory are skipped."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "real.txt").write_text("content")
+        (test_dir / "link.txt").symlink_to(test_dir / "real.txt")
+
+        _, manifest = cache.hash_directory(test_dir)
+
+        relpaths = [e["relpath"] for e in manifest]
+        assert "real.txt" in relpaths
+        assert "link.txt" not in relpaths, "Symlinks should be skipped"
+
+    def test_hash_directory_marks_executable(self, tmp_path: pathlib.Path) -> None:
+        """Executable files are marked in manifest."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        regular = test_dir / "regular.txt"
+        regular.write_text("content")
+        executable = test_dir / "script.sh"
+        executable.write_text("#!/bin/bash")
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+        _, manifest = cache.hash_directory(test_dir)
+
+        manifest_dict = {e["relpath"]: e for e in manifest}
+        assert "isexec" not in manifest_dict["regular.txt"]
+        assert manifest_dict["script.sh"].get("isexec") is True
+
+
+class TestSaveToCache:
+    """Tests for saving files to cache."""
+
+    def test_save_to_cache_creates_cache_file(self, tmp_path: pathlib.Path) -> None:
+        """save_to_cache creates file in cache directory."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_file, cache_dir)
+        assert output_hash is not None
+
+        cache_path = cache_dir / output_hash["hash"][:2] / output_hash["hash"][2:]
+        assert cache_path.exists()
+
+    def test_save_to_cache_read_only(self, tmp_path: pathlib.Path) -> None:
+        """Cached files are read-only (mode 0o444)."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_file, cache_dir)
+        assert output_hash is not None
+
+        cache_path = cache_dir / output_hash["hash"][:2] / output_hash["hash"][2:]
+        mode = cache_path.stat().st_mode & 0o777
+        assert mode == 0o444
+
+    def test_save_to_cache_creates_symlink(self, tmp_path: pathlib.Path) -> None:
+        """Original file is replaced with symlink to cache."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        cache.save_to_cache(test_file, cache_dir)
+
+        assert test_file.is_symlink()
+
+    def test_save_to_cache_directory(self, tmp_path: pathlib.Path) -> None:
+        """save_to_cache handles directories."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_dir, cache_dir)
+        assert output_hash is not None
+
+        assert "manifest" in output_hash
+        assert test_dir.is_symlink() or test_dir.is_dir()
+
+    def test_save_to_cache_deduplicates(self, tmp_path: pathlib.Path) -> None:
+        """Identical files share cache entry."""
+        file1 = tmp_path / "file1.txt"
+        file2 = tmp_path / "file2.txt"
+        file1.write_text("same content")
+        file2.write_text("same content")
+        cache_dir = tmp_path / "cache"
+
+        hash1 = cache.save_to_cache(file1, cache_dir)
+        hash2 = cache.save_to_cache(file2, cache_dir)
+        assert hash1 is not None and hash2 is not None
+
+        assert hash1["hash"] == hash2["hash"]
+
+    def test_save_atomic_no_partial(self, tmp_path: pathlib.Path) -> None:
+        """No partial files on failure."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        cache.save_to_cache(test_file, cache_dir)
+
+        tmp_files = list(cache_dir.rglob("*.tmp"))
+        assert len(tmp_files) == 0
+
+
+class TestRestoreFromCache:
+    """Tests for restoring files from cache."""
+
+    def test_restore_from_cache_creates_link(self, tmp_path: pathlib.Path) -> None:
+        """restore_from_cache creates symlink to cached file."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_file, cache_dir)
+        test_file.unlink()
+
+        restored = cache.restore_from_cache(test_file, output_hash, cache_dir)
+
+        assert restored is True
+        assert test_file.is_symlink()
+        assert test_file.read_text() == "content"
+
+    def test_restore_from_cache_missing(self, tmp_path: pathlib.Path) -> None:
+        """restore_from_cache returns False if cache entry missing."""
+        test_file = tmp_path / "file.txt"
+        cache_dir = tmp_path / "cache"
+        missing_hash: FileHash = {"hash": "0" * 16}
+
+        restored = cache.restore_from_cache(test_file, missing_hash, cache_dir)
+
+        assert restored is False
+
+    def test_restore_directory_from_cache(self, tmp_path: pathlib.Path) -> None:
+        """restore_from_cache restores directories."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_dir, cache_dir)
+        cache.remove_output(test_dir)  # Use remove_output to handle symlinks
+
+        restored = cache.restore_from_cache(test_dir, output_hash, cache_dir)
+
+        assert restored is True
+        assert (test_dir / "file.txt").exists()
+
+    def test_restore_directory_hardlink_mode(self, tmp_path: pathlib.Path) -> None:
+        """restore_from_cache restores directories with hardlink mode."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        subdir = test_dir / "subdir"
+        subdir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+        (subdir / "nested.txt").write_text("nested")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_dir, cache_dir, link_mode=cache.LinkMode.HARDLINK)
+        cache.remove_output(test_dir)
+
+        restored = cache.restore_from_cache(
+            test_dir, output_hash, cache_dir, link_mode=cache.LinkMode.HARDLINK
+        )
+
+        assert restored is True
+        assert (test_dir / "file.txt").read_text() == "content"
+        assert (subdir / "nested.txt").read_text() == "nested"
+
+
+class TestRemoveOutput:
+    """Tests for removing outputs before execution."""
+
+    def test_remove_output_file(self, tmp_path: pathlib.Path) -> None:
+        """remove_output deletes regular file."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+
+        cache.remove_output(test_file)
+
+        assert not test_file.exists()
+
+    def test_remove_output_directory(self, tmp_path: pathlib.Path) -> None:
+        """remove_output deletes directory recursively."""
+        test_dir = tmp_path / "mydir"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("content")
+
+        cache.remove_output(test_dir)
+
+        assert not test_dir.exists()
+
+    def test_remove_output_symlink(self, tmp_path: pathlib.Path) -> None:
+        """remove_output removes symlink without following."""
+        target = tmp_path / "target.txt"
+        target.write_text("content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+
+        cache.remove_output(link)
+
+        assert not link.exists()
+        assert target.exists()
+
+    def test_remove_output_missing_ok(self, tmp_path: pathlib.Path) -> None:
+        """remove_output does nothing if path doesn't exist."""
+        missing = tmp_path / "missing.txt"
+
+        cache.remove_output(missing)
+
+
+class TestProtection:
+    """Tests for file protection (read-only mode)."""
+
+    def test_protect(self, tmp_path: pathlib.Path) -> None:
+        """protect makes file read-only."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+
+        cache.protect(test_file)
+
+        mode = test_file.stat().st_mode & 0o777
+        assert mode == 0o444
+
+    def test_unprotect(self, tmp_path: pathlib.Path) -> None:
+        """unprotect restores write permission."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache.protect(test_file)
+
+        cache.unprotect(test_file)
+
+        mode = test_file.stat().st_mode & 0o777
+        assert mode & stat.S_IWUSR
+
+
+class TestLinkModes:
+    """Tests for different link strategies."""
+
+    def test_link_mode_symlink(self, tmp_path: pathlib.Path) -> None:
+        """SYMLINK mode creates symlinks."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        cache.save_to_cache(test_file, cache_dir, link_mode=cache.LinkMode.SYMLINK)
+
+        assert test_file.is_symlink()
+
+    def test_link_mode_hardlink(self, tmp_path: pathlib.Path) -> None:
+        """HARDLINK mode creates hardlinks."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_file, cache_dir, link_mode=cache.LinkMode.HARDLINK)
+        assert output_hash is not None
+
+        cache_path = cache_dir / output_hash["hash"][:2] / output_hash["hash"][2:]
+        assert test_file.stat().st_ino == cache_path.stat().st_ino
+
+    def test_link_mode_copy(self, tmp_path: pathlib.Path) -> None:
+        """COPY mode creates separate copies."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+        cache_dir = tmp_path / "cache"
+
+        output_hash = cache.save_to_cache(test_file, cache_dir, link_mode=cache.LinkMode.COPY)
+        assert output_hash is not None
+
+        cache_path = cache_dir / output_hash["hash"][:2] / output_hash["hash"][2:]
+        assert not test_file.is_symlink()
+        assert test_file.stat().st_ino != cache_path.stat().st_ino
+        assert test_file.read_text() == "content"

--- a/tests/test_incremental_out.py
+++ b/tests/test_incremental_out.py
@@ -1,0 +1,190 @@
+"""Integration tests for IncrementalOut feature."""
+
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import IncrementalOut, cache, executor, outputs, registry
+
+if TYPE_CHECKING:
+    from pivot.types import LockData
+
+
+# Module-level stage functions for testing (must be picklable)
+def _incremental_stage_append() -> None:
+    """Stage that appends to an incremental output."""
+    import pathlib
+
+    db_path = pathlib.Path("database.txt")
+    if db_path.exists():
+        existing = db_path.read_text()
+        count = len(existing.strip().split("\n")) if existing.strip() else 0
+    else:
+        existing = ""
+        count = 0
+
+    with open(db_path, "w") as f:
+        f.write(existing)
+        f.write(f"line {count + 1}\n")
+
+
+def _regular_stage_create() -> None:
+    """Stage that creates a regular output."""
+    pathlib.Path("output.txt").write_text("created\n")
+
+
+class TestPrepareOutputsForExecution:
+    """Tests for _prepare_outputs_for_execution helper."""
+
+    def test_regular_out_is_deleted(self, tmp_path: pathlib.Path) -> None:
+        """Regular Out should be deleted before execution."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("existing content")
+
+        stage_outs: list[outputs.BaseOut] = [outputs.Out(path=str(output_file))]
+        executor._prepare_outputs_for_execution(stage_outs, None, tmp_path / "cache")
+
+        assert not output_file.exists()
+
+    def test_incremental_out_no_cache_creates_empty(self, tmp_path: pathlib.Path) -> None:
+        """IncrementalOut with no cache should start fresh (file doesn't exist)."""
+        output_file = tmp_path / "database.txt"
+
+        stage_outs: list[outputs.BaseOut] = [outputs.IncrementalOut(path=str(output_file))]
+        executor._prepare_outputs_for_execution(stage_outs, None, tmp_path / "cache")
+
+        assert not output_file.exists()
+
+    def test_incremental_out_restores_from_cache(self, tmp_path: pathlib.Path) -> None:
+        """IncrementalOut should restore from cache before execution."""
+        output_file = tmp_path / "database.txt"
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Create a cached version
+        output_file.write_text("cached content\n")
+        output_hash = cache.save_to_cache(output_file, cache_dir)
+
+        # Lock data simulating previous run
+        lock_data: LockData = {
+            "output_hashes": {str(output_file): output_hash},
+        }
+
+        # Prepare for execution
+        stage_outs = [outputs.IncrementalOut(path=str(output_file))]
+        executor._prepare_outputs_for_execution(stage_outs, lock_data, cache_dir)
+
+        # File should be restored
+        assert output_file.exists()
+        assert output_file.read_text() == "cached content\n"
+
+    def test_incremental_out_restored_file_is_writable(self, tmp_path: pathlib.Path) -> None:
+        """Restored IncrementalOut should be a writable copy, not symlink."""
+        output_file = tmp_path / "database.txt"
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Create a cached version
+        output_file.write_text("cached content\n")
+        output_hash = cache.save_to_cache(output_file, cache_dir)
+
+        lock_data: LockData = {
+            "output_hashes": {str(output_file): output_hash},
+        }
+
+        # Prepare for execution
+        stage_outs = [outputs.IncrementalOut(path=str(output_file))]
+        executor._prepare_outputs_for_execution(stage_outs, lock_data, cache_dir)
+
+        # Should NOT be a symlink (should be a copy)
+        assert not output_file.is_symlink()
+
+        # Should be writable
+        output_file.write_text("modified content\n")
+        assert output_file.read_text() == "modified content\n"
+
+
+class TestIncrementalOutDvcExport:
+    """Tests for IncrementalOut DVC export."""
+
+    def test_incremental_out_always_persist(self) -> None:
+        """IncrementalOut should always export with persist: true."""
+        from pivot import dvc_compat
+
+        inc = outputs.IncrementalOut(path="database.csv")
+        result = dvc_compat._build_out_entry(inc, "database.csv")
+        assert result == {"database.csv": {"persist": True}}
+
+    def test_incremental_out_with_cache_false(self) -> None:
+        """IncrementalOut with cache=False should export both options."""
+        from pivot import dvc_compat
+
+        inc = outputs.IncrementalOut(path="database.csv", cache=False)
+        result = dvc_compat._build_out_entry(inc, "database.csv")
+        assert result == {"database.csv": {"cache": False, "persist": True}}
+
+
+class TestIncrementalOutIntegration:
+    """End-to-end integration tests for IncrementalOut."""
+
+    def test_first_run_creates_output(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, clean_registry: None
+    ) -> None:
+        """First run with IncrementalOut should create the output from scratch."""
+        monkeypatch.setattr("pivot.project.get_project_root", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        db_path = tmp_path / "database.txt"
+
+        registry.REGISTRY.register(
+            _incremental_stage_append,
+            name="append_stage",
+            deps=[],
+            outs=[IncrementalOut(path=str(db_path))],
+        )
+
+        results = executor.run(cache_dir=tmp_path / ".pivot" / "cache")
+
+        assert results["append_stage"]["status"] == "ran"
+        assert db_path.exists()
+        assert db_path.read_text() == "line 1\n"
+
+    def test_second_run_appends_to_output(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, clean_registry: None
+    ) -> None:
+        """Second run should restore and append to existing output."""
+        import yaml
+
+        monkeypatch.setattr("pivot.project.get_project_root", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        db_path = tmp_path / "database.txt"
+        cache_dir = tmp_path / ".pivot" / "cache"
+
+        registry.REGISTRY.register(
+            _incremental_stage_append,
+            name="append_stage",
+            deps=[],
+            outs=[IncrementalOut(path=str(db_path))],
+        )
+
+        # First run
+        executor.run(cache_dir=cache_dir)
+        assert db_path.read_text() == "line 1\n"
+
+        # Simulate code change by modifying the lock file's code_manifest
+        # Keep output_hashes so we can restore
+        lock_file = cache_dir / "stages" / "append_stage.lock"
+        lock_data = yaml.safe_load(lock_file.read_text())
+        lock_data["code_manifest"] = {"self:fake": "changed_hash"}
+        lock_file.write_text(yaml.dump(lock_data))
+
+        # Delete the output file to verify restoration works
+        db_path.unlink()
+
+        # Second run - should restore from cache and append
+        results = executor.run(cache_dir=cache_dir)
+
+        assert results["append_stage"]["status"] == "ran"
+        assert db_path.read_text() == "line 1\nline 2\n"

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -114,3 +114,38 @@ def test_out_instances_are_baseout() -> None:
     assert isinstance(out, outputs.BaseOut)
     assert isinstance(metric, outputs.BaseOut)
     assert isinstance(plot, outputs.BaseOut)
+
+
+# IncrementalOut tests
+
+
+def test_incremental_out_cache_default_true() -> None:
+    """IncrementalOut should have cache=True by default."""
+    inc = outputs.IncrementalOut(path="database.csv")
+    assert inc.cache is True
+
+
+def test_incremental_out_persist_default_false() -> None:
+    """IncrementalOut should have persist=False by default."""
+    inc = outputs.IncrementalOut(path="database.csv")
+    assert inc.persist is False
+
+
+def test_incremental_out_frozen() -> None:
+    """IncrementalOut should be immutable (frozen dataclass)."""
+    inc = outputs.IncrementalOut(path="database.csv")
+    with pytest.raises(AttributeError):
+        inc.path = "other.csv"  # type: ignore[misc]
+
+
+def test_incremental_out_is_base_out() -> None:
+    """IncrementalOut should inherit from BaseOut."""
+    assert issubclass(outputs.IncrementalOut, outputs.BaseOut)
+    inc = outputs.IncrementalOut(path="database.csv")
+    assert isinstance(inc, outputs.BaseOut)
+
+
+def test_normalize_out_incremental_passthrough() -> None:
+    """IncrementalOut should pass through normalize_out unchanged."""
+    inc = outputs.IncrementalOut(path="database.csv")
+    assert outputs.normalize_out(inc) is inc

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -88,15 +88,15 @@ def test_state_save_many(tmp_path: pathlib.Path) -> None:
     for i in range(5):
         f = tmp_path / f"file_{i}.txt"
         f.write_text(f"content {i}")
-        stat = f.stat()
-        files.append((f, stat))
-        entries.append((f, stat, f"hash_{i}"))
+        file_stat = f.stat()
+        files.append((f, file_stat))
+        entries.append((f, file_stat, f"hash_{i}"))
 
     db = state.StateDB(db_path)
     db.save_many(entries)
 
-    for i, (f, stat) in enumerate(files):
-        result = db.get(f, stat)
+    for i, (f, file_stat) in enumerate(files):
+        result = db.get(f, file_stat)
         assert result == f"hash_{i}"
 
 


### PR DESCRIPTION
## Overview

Implements content-addressable storage (CAS) for pipeline stage outputs, enabling automatic cache restoration when stages are skipped and reducing disk usage through deduplication.

**Issue:** Closes #4

## Approach and Alternatives

### Approach
Built a content-addressable cache system inspired by DVC's architecture but implemented from scratch to avoid heavy dependencies (~30-50MB). Key design decisions:

1. **xxhash64 for hashing** - ~20x faster than SHA256, already in dependencies
2. **SQLite state cache** - Caches `(inode, mtime_ns, size) → hash` mappings to skip rehashing unchanged files (major perf win)
3. **Per-stage lock files** - Each stage stores its own `output_hashes` in its lock file for O(1) lookups
4. **Symlinks by default** - Workspace outputs become symlinks to read-only cache files (0o444), with hardlink/copy fallbacks
5. **Atomic writes** - Temp file + rename pattern prevents partial/corrupted cache entries
6. **Directory support** - Directories get tree hashes with manifests stored in lock files

### Cache Structure
```
.pivot/
├── cache/
│   ├── stages/           # Per-stage lock files with output_hashes
│   │   └── <stage>.lock
│   ├── files/            # Content-addressed storage
│   │   └── XX/           # First 2 chars of hash
│   │       └── XXXX...   # Read-only cached content
│   └── state.db          # SQLite metadata cache
```

### Alternatives Considered
- **dvc-data library**: Too heavy (30-50MB deps), MD5 default, tightly coupled ODB model
- **Stage-based paths**: `cache/<stage>/<run_hash>/` - simpler but no deduplication
- **Hash tracking only**: Track hashes without caching - no restore capability

### Review Focus Areas
- `src/pivot/cache.py:216-234` - Directory caching has a known TOCTOU race (documented, fix deferred)
- `src/pivot/executor.py:127-147` - IncrementalOut safety check prevents accidental data loss
- Thread safety in `src/pivot/state.py` - SQLite with WAL mode and threading.Lock

## Testing & Validation

- [x] Covered by automated tests
- [x] Manual testing instructions:
  1. Run a pipeline: `pivot run`
  2. Check `.pivot/cache/files/` for cached content
  3. Delete an output file, run again - should restore from cache
  4. Modify stage code, run again - should re-execute and update cache

```
$ pytest tests/test_cache.py tests/test_state.py tests/test_lock.py -v
63 passed
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Comments added for complex or non-obvious code
- [x] Uninformative comments removed
- [x] Documentation updated (if applicable)
- [x] Tests added or updated (if applicable)

## Additional Context

### New Files
- `src/pivot/cache.py` - CAS operations, hashing, linking
- `src/pivot/state.py` - SQLite-backed file metadata cache
- `tests/test_cache.py` - Cache module tests
- `tests/test_incremental_out.py` - IncrementalOut safety tests

### Key Features
- **Automatic restoration**: Skipped stages restore missing outputs from cache
- **Output validation**: Stages fail if declared outputs aren't produced
- **IncrementalOut safety**: Warns before deleting uncached incremental outputs (use `force=True` to override)
- **Link modes**: Configurable via `LinkMode.SYMLINK` (default), `HARDLINK`, or `COPY`
- **Cross-device fallback**: Hardlinks automatically fall back to copy on EXDEV errors

### Breaking Changes
- Lock files now include `output_hashes` field
- Old lock files without `output_hashes` trigger re-caching on first run

### Known Limitations (deferred)
- Directory cache copy has TOCTOU race for parallel identical outputs
- No garbage collection command yet (`pivot cache gc`)
- No remote cache support (S3/GCS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)