### PR TITLE
test: add coverage for cache=False output existence verification

### DIFF
--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -1068,6 +1068,20 @@ def test_executor_handles_cache_false_outputs(pipeline_dir: pathlib.Path) -> Non
     assert not metrics_file.is_symlink(), "Metric with cache=False should not be symlink"
 
 
+def test_executor_fails_if_cache_false_output_missing(pipeline_dir: pathlib.Path) -> None:
+    """Stage fails if cache=False output is not produced."""
+    (pipeline_dir / "input.txt").write_text("data")
+
+    @pivot.stage(deps=["input.txt"], outs=[Metric("metrics.json")])
+    def process() -> None:
+        pass  # Intentionally don't create metrics.json
+
+    results = executor.run(show_output=False)
+
+    assert results["process"]["status"] == "failed"
+    assert "metrics.json" in results["process"]["reason"]
+
+
 def test_executor_output_hashes_in_lock_file(pipeline_dir: pathlib.Path) -> None:
     """Output hashes are stored in lock file."""
     (pipeline_dir / "input.txt").write_text("data")


### PR DESCRIPTION
## Summary

- Adds `test_executor_fails_if_cache_false_output_missing()` to verify stages with `cache=False` outputs fail properly when the output is not produced

## Issue

Closes #25

## Approach

Investigation confirmed the reported bug does NOT exist - the implementation in `_save_outputs_to_cache()` already correctly verifies ALL outputs exist before any caching decisions:

```python
if not path.exists():
    raise exceptions.OutputMissingError(f"Stage did not produce output: {out.path}")
```

However, there was a gap in test coverage:
- `test_executor_fails_if_output_missing()` only tested `cache=True` outputs
- `test_executor_handles_cache_false_outputs()` only tested the success path

This PR adds the missing test to document and protect this behavior.

## Testing

- New test verifies that `Metric` outputs (cache=False by default) that are not produced cause proper stage failure
- All 666 tests pass with 90.53% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)