### PR TITLE
feat: tracked files/dirs

### DIFF
--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -23,6 +23,7 @@ from pivot import cache as cache
 from pivot import dvc_compat as dvc_compat
 from pivot import outputs as outputs
 from pivot import parameters as parameters
+from pivot import pvt as pvt
 from pivot import state as state
 from pivot.outputs import BaseOut as BaseOut
 from pivot.outputs import IncrementalOut as IncrementalOut

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -22,6 +22,12 @@ class OverlappingOutputPathsError(ValidationError):
     pass
 
 
+class InvalidPathError(ValidationError):
+    """Raised when a path is invalid (e.g., resolves outside project root)."""
+
+    pass
+
+
 class DAGError(PivotError):
     """Base class for DAG-related errors."""
 
@@ -108,5 +114,11 @@ class UncachedIncrementalOutputError(CacheError):
 
 class ParamsError(PivotError):
     """Raised when parameter validation or loading fails."""
+
+    pass
+
+
+class TrackedFileMissingError(CacheError):
+    """Raised when a .pvt tracked file is missing (user should run pivot checkout)."""
 
     pass

--- a/src/pivot/pvt.py
+++ b/src/pivot/pvt.py
@@ -1,0 +1,134 @@
+"""PVT file handling for tracked files.
+
+.pvt files are YAML manifests that track arbitrary data files/directories,
+similar to DVC's .dvc files. They sit alongside the tracked data for
+discoverability.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import TYPE_CHECKING, NotRequired, TypedDict, TypeGuard, cast
+
+import yaml
+
+from pivot import cache
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from pivot.types import DirManifestEntry
+
+# Use union types to avoid type: ignore on fallback assignment
+_Loader: type[yaml.SafeLoader] | type[yaml.CSafeLoader]
+_Dumper: type[yaml.SafeDumper] | type[yaml.CSafeDumper]
+
+try:
+    _Loader = yaml.CSafeLoader
+    _Dumper = yaml.CSafeDumper
+except AttributeError:
+    _Loader = yaml.SafeLoader
+    _Dumper = yaml.SafeDumper
+
+
+class PvtData(TypedDict):
+    """Data stored in .pvt files."""
+
+    path: str  # Relative path to tracked file/directory
+    hash: str  # Content hash
+    size: int  # Total size (file or sum of directory)
+    num_files: NotRequired[int]  # For directories only
+    manifest: NotRequired[list[DirManifestEntry]]  # For directories only
+
+
+_REQUIRED_KEYS = frozenset({"path", "hash", "size"})
+_VALID_KEYS = frozenset({"path", "hash", "size", "num_files", "manifest"})
+_PATH_TRAVERSAL = re.compile(r"(^|/)\.\.(/|$)")
+
+
+def _is_pvt_data(data: object) -> TypeGuard[PvtData]:
+    """Validate that parsed YAML has valid PvtData structure."""
+    if not isinstance(data, dict):
+        return False
+    str_data = cast("dict[str, object]", data)
+    if not _REQUIRED_KEYS.issubset(str_data.keys()):
+        return False
+    return all(key in _VALID_KEYS for key in str_data)
+
+
+def has_path_traversal(path: str) -> bool:
+    """Check if path contains traversal components (..)."""
+    return bool(_PATH_TRAVERSAL.search(path))
+
+
+def _validate_path(path: str) -> None:
+    """Validate path doesn't contain traversal."""
+    if has_path_traversal(path):
+        raise ValueError(f"Path contains path traversal: {path!r}")
+
+
+def write_pvt_file(pvt_path: pathlib.Path, data: PvtData) -> None:
+    """Write .pvt file atomically."""
+    _validate_path(data["path"])
+
+    def write_yaml(fd: int) -> None:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(dict(data), f, Dumper=_Dumper, sort_keys=False)
+
+    cache.atomic_write_file(pvt_path, write_yaml)
+
+
+def read_pvt_file(pvt_path: pathlib.Path) -> PvtData | None:
+    """Read .pvt file, return None if missing or invalid."""
+    try:
+        with open(pvt_path) as f:
+            data: object = yaml.load(f, Loader=_Loader)
+        if not _is_pvt_data(data):
+            return None
+        # Validate path doesn't contain traversal (security check)
+        if has_path_traversal(data["path"]):
+            return None
+        return data
+    except (FileNotFoundError, UnicodeDecodeError, yaml.YAMLError):
+        return None
+
+
+def get_pvt_path(data_path: pathlib.Path) -> pathlib.Path:
+    """Get .pvt path for a data path (file.csv -> file.csv.pvt, dir/ -> dir.pvt)."""
+    # pathlib normalizes trailing slashes, so "images/" becomes "images"
+    return data_path.with_suffix(data_path.suffix + ".pvt")
+
+
+def get_data_path(pvt_path: pathlib.Path) -> pathlib.Path:
+    """Get data path from .pvt path."""
+    if not pvt_path.suffix == ".pvt":
+        raise ValueError(f"Expected .pvt file, got: {pvt_path}")
+    # Remove .pvt suffix
+    return pvt_path.with_suffix("")
+
+
+def discover_pvt_files(root: pathlib.Path) -> dict[str, PvtData]:
+    """Find all .pvt files under root, return {data_path: PvtData}."""
+    from pivot import project
+
+    result = dict[str, PvtData]()
+
+    for pvt_path in root.rglob("*.pvt"):
+        if not pvt_path.is_file():
+            continue
+        data = read_pvt_file(pvt_path)
+        if data is None:
+            logger.warning(f"Skipping invalid .pvt file: {pvt_path}")
+            continue
+
+        # Compute absolute data path from pvt file location + relative path
+        # Use normalized path (preserve symlinks) for portability
+        data_path = pvt_path.parent / data["path"]
+        normalized = project.normalize_path(str(data_path))
+        result[str(normalized)] = data
+
+    return result

--- a/src/pivot/state.py
+++ b/src/pivot/state.py
@@ -51,7 +51,11 @@ class StateDB:
             raise RuntimeError("Cannot operate on closed StateDB")
 
     def get(self, path: pathlib.Path, fs_stat: os.stat_result) -> str | None:
-        """Return cached hash if file metadata matches, else None."""
+        """Return cached hash if file metadata matches, else None.
+
+        Note: Uses resolved paths (symlinks followed) as keys because state DB
+        is local-only. Lock files use normalized paths for portability.
+        """
         self._check_closed()
         abs_path = str(path.resolve())
         with self._lock:
@@ -63,7 +67,10 @@ class StateDB:
         return row[0] if row else None
 
     def save(self, path: pathlib.Path, fs_stat: os.stat_result, file_hash: str) -> None:
