### PR TITLE
feat: Pydantic Stage Parameters with Automatic Injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ if __name__ == '__main__':
 - Use `Callable[..., Any]` for function params, not bare `Any`.
 - Document why when using `Any`.
 
+## TypedDict Access (Critical)
+
+**Never use `.get()` on TypedDicts.** TypedDicts have known keys at type-check time—use direct key access.
+TypedDicts with `total=False` or `NotRequired` fields may have optional fields, in which case you should
+use `if "key" in dict: ...` to check for the key and then use `dict["key"]` to access the value.
+
 ## Import Style (Google Python Style Guide)
 
 - Import modules, not functions: `from pivot import fingerprint` then `fingerprint.get_stage_fingerprint(...)`.

--- a/src/pivot/dag.py
+++ b/src/pivot/dag.py
@@ -48,7 +48,7 @@ def build_dag(stages: dict[str, RegistryStageInfo], validate: bool = True) -> nx
     outputs_map = _build_outputs_map(stages)
 
     for stage_name, stage_info in stages.items():
-        for dep in stage_info.get("deps", []):
+        for dep in stage_info["deps"]:
             producer = outputs_map.get(dep)
             if producer:
                 graph.add_edge(stage_name, producer)

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -104,3 +104,9 @@ class UncachedIncrementalOutputError(CacheError):
     """Raised when an IncrementalOut file exists but is not in cache."""
 
     pass
+
+
+class ParamsError(PivotError):
+    """Raised when parameter validation or loading fails."""
+
+    pass