-        """Cache file metadata and hash."""
+        """Cache file metadata and hash.
+
+        Note: Uses resolved paths (symlinks followed) as keys for local-only cache.
+        """
         self._check_closed()
         abs_path = str(path.resolve())
         with self._lock:

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -15,6 +15,7 @@ class StageStatus(enum.StrEnum):
     SKIPPED = "skipped"
     FAILED = "failed"
     RAN = "ran"
+    UNKNOWN = "unknown"
 
 
 class StageDisplayStatus(enum.StrEnum):
@@ -36,7 +37,7 @@ class OnError(enum.StrEnum):
 class StageResult(TypedDict):
     """Result from executing a single stage."""
 
-    status: Literal["ran", "skipped", "failed"]
+    status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED]
     reason: str
     output_lines: list[tuple[str, bool]]
 
@@ -63,6 +64,10 @@ class DirHash(TypedDict):
     manifest: list[DirManifestEntry]
 
 
+# Non-null hash for computed hashes (from hash_dependencies, save_to_cache)
+HashInfo = FileHash | DirHash
+
+# Nullable hash for lock file storage (may be None for uncached outputs)
 OutputHash = FileHash | DirHash | None
 
 
@@ -71,8 +76,8 @@ class LockData(TypedDict, total=False):
 
     code_manifest: dict[str, str]
     params: dict[str, Any]
-    dep_hashes: dict[str, str]
-    output_hashes: dict[str, OutputHash]
+    dep_hashes: dict[str, HashInfo]  # FileHash or DirHash (with manifest), never None
+    output_hashes: dict[str, OutputHash]  # Can be None for uncached outputs
 
 
 # Type alias for output queue messages: (stage_name, line, is_stderr) or None for shutdown

--- a/tests/test_cli_checkout.py
+++ b/tests/test_cli_checkout.py
@@ -1,0 +1,337 @@
+"""Tests for pivot checkout CLI command."""
+
+import pathlib
+
+import click.testing
+import pytest
+
+from pivot import cli, executor, project, pvt, stage
+from pivot.registry import REGISTRY
+
+
+@pytest.fixture
+def runner() -> click.testing.CliRunner:
+    """Create a CLI runner for testing."""
+    return click.testing.CliRunner()
+
+
+# =============================================================================
+# Basic Checkout Command Tests
+# =============================================================================
+
+
+def test_checkout_help(runner: click.testing.CliRunner) -> None:
+    """Checkout command shows help."""
+    result = runner.invoke(cli.cli, ["checkout", "--help"])
+    assert result.exit_code == 0
+    assert "Restore" in result.output or "checkout" in result.output.lower()
+
+
+def test_checkout_restores_tracked_file(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout restores a tracked file from cache."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create and track a file
+        data_file = pathlib.Path("data.csv")
+        data_file.write_text("col1,col2\n1,2\n")
+        original_content = data_file.read_text()
+
+        result = runner.invoke(cli.cli, ["track", "data.csv"])
+        assert result.exit_code == 0
+
+        # Delete the data file
+        data_file.unlink()
+        assert not data_file.exists()
+
+        # Checkout should restore it
+        result = runner.invoke(cli.cli, ["checkout", "data.csv"])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        # File should be restored
+        assert data_file.exists(), "File should be restored"
+        assert data_file.read_text() == original_content
+
+
+def test_checkout_restores_tracked_directory(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout restores a tracked directory from cache."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create and track a directory
+        data_dir = pathlib.Path("images")
+        data_dir.mkdir()
+        (data_dir / "cat.jpg").write_bytes(b"cat image")
+        (data_dir / "dog.jpg").write_bytes(b"dog image")
+
+        result = runner.invoke(cli.cli, ["track", "images"])
+        assert result.exit_code == 0
+
+        # Delete the directory
+        import shutil
+
+        shutil.rmtree(data_dir)
+        assert not data_dir.exists()
+
+        # Checkout should restore it
+        result = runner.invoke(cli.cli, ["checkout", "images"])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        # Directory should be restored
+        assert data_dir.exists(), "Directory should be restored"
+        assert (data_dir / "cat.jpg").read_bytes() == b"cat image"
+        assert (data_dir / "dog.jpg").read_bytes() == b"dog image"
+
+
+def test_checkout_restores_stage_output(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout restores a stage output from cache."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create input file
+        pathlib.Path("input.txt").write_text("input data")
+
+        # Define and run a stage
+        @stage(deps=["input.txt"], outs=["output.txt"])
+        def process() -> None:
+            pathlib.Path("output.txt").write_text("output data")
+
+        # Run the stage to create and cache output
+        executor.run(show_output=False)
+
+        # Verify output exists
+        output_file = pathlib.Path("output.txt")
+        assert output_file.exists()
+
+        # Delete the output
+        output_file.unlink()
+        assert not output_file.exists()
+
+        # Checkout should restore it
+        result = runner.invoke(cli.cli, ["checkout", "output.txt"])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        # Output should be restored
+        assert output_file.exists(), "Stage output should be restored"
+        # Content may differ slightly due to symlinking behavior, but should exist
+
+        REGISTRY.clear()
+
+
+def test_checkout_all_restores_everything(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout without arguments restores all tracked files and outputs."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Track a file
+        pathlib.Path("data.csv").write_text("data")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        # Create and run a stage
+        pathlib.Path("input.txt").write_text("input")
+
+        @stage(deps=["input.txt"], outs=["model.pkl"])
+        def train() -> None:
+            pathlib.Path("model.pkl").write_bytes(b"model")
+
+        executor.run(show_output=False)
+
+        # Delete both
+        pathlib.Path("data.csv").unlink()
+        pathlib.Path("model.pkl").unlink()
+
+        # Checkout all
+        result = runner.invoke(cli.cli, ["checkout"])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        # Both should be restored
+        assert pathlib.Path("data.csv").exists(), "Tracked file should be restored"
+        assert pathlib.Path("model.pkl").exists(), "Stage output should be restored"
+
+        REGISTRY.clear()
+
+
+def test_checkout_with_link_option(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Checkout respects --link option."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Track a file
+        pathlib.Path("data.csv").write_text("data content")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        # Delete it
+        pathlib.Path("data.csv").unlink()
+
+        # Checkout with copy mode
+        result = runner.invoke(cli.cli, ["checkout", "--link", "copy", "data.csv"])
+        assert result.exit_code == 0
+
+        # File should exist and be a regular file (not symlink)
+        data_file = pathlib.Path("data.csv")
+        assert data_file.exists()
+        assert not data_file.is_symlink(), "With --link=copy, should not be symlink"
+
+
+def test_checkout_with_symlink_mode(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout with symlink mode creates symlinks."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("data")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        pathlib.Path("data.csv").unlink()
+
+        result = runner.invoke(cli.cli, ["checkout", "--link", "symlink", "data.csv"])
+        assert result.exit_code == 0
+
+        data_file = pathlib.Path("data.csv")
+        assert data_file.exists()
+        # With symlink mode, file should be a symlink
+        assert data_file.is_symlink(), "With --link=symlink, should be symlink"
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+def test_checkout_missing_from_cache_errors(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout fails when file not in cache."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create .pvt file manually without caching the data
+        pvt_data: pvt.PvtData = {
+            "path": "data.csv",
+            "hash": "nonexistent_hash",
+            "size": 100,
+        }
+        pvt.write_pvt_file(pathlib.Path("data.csv.pvt"), pvt_data)
+
+        result = runner.invoke(cli.cli, ["checkout", "data.csv"])
+
+        assert result.exit_code != 0
+        assert "cache" in result.output.lower() or "not found" in result.output.lower()
+
+
+def test_checkout_unknown_target_errors(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout fails for unknown target (not tracked, not a stage output)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        result = runner.invoke(cli.cli, ["checkout", "unknown.csv"])
+
+        assert result.exit_code != 0
+
+
+def test_checkout_already_exists_skips(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout skips files that already exist (without --force)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("original")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        # Modify file
+        pathlib.Path("data.csv").write_text("modified")
+
+        # Checkout should skip (file exists)
+        result = runner.invoke(cli.cli, ["checkout", "data.csv"])
+        assert result.exit_code == 0
+        assert "skip" in result.output.lower() or pathlib.Path("data.csv").read_text() == "modified"
+
+
+def test_checkout_force_overwrites(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Checkout with --force overwrites existing files."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("original")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        # Modify file
+        pathlib.Path("data.csv").write_text("modified")
+
+        # Checkout with --force should overwrite
+        result = runner.invoke(cli.cli, ["checkout", "--force", "data.csv"])
+        assert result.exit_code == 0
+
+        # File should have original content
+        assert pathlib.Path("data.csv").read_text() == "original"
+
+
+# =============================================================================
+# Multiple Targets Tests
+# =============================================================================
+
+
+def test_checkout_multiple_targets(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Checkout can restore multiple targets at once."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Track multiple files
+        pathlib.Path("a.csv").write_text("a")
+        pathlib.Path("b.csv").write_text("b")
+        runner.invoke(cli.cli, ["track", "a.csv", "b.csv"])
+
+        # Delete both
+        pathlib.Path("a.csv").unlink()
+        pathlib.Path("b.csv").unlink()
+
+        # Checkout both
+        result = runner.invoke(cli.cli, ["checkout", "a.csv", "b.csv"])
+        assert result.exit_code == 0
+
+        assert pathlib.Path("a.csv").exists()
+        assert pathlib.Path("b.csv").exists()
+
+
+# =============================================================================
+# Status Reporting Tests
+# =============================================================================
+
+
+def test_checkout_reports_status(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Checkout reports status for each target."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("data")
+        runner.invoke(cli.cli, ["track", "data.csv"])
+
+        pathlib.Path("data.csv").unlink()
+
+        result = runner.invoke(cli.cli, ["checkout", "data.csv"])
+        assert result.exit_code == 0
+        assert "data.csv" in result.output

--- a/tests/test_cli_track.py
+++ b/tests/test_cli_track.py
@@ -1,0 +1,546 @@
+"""Tests for pivot track CLI command."""
+
+import pathlib
+
+import click.testing
+import pytest
+
+from pivot import cli, project, pvt
+
+
+@pytest.fixture
+def runner() -> click.testing.CliRunner:
+    """Create a CLI runner for testing."""
+    return click.testing.CliRunner()
+
+
+# =============================================================================
+# Basic Track Command Tests
+# =============================================================================
+
+
+def test_track_help(runner: click.testing.CliRunner) -> None:
+    """Track command shows help."""
+    result = runner.invoke(cli.cli, ["track", "--help"])
+    assert result.exit_code == 0
+    assert "Track files" in result.output or "track" in result.output.lower()
+
+
+def test_track_file_creates_pvt_and_caches(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking a file creates .pvt file and caches content."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create a file to track
+        data_file = pathlib.Path("data.csv")
+        data_file.write_text("col1,col2\n1,2\n3,4\n")
+
+        result = runner.invoke(cli.cli, ["track", "data.csv"])
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # .pvt file should exist
+        pvt_file = pathlib.Path("data.csv.pvt")
+        assert pvt_file.exists(), ".pvt file should be created"
+
+        # Read and verify .pvt content
+        pvt_data = pvt.read_pvt_file(pvt_file)
+        assert pvt_data is not None
+        assert pvt_data["path"] == "data.csv"
+        assert pvt_data["hash"], "Hash should be set"
+        assert pvt_data["size"] > 0, "Size should be positive"
+
+        # Cache should contain the file
+        cache_dir = pathlib.Path(".pivot/cache/files")
+        assert cache_dir.exists(), "Cache directory should be created"
+
+
+def test_track_file_shows_confirmation(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking shows confirmation message."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("content")
+
+        result = runner.invoke(cli.cli, ["track", "data.csv"])
+
+        assert result.exit_code == 0
+        assert "data.csv" in result.output
+
+
+def test_track_multiple_files(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Can track multiple files at once."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("a.csv").write_text("a")
+        pathlib.Path("b.csv").write_text("b")
+
+        result = runner.invoke(cli.cli, ["track", "a.csv", "b.csv"])
+
+        assert result.exit_code == 0
+        assert pathlib.Path("a.csv.pvt").exists()
+        assert pathlib.Path("b.csv.pvt").exists()
+
+
+def test_track_directory_with_manifest(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking a directory creates .pvt with manifest."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create directory with files
+        data_dir = pathlib.Path("images")
+        data_dir.mkdir()
+        (data_dir / "cat.jpg").write_bytes(b"fake image 1")
+        (data_dir / "dog.jpg").write_bytes(b"fake image 2")
+
+        result = runner.invoke(cli.cli, ["track", "images"])
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+
+        # .pvt file should exist (not images.pvt/ but images.pvt)
+        pvt_file = pathlib.Path("images.pvt")
+        assert pvt_file.exists(), ".pvt file should be created for directory"
+
+        # Read and verify .pvt content
+        pvt_data = pvt.read_pvt_file(pvt_file)
+        assert pvt_data is not None
+        assert pvt_data["path"] == "images"
+        assert pvt_data["hash"], "Tree hash should be set"
+        assert pvt_data.get("num_files") == 2, "Should have 2 files"
+        manifest = pvt_data.get("manifest")
+        assert manifest is not None, "Should have manifest"
+        assert len(manifest) == 2, "Manifest should have 2 entries"
+
+        # Verify manifest entries
+        relpaths = {e["relpath"] for e in manifest}
+        assert "cat.jpg" in relpaths
+        assert "dog.jpg" in relpaths
+
+
+def test_track_nested_file(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Track file in nested directory creates .pvt next to file."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        nested = pathlib.Path("data/raw")
+        nested.mkdir(parents=True)
+        (nested / "train.csv").write_text("data")
+
+        result = runner.invoke(cli.cli, ["track", "data/raw/train.csv"])
+
+        assert result.exit_code == 0
+        pvt_file = pathlib.Path("data/raw/train.csv.pvt")
+        assert pvt_file.exists(), ".pvt should be next to tracked file"
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+def test_track_missing_file_errors(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Tracking non-existent file fails with error."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        result = runner.invoke(cli.cli, ["track", "missing.csv"])
+
+        assert result.exit_code != 0
+        assert "missing" in result.output.lower() or "not found" in result.output.lower()
+
+
+def test_track_no_arguments_errors(runner: click.testing.CliRunner) -> None:
+    """Track without arguments shows error."""
+    result = runner.invoke(cli.cli, ["track"])
+
+    assert result.exit_code != 0
+
+
+def test_track_duplicate_file_raises_error(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking same file twice raises error."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("content")
+
+        # First track should succeed
+        result1 = runner.invoke(cli.cli, ["track", "data.csv"])
+        assert result1.exit_code == 0
+
+        # Second track should fail
+        result2 = runner.invoke(cli.cli, ["track", "data.csv"])
+        assert result2.exit_code != 0, "Duplicate tracking should fail"
+        assert "already tracked" in result2.output.lower() or "duplicate" in result2.output.lower()
+
+
+def test_track_file_in_stage_output_dir_raises_error(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking file within stage output directory raises error."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create output directory for a stage
+        output_dir = pathlib.Path("outputs")
+        output_dir.mkdir()
+        (output_dir / "model.pkl").write_bytes(b"model")
+
+        # Register a stage with directory output
+        @stage(deps=[], outs=["outputs/"])
+        def train() -> None:
+            pass
+
+        # Try to track a file within that output directory
+        result = runner.invoke(cli.cli, ["track", "outputs/model.pkl"])
+
+        # Should fail because path overlaps with stage output
+        assert result.exit_code != 0, "Tracking file in stage output should fail"
+        assert "output" in result.output.lower() or "conflict" in result.output.lower()
+
+        # Clear registry for other tests
+        REGISTRY.clear()
+
+
+def test_track_stage_output_raises_error(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking a path that is a stage output raises error."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create the file
+        pathlib.Path("model.pkl").write_bytes(b"model")
+
+        # Register a stage with this file as output
+        @stage(deps=[], outs=["model.pkl"])
+        def train() -> None:
+            pass
+
+        # Try to track the stage output
+        result = runner.invoke(cli.cli, ["track", "model.pkl"])
+
+        assert result.exit_code != 0
+        assert "output" in result.output.lower() or "conflict" in result.output.lower()
+
+        REGISTRY.clear()
+
+
+# =============================================================================
+# Update Tracking Tests
+# =============================================================================
+
+
+def test_track_update_existing_with_force(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Re-tracking with --force updates the .pvt file."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        data_file = pathlib.Path("data.csv")
+        data_file.write_text("original")
+
+        # First track
+        result1 = runner.invoke(cli.cli, ["track", "data.csv"])
+        assert result1.exit_code == 0
+        pvt_data1 = pvt.read_pvt_file(pathlib.Path("data.csv.pvt"))
+        assert pvt_data1 is not None
+        original_hash = pvt_data1["hash"]
+
+        # Modify file
+        data_file.write_text("modified content")
+
+        # Re-track with --force should succeed and update hash
+        result2 = runner.invoke(cli.cli, ["track", "--force", "data.csv"])
+        assert result2.exit_code == 0
+
+        pvt_data2 = pvt.read_pvt_file(pathlib.Path("data.csv.pvt"))
+        assert pvt_data2 is not None
+        assert pvt_data2["hash"] != original_hash, "Hash should be updated"
+
+
+# =============================================================================
+# Path Handling Tests
+# =============================================================================
+
+
+def test_track_relative_path(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """Track accepts relative paths."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        pathlib.Path("data.csv").write_text("content")
+
+        result = runner.invoke(cli.cli, ["track", "./data.csv"])
+
+        assert result.exit_code == 0
+
+
+def test_track_path_traversal_rejected(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Paths with .. are rejected."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create file outside project
+        parent = pathlib.Path("..").resolve()
+        (parent / "outside.txt").write_text("secret")
+
+        result = runner.invoke(cli.cli, ["track", "../outside.txt"])
+
+        assert result.exit_code != 0
+
+
+# =============================================================================
+# Symlink Overlap Detection Tests
+# =============================================================================
+
+
+def test_track_symlink_to_stage_output_file_rejected(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking symlink that points to stage output file is rejected."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create stage output file
+        pathlib.Path("model.pkl").write_bytes(b"model")
+
+        # Register stage with this file as output
+        @stage(deps=[], outs=["model.pkl"])
+        def train() -> None:
+            pass
+
+        # Create symlink pointing to the stage output
+        pathlib.Path("model_link.pkl").symlink_to("model.pkl")
+
+        # Try to track the symlink
+        result = runner.invoke(cli.cli, ["track", "model_link.pkl"])
+
+        assert result.exit_code != 0, "Should reject symlink to stage output"
+        assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
+            "Error should mention overlap with stage output"
+        )
+        assert "resolves to" in result.output.lower(), (
+            "Error should show resolved path for debugging"
+        )
+
+        REGISTRY.clear()
+
+
+def test_track_symlink_to_stage_output_directory_rejected(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking symlink that points to stage output directory is rejected."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create stage output directory
+        output_dir = pathlib.Path("outputs")
+        output_dir.mkdir()
+        (output_dir / "results.txt").write_text("data")
+
+        # Register stage with directory as output
+        @stage(deps=[], outs=["outputs/"])
+        def process() -> None:
+            pass
+
+        # Create symlink pointing to the output directory
+        pathlib.Path("output_link").symlink_to("outputs")
+
+        # Try to track the symlink
+        result = runner.invoke(cli.cli, ["track", "output_link"])
+
+        assert result.exit_code != 0, "Should reject symlink to stage output directory"
+        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+
+        REGISTRY.clear()
+
+
+def test_track_file_inside_symlinked_stage_output_rejected(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking file inside symlinked directory that's a stage output is rejected."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create actual directory with files
+        real_dir = pathlib.Path("real_outputs")
+        real_dir.mkdir()
+        (real_dir / "model.pkl").write_bytes(b"model")
+
+        # Create symlink to directory
+        pathlib.Path("outputs_link").symlink_to("real_outputs")
+
+        # Register stage with symlinked path as output
+        @stage(deps=[], outs=["outputs_link/"])
+        def train() -> None:
+            pass
+
+        # Try to track file via the real path
+        result = runner.invoke(cli.cli, ["track", "real_outputs/model.pkl"])
+
+        assert result.exit_code != 0, "Should detect overlap through symlink aliasing"
+        assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
+            "Error should mention overlap with stage output"
+        )
+
+        REGISTRY.clear()
+
+
+def test_track_broken_symlink_rejected_with_clear_error(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking broken symlink fails with clear error message."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create broken symlink (target doesn't exist)
+        pathlib.Path("broken_link.csv").symlink_to("nonexistent.csv")
+
+        result = runner.invoke(cli.cli, ["track", "broken_link.csv"])
+
+        assert result.exit_code != 0, "Should reject broken symlink"
+        assert "broken" in result.output.lower() or "does not exist" in result.output.lower(), (
+            "Error should clearly indicate broken symlink"
+        )
+
+
+def test_track_symlink_aliasing_same_file_different_paths(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking same file via different symlink paths detects aliasing."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create real file
+        pathlib.Path("real_data.csv").write_text("data")
+
+        # Create two symlinks to same file
+        pathlib.Path("link1.csv").symlink_to("real_data.csv")
+        pathlib.Path("link2.csv").symlink_to("real_data.csv")
+
+        # Register stage with one symlink as output
+        @stage(deps=[], outs=["link1.csv"])
+        def produce() -> None:
+            pass
+
+        # Try to track the other symlink (points to same file)
+        result = runner.invoke(cli.cli, ["track", "link2.csv"])
+
+        assert result.exit_code != 0, "Should detect that link2 and link1 point to same file"
+        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+
+        REGISTRY.clear()
+
+
+def test_track_parent_directory_with_symlinked_stage_output(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Tracking parent directory when child is symlinked stage output is rejected."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create directory structure
+        parent_dir = pathlib.Path("data")
+        parent_dir.mkdir()
+        real_file = parent_dir / "real_model.pkl"
+        real_file.write_bytes(b"model")
+
+        # Create symlink inside parent directory
+        symlink = parent_dir / "model_link.pkl"
+        symlink.symlink_to("real_model.pkl")
+
+        # Register stage with symlink as output
+        @stage(deps=[], outs=["data/model_link.pkl"])
+        def train() -> None:
+            pass
+
+        # Try to track parent directory (contains stage output)
+        result = runner.invoke(cli.cli, ["track", "data"])
+
+        assert result.exit_code != 0, "Should reject tracking directory containing stage output"
+        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+
+        REGISTRY.clear()
+
+
+def test_track_with_normalized_vs_resolved_paths(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Error messages show both normalized and resolved paths for debugging."""
+    from pivot import stage
+    from pivot.registry import REGISTRY
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        project._project_root_cache = None
+
+        # Create nested directory structure with symlink
+        pathlib.Path("real").mkdir()
+        pathlib.Path("real/data.csv").write_text("data")
+        pathlib.Path("link_to_real").symlink_to("real")
+
+        # Register stage with real path
+        @stage(deps=[], outs=["real/data.csv"])
+        def process() -> None:
+            pass
+
+        # Try to track via symlinked path
+        result = runner.invoke(cli.cli, ["track", "link_to_real/data.csv"])
+
+        assert result.exit_code != 0, "Should detect overlap via symlink"
+        # Both paths should appear in error for clarity
+        assert "link_to_real" in result.output, "Should show user's path"
+        assert "real" in result.output, "Should show resolved path"
+
+        REGISTRY.clear()

--- a/tests/test_executor_pvt.py
+++ b/tests/test_executor_pvt.py
@@ -1,0 +1,301 @@
+"""Integration tests for executor with .pvt tracked files."""
+
+import pathlib
+
+import click.testing
+import pytest
+
+import pivot
+from pivot import cli, exceptions, executor, project, pvt, registry
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> None:
+    """Reset registry before each test."""
+    registry.REGISTRY.clear()
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Set up a temporary pipeline directory."""
+    (tmp_path / ".pivot").mkdir()
+    monkeypatch.chdir(tmp_path)
+    project._project_root_cache = None
+    return tmp_path
+
+
+@pytest.fixture
+def runner() -> click.testing.CliRunner:
+    """Create a CLI runner for testing."""
+    return click.testing.CliRunner()
+
+
+# =============================================================================
+# Tracked File Verification Tests
+# =============================================================================
+
+
+def test_run_succeeds_with_existing_tracked_file(pipeline_dir: pathlib.Path) -> None:
+    """Pipeline runs successfully when tracked file exists."""
+    # Create and track a data file
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("col1,col2\n1,2\n")
+
+    pvt.write_pvt_file(
+        pipeline_dir / "data.csv.pvt",
+        {"path": "data.csv", "hash": "placeholder", "size": 100},
+    )
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        data = pathlib.Path("data.csv").read_text()
+        pathlib.Path("output.txt").write_text(f"processed: {len(data)} bytes")
+
+    results = executor.run(show_output=False)
+
+    assert results["process"]["status"] == "ran"
+    assert (pipeline_dir / "output.txt").exists()
+
+
+def test_run_fails_when_tracked_file_missing(pipeline_dir: pathlib.Path) -> None:
+    """Pipeline fails if tracked file is missing (with helpful error message)."""
+    # Create .pvt file but NOT the data file
+    pvt.write_pvt_file(
+        pipeline_dir / "data.csv.pvt",
+        {"path": "data.csv", "hash": "abc123", "size": 100},
+    )
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        pathlib.Path("output.txt").write_text("done")
+
+    # Should fail with error message mentioning checkout
+    with pytest.raises(
+        exceptions.TrackedFileMissingError,
+        match=r"checkout|restore|missing",
+    ):
+        executor.run(show_output=False)
+
+
+def test_run_succeeds_with_hash_mismatch(
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Pipeline runs successfully when tracked file hash doesn't match .pvt."""
+    # Create data file with some content
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("original content")
+
+    # Track it properly via CLI to get correct hash
+    result = click.testing.CliRunner().invoke(cli.cli, ["track", "data.csv"])
+    assert result.exit_code == 0
+
+    # Now modify the data file (hash mismatch)
+    data_file.write_text("modified content that changes the hash")
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        pathlib.Path("output.txt").write_text("done")
+
+    # Should succeed (warning logged but execution continues)
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+    assert (pipeline_dir / "output.txt").exists()
+
+
+# =============================================================================
+# Dependency Change Detection Tests
+# =============================================================================
+
+
+def test_tracked_file_change_triggers_downstream_rerun(
+    pipeline_dir: pathlib.Path, runner: click.testing.CliRunner
+) -> None:
+    """Changing a tracked file triggers re-execution of dependent stages."""
+    # Create and track initial data
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("original")
+
+    result = runner.invoke(cli.cli, ["track", "data.csv"])
+    assert result.exit_code == 0
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        data = pathlib.Path("data.csv").read_text()
+        pathlib.Path("output.txt").write_text(f"processed: {data}")
+
+    # First run
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+    assert (pipeline_dir / "output.txt").read_text() == "processed: original"
+
+    # Modify tracked file and re-track
+    data_file.write_text("modified")
+    result = runner.invoke(cli.cli, ["track", "--force", "data.csv"])
+    assert result.exit_code == 0
+
+    # Second run - should re-execute due to tracked file change
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+    assert (pipeline_dir / "output.txt").read_text() == "processed: modified"
+
+
+def test_unchanged_tracked_file_allows_skip(
+    pipeline_dir: pathlib.Path, runner: click.testing.CliRunner
+) -> None:
+    """Unchanged tracked file allows stage to be skipped."""
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("content")
+
+    result = runner.invoke(cli.cli, ["track", "data.csv"])
+    assert result.exit_code == 0
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        data = pathlib.Path("data.csv").read_text()
+        pathlib.Path("output.txt").write_text(f"processed: {data}")
+
+    # First run
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+
+    # Second run - should skip (nothing changed)
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "skipped"
+
+
+# =============================================================================
+# Directory Tracking Tests
+# =============================================================================
+
+
+def test_tracked_directory_change_triggers_rerun(
+    pipeline_dir: pathlib.Path, runner: click.testing.CliRunner
+) -> None:
+    """Changing a tracked directory triggers re-execution."""
+    # Create and track directory
+    data_dir = pipeline_dir / "images"
+    data_dir.mkdir()
+    (data_dir / "a.jpg").write_bytes(b"image1")
+    (data_dir / "b.jpg").write_bytes(b"image2")
+
+    result = runner.invoke(cli.cli, ["track", "images"])
+    assert result.exit_code == 0
+
+    @pivot.stage(deps=["images"], outs=["count.txt"])
+    def count_images() -> None:
+        images = list(pathlib.Path("images").iterdir())
+        pathlib.Path("count.txt").write_text(str(len(images)))
+
+    # First run
+    results = executor.run(show_output=False)
+    assert results["count_images"]["status"] == "ran"
+    assert (pipeline_dir / "count.txt").read_text() == "2"
+
+    # Add file to directory and re-track
+    (data_dir / "c.jpg").write_bytes(b"image3")
+    result = runner.invoke(cli.cli, ["track", "--force", "images"])
+    assert result.exit_code == 0
+
+    # Second run - should re-execute
+    results = executor.run(show_output=False)
+    assert results["count_images"]["status"] == "ran"
+    assert (pipeline_dir / "count.txt").read_text() == "3"
+
+
+def test_run_fails_when_tracked_directory_missing(pipeline_dir: pathlib.Path) -> None:
+    """Pipeline fails if tracked directory is missing (with helpful error message)."""
+    pvt.write_pvt_file(
+        pipeline_dir / "images.pvt",
+        {
+            "path": "images",
+            "hash": "abc123",
+            "size": 1000,
+            "num_files": 2,
+            "manifest": [
+                {"relpath": "a.jpg", "hash": "h1", "size": 500},
+                {"relpath": "b.jpg", "hash": "h2", "size": 500},
+            ],
+        },
+    )
+
+    @pivot.stage(deps=["images"], outs=["output.txt"])
+    def process() -> None:
+        pathlib.Path("output.txt").write_text("done")
+
+    # Should fail with error message mentioning checkout
+    with pytest.raises(
+        exceptions.TrackedFileMissingError,
+        match=r"checkout|restore|missing",
+    ):
+        executor.run(show_output=False)
+
+
+# =============================================================================
+# Mixed Dependency Tests
+# =============================================================================
+
+
+def test_mixed_tracked_and_regular_dependencies(
+    pipeline_dir: pathlib.Path, runner: click.testing.CliRunner
+) -> None:
+    """Stages can depend on both tracked files and regular files."""
+    # Create tracked file
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("tracked data")
+    result = runner.invoke(cli.cli, ["track", "data.csv"])
+    assert result.exit_code == 0
+
+    # Create regular file
+    config_file = pipeline_dir / "config.txt"
+    config_file.write_text("setting=1")
+
+    @pivot.stage(deps=["data.csv", "config.txt"], outs=["output.txt"])
+    def process() -> None:
+        data = pathlib.Path("data.csv").read_text()
+        config = pathlib.Path("config.txt").read_text()
+        pathlib.Path("output.txt").write_text(f"{data}|{config}")
+
+    # First run
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+
+    # Change regular file - should trigger rerun
+    config_file.write_text("setting=2")
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+
+
+# =============================================================================
+# Checkpoint and Restore Tests
+# =============================================================================
+
+
+def test_checkout_then_run_succeeds(
+    pipeline_dir: pathlib.Path, runner: click.testing.CliRunner
+) -> None:
+    """After checkout, pipeline can run successfully."""
+    # Create, track, then delete a file
+    data_file = pipeline_dir / "data.csv"
+    data_file.write_text("important data")
+
+    result = runner.invoke(cli.cli, ["track", "data.csv"])
+    assert result.exit_code == 0
+
+    # Delete the file
+    data_file.unlink()
+    assert not data_file.exists()
+
+    # Checkout should restore it
+    result = runner.invoke(cli.cli, ["checkout", "data.csv"])
+    assert result.exit_code == 0
+    assert data_file.exists()
+
+    @pivot.stage(deps=["data.csv"], outs=["output.txt"])
+    def process() -> None:
+        data = pathlib.Path("data.csv").read_text()
+        pathlib.Path("output.txt").write_text(data.upper())
+
+    # Pipeline should run successfully
+    results = executor.run(show_output=False)
+    assert results["process"]["status"] == "ran"
+    assert (pipeline_dir / "output.txt").read_text() == "IMPORTANT DATA"

--- a/tests/test_pvt.py
+++ b/tests/test_pvt.py
@@ -1,0 +1,303 @@
+"""Tests for .pvt file handling."""
+
+import pathlib
+
+import pytest
+
+from pivot import pvt
+
+# write_pvt_file / read_pvt_file
+
+
+def test_write_read_pvt_file_roundtrip(tmp_path: pathlib.Path) -> None:
+    """PvtData can be written and read back identically."""
+    pvt_path = tmp_path / "data.csv.pvt"
+    data: pvt.PvtData = {
+        "path": "data.csv",
+        "hash": "abc123def456",
+        "size": 1024,
+    }
+
+    pvt.write_pvt_file(pvt_path, data)
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result == data
+
+
+def test_write_pvt_file_creates_parent_directories(tmp_path: pathlib.Path) -> None:
+    """write_pvt_file creates parent directories if needed."""
+    pvt_path = tmp_path / "nested" / "deep" / "data.csv.pvt"
+    data: pvt.PvtData = {"path": "data.csv", "hash": "abc123", "size": 100}
+
+    pvt.write_pvt_file(pvt_path, data)
+
+    assert pvt_path.exists()
+    assert pvt.read_pvt_file(pvt_path) == data
+
+
+def test_write_pvt_file_atomic_no_partial_on_error(tmp_path: pathlib.Path) -> None:
+    """Write failure does not leave partial .pvt file."""
+    pvt_path = tmp_path / "atomic.pvt"
+    # Write initial valid data
+    pvt.write_pvt_file(pvt_path, {"path": "x", "hash": "y", "size": 1})
+
+    # Verify no .tmp files remain
+    tmp_files = list(tmp_path.rglob("*.tmp"))
+    assert len(tmp_files) == 0, f"Temporary files remain: {tmp_files}"
+
+
+def test_pvt_file_for_directory_with_manifest(tmp_path: pathlib.Path) -> None:
+    """Directory .pvt files include manifest and num_files."""
+    pvt_path = tmp_path / "images.pvt"
+    data: pvt.PvtData = {
+        "path": "images",
+        "hash": "tree_hash_123",
+        "size": 5120,
+        "num_files": 2,
+        "manifest": [
+            {"relpath": "cat.jpg", "hash": "aaa111", "size": 2048},
+            {"relpath": "dog.jpg", "hash": "bbb222", "size": 3072, "isexec": False},
+        ],
+    }
+
+    pvt.write_pvt_file(pvt_path, data)
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result == data
+    assert result is not None
+    assert result.get("num_files") == 2
+    manifest = result.get("manifest")
+    assert manifest is not None
+    assert len(manifest) == 2
+
+
+# read_pvt_file error handling
+
+
+def test_read_pvt_file_missing_returns_none(tmp_path: pathlib.Path) -> None:
+    """Reading non-existent .pvt file returns None."""
+    pvt_path = tmp_path / "nonexistent.pvt"
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+def test_read_pvt_file_invalid_yaml_returns_none(tmp_path: pathlib.Path) -> None:
+    """Invalid YAML syntax returns None."""
+    pvt_path = tmp_path / "invalid.pvt"
+    pvt_path.write_text("path: [unclosed bracket\n")
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+def test_read_pvt_file_non_dict_returns_none(tmp_path: pathlib.Path) -> None:
+    """Non-dict YAML (list, string) returns None."""
+    pvt_path = tmp_path / "list.pvt"
+    pvt_path.write_text("- item1\n- item2\n")
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+def test_read_pvt_file_binary_garbage_returns_none(tmp_path: pathlib.Path) -> None:
+    """Binary garbage returns None."""
+    pvt_path = tmp_path / "binary.pvt"
+    pvt_path.write_bytes(b"\xff\xfe\x00\x01\x80\x81")
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+def test_read_pvt_file_empty_returns_none(tmp_path: pathlib.Path) -> None:
+    """Empty file returns None."""
+    pvt_path = tmp_path / "empty.pvt"
+    pvt_path.write_text("")
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+def test_read_pvt_file_missing_required_fields_returns_none(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Missing required fields (path, hash, size) returns None."""
+    pvt_path = tmp_path / "incomplete.pvt"
+    pvt_path.write_text("path: data.csv\n")  # Missing hash and size
+
+    result = pvt.read_pvt_file(pvt_path)
+
+    assert result is None
+
+
+# get_pvt_path
+
+
+def test_get_pvt_path_for_file() -> None:
+    """File path gets .pvt suffix appended."""
+    data_path = pathlib.Path("data/train.csv")
+
+    pvt_path = pvt.get_pvt_path(data_path)
+
+    assert pvt_path == pathlib.Path("data/train.csv.pvt")
+
+
+def test_get_pvt_path_for_directory() -> None:
+    """Directory path gets .pvt suffix (no trailing slash)."""
+    data_path = pathlib.Path("data/images")
+
+    pvt_path = pvt.get_pvt_path(data_path)
+
+    assert pvt_path == pathlib.Path("data/images.pvt")
+
+
+def test_get_pvt_path_for_directory_with_trailing_slash() -> None:
+    """Directory with trailing slash handled correctly."""
+    # pathlib normalizes this, but test explicitly
+    data_path = pathlib.Path("data/images/")
+
+    pvt_path = pvt.get_pvt_path(data_path)
+
+    assert pvt_path == pathlib.Path("data/images.pvt")
+
+
+def test_get_pvt_path_preserves_parent_directories() -> None:
+    """Parent directories preserved in .pvt path."""
+    data_path = pathlib.Path("project/data/nested/file.csv")
+
+    pvt_path = pvt.get_pvt_path(data_path)
+
+    assert pvt_path == pathlib.Path("project/data/nested/file.csv.pvt")
+
+
+# get_data_path
+
+
+def test_get_data_path_from_file_pvt() -> None:
+    """Get data path from file.csv.pvt."""
+    pvt_path = pathlib.Path("data/train.csv.pvt")
+
+    data_path = pvt.get_data_path(pvt_path)
+
+    assert data_path == pathlib.Path("data/train.csv")
+
+
+def test_get_data_path_from_directory_pvt() -> None:
+    """Get data path from directory.pvt."""
+    pvt_path = pathlib.Path("data/images.pvt")
+
+    data_path = pvt.get_data_path(pvt_path)
+
+    assert data_path == pathlib.Path("data/images")
+
+
+def test_get_data_path_invalid_suffix_raises() -> None:
+    """Non-.pvt file raises ValueError."""
+    not_pvt = pathlib.Path("data/file.txt")
+
+    with pytest.raises(ValueError, match=r"\.pvt"):
+        pvt.get_data_path(not_pvt)
+
+
+# discover_pvt_files
+
+
+def test_discover_pvt_files_finds_files(tmp_path: pathlib.Path) -> None:
+    """Discovers .pvt files in directory tree."""
+    # Create structure:
+    # tmp_path/
+    #   data.csv.pvt
+    #   subdir/
+    #     model.pkl.pvt
+    pvt.write_pvt_file(
+        tmp_path / "data.csv.pvt",
+        {"path": "data.csv", "hash": "hash1", "size": 100},
+    )
+    (tmp_path / "subdir").mkdir()
+    pvt.write_pvt_file(
+        tmp_path / "subdir" / "model.pkl.pvt",
+        {"path": "model.pkl", "hash": "hash2", "size": 200},
+    )
+
+    result = pvt.discover_pvt_files(tmp_path)
+
+    assert len(result) == 2
+    # Keys should be absolute paths to data files
+    data_csv_path = str(tmp_path / "data.csv")
+    model_pkl_path = str(tmp_path / "subdir" / "model.pkl")
+    assert data_csv_path in result
+    assert model_pkl_path in result
+    assert result[data_csv_path]["hash"] == "hash1"
+    assert result[model_pkl_path]["hash"] == "hash2"
+
+
+def test_discover_pvt_files_empty_directory(tmp_path: pathlib.Path) -> None:
+    """Empty directory returns empty dict."""
+    result = pvt.discover_pvt_files(tmp_path)
+
+    assert result == {}
+
+
+def test_discover_pvt_files_skips_invalid(tmp_path: pathlib.Path) -> None:
+    """Invalid .pvt files are skipped."""
+    # Valid file
+    pvt.write_pvt_file(
+        tmp_path / "valid.csv.pvt",
+        {"path": "valid.csv", "hash": "hash1", "size": 100},
+    )
+    # Invalid file
+    (tmp_path / "invalid.csv.pvt").write_text("not: valid: yaml: [")
+
+    result = pvt.discover_pvt_files(tmp_path)
+
+    assert len(result) == 1
+    assert str(tmp_path / "valid.csv") in result
+
+
+def test_discover_pvt_files_with_directory_manifest(tmp_path: pathlib.Path) -> None:
+    """Directory .pvt files with manifest are discovered correctly."""
+    pvt.write_pvt_file(
+        tmp_path / "images.pvt",
+        {
+            "path": "images",
+            "hash": "tree_hash",
+            "size": 5000,
+            "num_files": 3,
+            "manifest": [
+                {"relpath": "a.jpg", "hash": "h1", "size": 1000},
+                {"relpath": "b.jpg", "hash": "h2", "size": 2000},
+                {"relpath": "c.jpg", "hash": "h3", "size": 2000},
+            ],
+        },
+    )
+
+    result = pvt.discover_pvt_files(tmp_path)
+
+    assert len(result) == 1
+    images_path = str(tmp_path / "images")
+    assert images_path in result
+    assert result[images_path].get("num_files") == 3
+    manifest = result[images_path].get("manifest")
+    assert manifest is not None
+    assert len(manifest) == 3
+
+
+# Validation
+
+
+def test_write_pvt_file_rejects_path_traversal(tmp_path: pathlib.Path) -> None:
+    """Path with .. is rejected."""
+    pvt_path = tmp_path / "data.pvt"
+    data: pvt.PvtData = {
+        "path": "../../../etc/passwd",
+        "hash": "evil",
+        "size": 666,
+    }
+
+    with pytest.raises(ValueError, match=r"path traversal|\.\."):
+        pvt.write_pvt_file(pvt_path, data)


### PR DESCRIPTION
## Overview

Closes #17 

This PR improves symlink handling throughout Pivot to ensure portability across environments where symlinks may point to different locations. The implementation uses a two-layer approach: normalized paths (symlinks preserved) for storage and user-facing displays, and resolved paths (symlinks followed) for internal operations.

**Issue:**

Addresses symlink handling concerns where pipelines output to symlinked directories (e.g., `data/` → `/mnt/external/`). We need to store relative paths (`data/output.csv`) not resolved paths (`/mnt/external/output.csv`) for portability.

## Approach and Alternatives

**Approach:**
- Added `normalize_path()` utility using `.absolute()` to preserve symlinks (vs `.resolve()` which follows them)
- Added `contains_symlink_in_path()` to detect symlinks in path hierarchy
- Updated lock files to use normalized paths as keys for portability
- Added backward compatibility: lock file comparison normalizes both old and new paths
- Added user warnings when tracking files inside symlinked directories
- Documented the two-layer strategy in cache.py and state.py

**Why this approach:**
- Follows DVC's battle-tested approach (uses `abspath`/`normpath`, not `realpath`)
- Maintains portability: lock files work across environments with different symlink targets
- Preserves performance: state DB uses resolved paths for local-only caching
- Backward compatible: old lock files with resolved paths automatically normalized during comparison

**Alternatives considered:**
- Always resolve symlinks: Rejected - breaks portability when symlinks point to different locations across environments
- Always preserve symlinks in state DB: Rejected - would reduce cache hit rate when same file accessed via different symlink paths

🎯 **Review focus:** Please verify the two-layer path handling strategy makes sense for different use cases (tracked files, stage outputs, checkout command).

## Testing & Validation

- [x] Covered by automated tests
  - Added 9 new tests for path normalization utilities (`test_project_root.py`)
  - Updated 2 tests to expect normalized (absolute) paths as keys
  - All 527 existing tests still pass

- [x] Manual testing:
  \`\`\`bash
  # All quality checks pass
  ruff format .     # 3 files reformatted
  ruff check .      # All checks passed
  basedpyright .    # 0 errors, 0 warnings
  pytest tests/     # 527 passed, 19 skipped
  \`\`\`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Comments added for complex or non-obvious code (two-layer path strategy documented)
- [x] Uninformative comments removed
- [x] Documentation updated (docstrings for normalize_path, hash_directory, StateDB methods)
- [x] Tests added or updated (9 new tests, 2 updated tests)

## Additional Context

**Files changed:**
- \`src/pivot/project.py\` - Added normalize_path() and contains_symlink_in_path()
- \`src/pivot/executor.py\` - hash_dependencies() uses normalized paths as keys
- \`src/pivot/lock.py\` - is_changed() normalizes paths before comparison
- \`src/pivot/cli.py\` - Added symlink warnings, updated checkout to use normalized paths
- \`src/pivot/pvt.py\` - discover_pvt_files() returns normalized paths
- \`src/pivot/registry.py\` - _normalize_paths() uses normalized paths and warns
- \`src/pivot/cache.py\` - Documented symlink strategy
- \`src/pivot/state.py\` - Documented why resolved paths used for local cache
- \`tests/test_project_root.py\` - 9 new path normalization tests
- \`tests/test_executor_worker.py\` - Updated 2 tests for normalized path keys

**No breaking changes:** Backward compatible with existing lock files through automatic path normalization during comparison.