--- a/src/pivot/params.py
+++ b/src/pivot/params.py
@@ -1,0 +1,127 @@
+"""Parameter loading and validation for Pydantic-based stage parameters.
+
+Supports loading parameters from YAML files with fallback to Pydantic model defaults.
+Parameters are injected into stage functions via a single `params` argument.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from pydantic import BaseModel
+
+from pivot import project
+
+if TYPE_CHECKING:
+    import inspect
+    import pathlib
+
+logger = logging.getLogger(__name__)
+
+_Loader: type[yaml.SafeLoader] | type[yaml.CSafeLoader]
+try:
+    _Loader = yaml.CSafeLoader
+except AttributeError:
+    _Loader = yaml.SafeLoader
+
+# Type alias for YAML params structure: stage_name -> param_name -> param_value
+# Inner dict values are Any because YAML can contain arbitrary JSON-compatible types
+YamlParams = dict[str, dict[str, Any]]
+
+
+def load_params_yaml(path: pathlib.Path | None = None) -> YamlParams:
+    """Load params.yaml from project root or specified path.
+
+    Returns dict of stage_name -> param_dict. Returns empty dict if file missing.
+    """
+    if path is None:
+        path = project.get_project_root() / "params.yaml"
+
+    if not path.exists():
+        return {}
+
+    try:
+        with open(path) as f:
+            data: object = yaml.load(f, Loader=_Loader)
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning(f"Failed to load params.yaml: {e}")
+        return {}
+
+    if not isinstance(data, dict):
+        logger.warning(f"params.yaml root must be a dict, got {type(data).__name__}")
+        return {}
+
+    # YAML dict has unknown key/value types from parsing arbitrary user input
+    typed_data = cast("dict[Any, Any]", data)
+    result = YamlParams()
+    for k, v in typed_data.items():
+        if isinstance(v, dict):
+            result[str(k)] = v
+    return result
+
+
+def build_params_instance[T: BaseModel](
+    params_cls: type[T],
+    stage_name: str,
+    yaml_overrides: YamlParams | None = None,
+) -> T:
+    """Build Pydantic model instance with YAML overrides applied.
+
+    Args:
+        params_cls: The Pydantic BaseModel class
+        stage_name: Name of the stage (for looking up YAML overrides)
+        yaml_overrides: Dict from load_params_yaml() or None
+
+    Returns:
+        Instantiated Pydantic model (preserves the specific type passed in)
+
+    Raises:
+        pydantic.ValidationError: If required fields missing or type mismatch
+    """
+    if yaml_overrides is None:
+        yaml_overrides = {}
+
+    stage_overrides = yaml_overrides.get(stage_name, {})
+    return params_cls(**stage_overrides)
+
+
+def params_to_dict(params: BaseModel) -> dict[str, Any]:
+    """Convert Pydantic model instance to dict for lock file storage."""
+    return params.model_dump()
+
+
+def validate_params_cls(params_cls: object) -> bool:
+    """Check if params_cls is a valid Pydantic BaseModel subclass."""
+    return isinstance(params_cls, type) and issubclass(params_cls, BaseModel)
+
+
+def extract_stage_params(
+    params_cls: type[BaseModel] | None,
+    signature: inspect.Signature | None,
+    stage_name: str,
+    yaml_overrides: YamlParams | None = None,
+) -> tuple[dict[str, Any], BaseModel | None]:
+    """Extract params dict and optionally the Pydantic instance for a stage.
+
+    For Pydantic params_cls: builds instance with YAML overrides and converts to dict.
+    For legacy stages: extracts defaults from function signature.
+
+    Returns:
+        Tuple of (params_dict, params_instance). params_instance is None for legacy stages.
+    """
+    if params_cls is not None:
+        instance = build_params_instance(params_cls, stage_name, yaml_overrides)
+        return params_to_dict(instance), instance
+
+    # Legacy: extract from signature defaults
+    if not signature:
+        return {}, None
+
+    params_dict = {
+        name: param.default
+        for name, param in signature.parameters.items()
+        if param.default is not param.empty
+    }
+    return params_dict, None

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -44,6 +44,8 @@ def test_execute_stage_worker_with_missing_deps(worker_env: pathlib.Path) -> Non
         "deps": ["missing_file.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     result = executor.execute_stage_worker(
@@ -75,6 +77,8 @@ def test_execute_stage_worker_with_directory_dep(
         "deps": ["data_dir"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     result = executor.execute_stage_worker(
@@ -103,6 +107,8 @@ def test_execute_stage_worker_runs_unchanged_stage(
         "deps": ["input.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     # First run - creates lock file
@@ -143,6 +149,8 @@ def test_execute_stage_worker_reruns_when_fingerprint_changes(
         "deps": ["input.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     # First run
@@ -186,6 +194,8 @@ def test_execute_stage_worker_handles_stage_exception(
         "deps": ["input.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     result = executor.execute_stage_worker(
@@ -214,6 +224,8 @@ def test_execute_stage_worker_handles_sys_exit(
         "deps": ["input.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     result = executor.execute_stage_worker(
@@ -243,6 +255,8 @@ def test_execute_stage_worker_handles_keyboard_interrupt(
         "deps": ["input.txt"],
         "signature": None,
         "outs": [],
+        "params_cls": None,
+        "yaml_overrides": {},
     }
 
     result = executor.execute_stage_worker(
@@ -700,9 +714,11 @@ def test_extract_params_with_no_signature() -> None:
         deps=[],
         outs=[],
         signature=None,
+        params_cls=None,
+        yaml_overrides={},
     )
-    params = executor.extract_params(stage_info)
-    assert params == {}
+    result = executor.extract_params(stage_info)
+    assert result == {}
 
 
 def test_extract_params_with_no_defaults() -> None:
@@ -718,9 +734,11 @@ def test_extract_params_with_no_defaults() -> None:
         deps=[],
         outs=[],
         signature=inspect.signature(func),
+        params_cls=None,
+        yaml_overrides={},
     )
-    params = executor.extract_params(stage_info)
-    assert params == {}
+    result = executor.extract_params(stage_info)
+    assert result == {}
 
 
 def test_extract_params_with_defaults() -> None:
@@ -736,9 +754,11 @@ def test_extract_params_with_defaults() -> None:
         deps=[],
         outs=[],
         signature=inspect.signature(func),
+        params_cls=None,
+        yaml_overrides={},
     )
-    params = executor.extract_params(stage_info)
-    assert params == {"b": "default", "c": 3.14}
+    result = executor.extract_params(stage_info)
+    assert result == {"b": "default", "c": 3.14}
 
 
 def test_hash_dependencies_with_existing_files(tmp_path: pathlib.Path) -> None:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,259 @@
+"""Tests for parameter loading and validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from pivot import params
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from pytest_mock import MockerFixture
+
+
+# -----------------------------------------------------------------------------
+# Test Pydantic models
+# -----------------------------------------------------------------------------
+
+
+class TrainParams(BaseModel):
+    learning_rate: float = 0.01
+    epochs: int = 100
+    batch_size: int = 32
+
+
+class RequiredParams(BaseModel):
+    name: str  # Required - no default
+    value: int = 10
+
+
+class NestedParams(BaseModel):
+    lr: float = 0.001
+    optimizer: str = "adam"
+
+
+class ComplexParams(BaseModel):
+    training: NestedParams = NestedParams()
+    debug: bool = False
+
+
+# -----------------------------------------------------------------------------
+# load_params_yaml tests
+# -----------------------------------------------------------------------------
+
+
+def test_load_params_yaml_missing_file(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    mocker.patch("pivot.project.get_project_root", return_value=tmp_path)
+    result = params.load_params_yaml()
+    assert result == {}, "Missing params.yaml should return empty dict"
+
+
+def test_load_params_yaml_from_explicit_path(tmp_path: pathlib.Path) -> None:
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("train:\n  learning_rate: 0.001\n  epochs: 200\n")
+
+    result = params.load_params_yaml(params_file)
+    assert result == {"train": {"learning_rate": 0.001, "epochs": 200}}
+
+
+def test_load_params_yaml_from_project_root(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    mocker.patch("pivot.project.get_project_root", return_value=tmp_path)
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("stage1:\n  lr: 0.01\nstage2:\n  batch: 64\n")
+
+    result = params.load_params_yaml()
+    assert result == {"stage1": {"lr": 0.01}, "stage2": {"batch": 64}}
+
+
+def test_load_params_yaml_non_dict_root(tmp_path: pathlib.Path) -> None:
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("- item1\n- item2\n")
+
+    result = params.load_params_yaml(params_file)
+    assert result == {}, "Non-dict root should return empty dict"
+
+
+def test_load_params_yaml_filters_non_dict_values(tmp_path: pathlib.Path) -> None:
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("valid:\n  key: value\ninvalid: just_a_string\n")
+
+    result = params.load_params_yaml(params_file)
+    assert result == {"valid": {"key": "value"}}, "Non-dict stage values should be filtered"
+
+
+def test_load_params_yaml_invalid_yaml(tmp_path: pathlib.Path) -> None:
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("invalid: yaml: content: ::::")
+
+    result = params.load_params_yaml(params_file)
+    assert result == {}, "Invalid YAML should return empty dict"
+
+
+# -----------------------------------------------------------------------------
+# build_params_instance tests
+# -----------------------------------------------------------------------------
+
+
+def test_build_params_instance_defaults_only() -> None:
+    instance = params.build_params_instance(TrainParams, "train", None)
+    assert isinstance(instance, TrainParams)
+    assert instance.learning_rate == 0.01
+    assert instance.epochs == 100
+    assert instance.batch_size == 32
+
+
+def test_build_params_instance_with_yaml_overrides() -> None:
+    yaml_overrides = {"train": {"learning_rate": 0.001, "epochs": 200}}
+    instance = params.build_params_instance(TrainParams, "train", yaml_overrides)
+    assert isinstance(instance, TrainParams)
+    assert instance.learning_rate == 0.001, "YAML should override default"
+    assert instance.epochs == 200, "YAML should override default"
+    assert instance.batch_size == 32, "Unspecified fields keep defaults"
+
+
+def test_build_params_instance_missing_stage_in_yaml() -> None:
+    yaml_overrides = {"other_stage": {"lr": 0.1}}
+    instance = params.build_params_instance(TrainParams, "train", yaml_overrides)
+    assert isinstance(instance, TrainParams)
+    assert instance.learning_rate == 0.01, "Should use defaults when stage not in YAML"
+
+
+def test_build_params_instance_extra_yaml_fields_ignored() -> None:
+    yaml_overrides = {"train": {"learning_rate": 0.002, "extra_field": "ignored"}}
+    instance = params.build_params_instance(TrainParams, "train", yaml_overrides)
+    assert isinstance(instance, TrainParams)
+    assert instance.learning_rate == 0.002
+    assert not hasattr(instance, "extra_field"), "Extra fields should be ignored"
+
+
+def test_build_params_instance_required_field_from_yaml() -> None:
+    yaml_overrides = {"process": {"name": "my_process"}}
+    instance = params.build_params_instance(RequiredParams, "process", yaml_overrides)
+    assert isinstance(instance, RequiredParams)
+    assert instance.name == "my_process"
+    assert instance.value == 10
+
+
+def test_build_params_instance_required_field_missing_raises() -> None:
+    with pytest.raises(ValidationError):
+        params.build_params_instance(RequiredParams, "process", {})
+
+
+def test_build_params_instance_type_mismatch_raises() -> None:
+    yaml_overrides = {"train": {"epochs": "not_an_int"}}
+    with pytest.raises(ValidationError):
+        params.build_params_instance(TrainParams, "train", yaml_overrides)
+
+
+def test_build_params_instance_nested_model() -> None:
+    yaml_overrides = {"complex": {"debug": True}}
+    instance = params.build_params_instance(ComplexParams, "complex", yaml_overrides)
+    assert isinstance(instance, ComplexParams)
+    assert instance.debug is True
+    assert instance.training.lr == 0.001
+    assert instance.training.optimizer == "adam"
+
+
+# -----------------------------------------------------------------------------
+# params_to_dict tests
+# -----------------------------------------------------------------------------
+
+
+def test_params_to_dict_simple() -> None:
+    instance = TrainParams(learning_rate=0.05, epochs=50, batch_size=16)
+    result = params.params_to_dict(instance)
+    assert result == {"learning_rate": 0.05, "epochs": 50, "batch_size": 16}
+
+
+def test_params_to_dict_nested() -> None:
+    instance = ComplexParams(debug=True, training=NestedParams(lr=0.01, optimizer="sgd"))
+    result = params.params_to_dict(instance)
+    assert result == {
+        "debug": True,
+        "training": {"lr": 0.01, "optimizer": "sgd"},
+    }
+
+
+# -----------------------------------------------------------------------------
+# validate_params_cls tests
+# -----------------------------------------------------------------------------
+
+
+def test_validate_params_cls_with_basemodel() -> None:
+    assert params.validate_params_cls(TrainParams) is True
+
+
+def test_validate_params_cls_with_non_class() -> None:
+    assert params.validate_params_cls("not a class") is False
+
+
+def test_validate_params_cls_with_regular_class() -> None:
+    class RegularClass:
+        pass
+
+    assert params.validate_params_cls(RegularClass) is False
+
+
+def test_validate_params_cls_with_dict() -> None:
+    assert params.validate_params_cls(dict) is False
+
+
+# -----------------------------------------------------------------------------
+# extract_stage_params tests
+# -----------------------------------------------------------------------------
+
+
+def test_extract_stage_params_with_pydantic_model() -> None:
+    yaml_overrides = {"train": {"learning_rate": 0.005}}
+    params_dict, instance = params.extract_stage_params(TrainParams, None, "train", yaml_overrides)
+    assert params_dict == {"learning_rate": 0.005, "epochs": 100, "batch_size": 32}
+    assert isinstance(instance, TrainParams)
+    assert instance.learning_rate == 0.005
+
+
+def test_extract_stage_params_with_signature_defaults() -> None:
+    import inspect
+
+    def stage_func(lr: float = 0.01, epochs: int = 100) -> None:
+        pass
+
+    sig = inspect.signature(stage_func)
+    params_dict, instance = params.extract_stage_params(None, sig, "train", None)
+    assert params_dict == {"lr": 0.01, "epochs": 100}
+    assert instance is None, "Legacy signature path returns no instance"
+
+
+def test_extract_stage_params_no_params_cls_no_signature() -> None:
+    params_dict, instance = params.extract_stage_params(None, None, "train", None)
+    assert params_dict == {}
+    assert instance is None
+
+
+def test_extract_stage_params_pydantic_takes_precedence() -> None:
+    import inspect
+
+    def stage_func(lr: float = 0.99) -> None:
+        pass
+
+    sig = inspect.signature(stage_func)
+    yaml_overrides = {"train": {"learning_rate": 0.002}}
+    params_dict, instance = params.extract_stage_params(TrainParams, sig, "train", yaml_overrides)
+    assert params_dict == {"learning_rate": 0.002, "epochs": 100, "batch_size": 32}
+    assert isinstance(instance, TrainParams), "Pydantic model takes precedence over signature"
+
+
+def test_extract_stage_params_signature_filters_empty_defaults() -> None:
+    import inspect
+
+    def stage_func(required_arg: str, optional: int = 42) -> None:
+        pass
+
+    sig = inspect.signature(stage_func)
+    params_dict, instance = params.extract_stage_params(None, sig, "test", None)
+    assert params_dict == {"optional": 42}, "Only params with defaults are extracted"
+    assert "required_arg" not in params_dict
+    assert instance is None


### PR DESCRIPTION
## Summary

Closes #8

- Add `params_cls` argument to `@stage` decorator for Pydantic BaseModel parameters
- Automatic parameter injection via `params` function argument
- Support `params.yaml` file to override Pydantic model defaults
- Parameter change detection for cache invalidation
- Fail-fast validation at registration time

## Target API

```python
from pydantic import BaseModel
from pivot import stage

class TrainParams(BaseModel):
    learning_rate: float = 0.01
    epochs: int = 100

@stage(deps=['data.csv'], outs=['model.pkl'], params_cls=TrainParams)
def train(params: TrainParams):
    print(f"Training with lr={params.learning_rate}")
```

Optional `params.yaml` override:
```yaml
train:
  learning_rate: 0.001
  epochs: 200
```

## Changes

- **New file:** `src/pivot/params.py` - Parameter loading, validation, and extraction
- **Modified:** `src/pivot/registry.py` - BaseModel validation at registration
- **Modified:** `src/pivot/executor.py` - Parameter injection into stage functions
- **Modified:** `src/pivot/cli.py` - Dry-run parameter extraction
- **Modified:** `src/pivot/dvc_compat.py` - DVC export with Pydantic defaults
- **Modified:** `src/pivot/exceptions.py` - Added `ParamsError`
- **New file:** `tests/test_params.py` - Unit tests for params module

## Test plan

- [x] All 483 existing tests pass
- [x] Coverage at 91.16% (above 90% target)
- [x] New unit tests for params module
- [x] Integration tests for parameter injection
- [x] Validation error handling tests

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)