### PR TITLE
feat: add plots CLI commands for viewing and comparing plot outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,14 @@ authors = [{ name = "Internal Team" }]
 dependencies = [
   "click>=8.0",
   "deepmerge>=2.0",
+  "dulwich>=0.22.0",
   "lmdb>=1.4.0",
   "loky>=3.4",
   "networkx>=3.0",
   "pydantic>=2.0",
   "pygtrie>=2.5.0",
   "pyyaml>=6.0",
+  "tabulate>=0.8.0",
   "watchfiles>=1.0",
   "xxhash>=3.0",
 ]

--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -3,6 +3,7 @@ from pivot import dvc_compat as dvc_compat
 from pivot import explain as explain
 from pivot import outputs as outputs
 from pivot import parameters as parameters
+from pivot import plots as plots
 from pivot import pvt as pvt
 from pivot import state as state
 from pivot.outputs import BaseOut as BaseOut

--- a/src/pivot/cli.py
+++ b/src/pivot/cli.py
@@ -11,6 +11,7 @@ from pivot.types import OutputHash, StageExplanation, StageStatus
 
 if TYPE_CHECKING:
     from pivot.executor import ExecutionSummary
+    from pivot.types import OutputFormat
 
 logger = logging.getLogger(__name__)
 
@@ -648,6 +649,98 @@ def _setup_logging(verbose: bool) -> None:
         format="%(message)s",
         force=True,
     )
+
+
+# =============================================================================
+# Plots Commands
+# =============================================================================
+
+
+@cli.group()
+def plots() -> None:
+    """Display and compare plots."""
+
+
+@plots.command("show")
+@click.argument("targets", nargs=-1)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=pathlib.Path),
+    default="pivot_plots/index.html",
+    help="Output HTML path (default: pivot_plots/index.html)",
+)
+@click.option("--open", "open_browser", is_flag=True, help="Open browser after rendering")
+def plots_show(targets: tuple[str, ...], output: pathlib.Path, open_browser: bool) -> None:
+    """Render plots as HTML image gallery."""
+    from pivot import plots as plots_mod
+
+    try:
+        if targets:
+            # Filter to specific targets
+            all_plots = plots_mod.collect_plots_from_stages()
+            target_set = set(targets)
+            plot_list = [p for p in all_plots if p["path"] in target_set]
+        else:
+            plot_list = plots_mod.collect_plots_from_stages()
+
+        if not plot_list:
+            click.echo("No plots found.")
+            return
+
+        output_path = plots_mod.render_plots_html(plot_list, output)
+        click.echo(f"Rendered {len(plot_list)} plot(s) to {output_path}")
+
+        if open_browser:
+            import webbrowser
+
+            webbrowser.open(f"file://{output_path.resolve()}")
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
+@plots.command("diff")
+@click.argument("targets", nargs=-1)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@click.option("--md", is_flag=True, help="Output as markdown table")
+@click.option("--no-path", "no_path", is_flag=True, help="Hide path column")
+def plots_diff(targets: tuple[str, ...], json_output: bool, md: bool, no_path: bool) -> None:
+    """Show which plots changed since last commit."""
+    from pivot import plots as plots_mod
+
+    try:
+        # Get old hashes from lock files at Git HEAD
+        all_old_hashes = plots_mod.get_plot_hashes_from_head()
+
+        if not all_old_hashes:
+            click.echo("No plots found in registered stages.")
+            return
+
+        # Filter to targets if specified
+        if targets:
+            # Normalize user targets to relative paths from project root
+            proj_root = project.get_project_root()
+            target_set = {
+                project.to_relative_path(project.normalize_path(t), proj_root) for t in targets
+            }
+            old_hashes = {k: v for k, v in all_old_hashes.items() if k in target_set}
+            paths = list(target_set)
+        else:
+            old_hashes = all_old_hashes
+            paths = list(old_hashes.keys())
+
+        # Get current hashes from workspace
+        new_hashes = plots_mod.get_plot_hashes_from_workspace(paths)
+
+        # Compute diffs
+        diffs = plots_mod.diff_plots(old_hashes, new_hashes)
+
+        # Format output
+        output_format: OutputFormat = "json" if json_output else ("md" if md else None)
+        result = plots_mod.format_diff_table(diffs, output_format, show_path=not no_path)
+        click.echo(result)
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
 
 
 def main() -> None:

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -122,6 +122,12 @@ class ParamsError(PivotError):
     pass
 
 
+class PlotsError(PivotError):
+    """Raised when plot processing fails."""
+
+    pass
+
+
 class TrackedFileMissingError(CacheError):
     """Raised when a .pvt tracked file is missing (user should run pivot checkout)."""
 

--- a/src/pivot/git.py
+++ b/src/pivot/git.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import dulwich.errors
+import dulwich.object_store
+import dulwich.objects
+import dulwich.repo
+
+from pivot import project
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _find_git_root(start: pathlib.Path) -> pathlib.Path | None:
+    """Walk up to find .git directory."""
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def read_file_from_head(rel_path: str) -> bytes | None:
+    """Read file contents from HEAD commit.
+
+    Args:
+        rel_path: Path relative to project root
+
+    Returns:
+        File contents as bytes, or None if not found
+    """
+    proj_root = project.get_project_root()
+    git_root = _find_git_root(proj_root)
+
+    if git_root is None:
+        logger.debug("No git repository found")
+        return None
+
+    try:
+        repo = dulwich.repo.Repo(str(git_root))
+    except dulwich.errors.NotGitRepository:
+        logger.debug(f"Not a git repository: {git_root}")
+        return None
+
+    try:
+        head_sha = repo.head()
+    except KeyError:
+        logger.debug("No HEAD commit (empty repository?)")
+        return None
+
+    commit = repo[head_sha]
+    if not isinstance(commit, dulwich.objects.Commit):
+        logger.debug(f"HEAD is not a commit: {type(commit)}")
+        return None
+
+    # If project root is inside git root, adjust path
+    if proj_root != git_root:
+        try:
+            proj_prefix = proj_root.relative_to(git_root)
+            full_path = str(proj_prefix / rel_path)
+        except ValueError:
+            full_path = rel_path
+    else:
+        full_path = rel_path
+
+    try:
+        _mode, sha = dulwich.object_store.tree_lookup_path(
+            repo.__getitem__, commit.tree, full_path.encode()
+        )
+        blob = repo[sha]
+        if isinstance(blob, dulwich.objects.Blob):
+            return blob.data
+        return None
+    except KeyError:
+        logger.debug(f"File not found in HEAD: {full_path}")
+        return None
+
+
+def read_files_from_head(rel_paths: Sequence[str]) -> dict[str, bytes]:
+    """Read multiple files from HEAD commit efficiently.
+
+    Args:
+        rel_paths: Paths relative to project root
+
+    Returns:
+        Dict mapping path to contents for files that exist in HEAD
+    """
+    if not rel_paths:
+        return {}
+
+    proj_root = project.get_project_root()
+    git_root = _find_git_root(proj_root)
+
+    if git_root is None:
+        return {}
+
+    try:
+        repo = dulwich.repo.Repo(str(git_root))
+    except dulwich.errors.NotGitRepository:
+        return {}
+
+    try:
+        head_sha = repo.head()
+    except KeyError:
+        return {}
+
+    commit = repo[head_sha]
+    if not isinstance(commit, dulwich.objects.Commit):
+        return {}
+
+    # Calculate prefix adjustment once
+    try:
+        proj_prefix = proj_root.relative_to(git_root) if proj_root != git_root else None
+    except ValueError:
+        proj_prefix = None
+
+    result = dict[str, bytes]()
+    for rel_path in rel_paths:
+        full_path = str(proj_prefix / rel_path) if proj_prefix else rel_path
+        try:
+            _mode, sha = dulwich.object_store.tree_lookup_path(
+                repo.__getitem__, commit.tree, full_path.encode()
+            )
+            blob = repo[sha]
+            if isinstance(blob, dulwich.objects.Blob):
+                result[rel_path] = blob.data
+        except KeyError:
+            pass
+
+    return result

--- a/src/pivot/plots.py
+++ b/src/pivot/plots.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import html
+import json
+import pathlib
+from typing import TYPE_CHECKING, Any, TypedDict, cast
+
+import tabulate
+import yaml
+
+from pivot import cache, git, lock, outputs, project, yaml_config
+from pivot.types import ChangeType, OutEntry  # noqa: TC001 - runtime import for TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from pivot.types import OutputFormat
+
+
+class PlotInfo(TypedDict):
+    """Info about a registered Plot output."""
+
+    path: str
+    stage_name: str
+    x: str | None
+    y: str | None
+    template: str | None
+
+
+class PlotDiffEntry(TypedDict):
+    """Result of comparing a plot file."""
+
+    path: str
+    old_hash: str | None
+    new_hash: str | None
+    change: ChangeType
+
+
+def collect_plots_from_stages() -> list[PlotInfo]:
+    """Discover Plot outputs from registry."""
+    from pivot import registry
+
+    result = list[PlotInfo]()
+    for stage_name in registry.REGISTRY.list_stages():
+        info = registry.REGISTRY.get(stage_name)
+        for out in info["outs"]:
+            if isinstance(out, outputs.Plot):
+                result.append(
+                    PlotInfo(
+                        path=out.path,
+                        stage_name=stage_name,
+                        x=out.x,
+                        y=out.y,
+                        template=out.template,
+                    )
+                )
+    return result
+
+
+def get_plot_hashes_from_lock(
+    cache_dir: pathlib.Path | None = None,
+) -> dict[str, str | None]:
+    """Read output_hashes for plots from lock files.
+
+    Returns paths relative to project root for consistent comparison with user input.
+    """
+    from pivot import registry
+
+    if cache_dir is None:
+        cache_dir = project.get_project_root() / ".pivot" / "cache"
+
+    proj_root = project.get_project_root()
+    result = dict[str, str | None]()
+    for stage_name in registry.REGISTRY.list_stages():
+        info = registry.REGISTRY.get(stage_name)
+        stage_lock = lock.StageLock(stage_name, cache_dir)
+        lock_data = stage_lock.read()
+
+        for out in info["outs"]:
+            if isinstance(out, outputs.Plot):
+                # Normalize to absolute for lock data lookup, then convert to relative for result
+                abs_path = str(project.normalize_path(out.path))
+                rel_path = project.to_relative_path(abs_path, proj_root)
+                if lock_data and abs_path in lock_data["output_hashes"]:
+                    hash_info = lock_data["output_hashes"][abs_path]
+                    result[rel_path] = hash_info["hash"] if hash_info else None
+                else:
+                    result[rel_path] = None
+    return result
+
+
+def get_plot_hashes_from_head() -> dict[str, str | None]:
+    """Read output_hashes for plots from lock files at Git HEAD.
+
+    Returns paths relative to project root for consistent comparison with workspace.
+    Returns empty dict if not in a git repo or no HEAD commit exists.
+    """
+    from pivot import registry
+
+    result = dict[str, str | None]()
+    proj_root = project.get_project_root()
+
+    # Collect lock file paths we need to read
+    stage_plot_paths: dict[str, list[str]] = {}  # stage_name -> [rel_plot_paths]
+    for stage_name in registry.REGISTRY.list_stages():
+        info = registry.REGISTRY.get(stage_name)
+        for out in info["outs"]:
+            if isinstance(out, outputs.Plot):
+                if stage_name not in stage_plot_paths:
+                    stage_plot_paths[stage_name] = []
+                abs_path = str(project.normalize_path(out.path))
+                rel_path = project.to_relative_path(abs_path, proj_root)
+                stage_plot_paths[stage_name].append(rel_path)
+                result[rel_path] = None  # Default to None
+
+    # Read all lock files from HEAD in one batch
+    lock_paths = [f".pivot/cache/stages/{name}.lock" for name in stage_plot_paths]
+    lock_contents = git.read_files_from_head(lock_paths)
+
+    # Parse lock files and extract plot hashes
+    for stage_name, plot_paths in stage_plot_paths.items():
+        lock_path = f".pivot/cache/stages/{stage_name}.lock"
+        content = lock_contents.get(lock_path)
+        if content is None:
+            continue
+
+        try:
+            data = yaml.load(content, Loader=yaml_config.Loader)
+        except yaml.YAMLError:
+            continue
+
+        if not isinstance(data, dict) or "outs" not in data:
+            continue
+
+        # Build path->hash lookup from storage format (uses relative paths)
+        outs_raw = cast("dict[str, Any]", data)["outs"]
+        if not isinstance(outs_raw, list):
+            continue
+        outs_list = cast("list[OutEntry]", outs_raw)
+
+        path_to_hash = dict[str, str | None]()
+        for out in outs_list:
+            if "path" in out:
+                path_to_hash[out["path"]] = out["hash"]
+
+        # Match our plot paths against storage paths
+        for plot_rel_path in plot_paths:
+            if plot_rel_path in path_to_hash:
+                result[plot_rel_path] = path_to_hash[plot_rel_path]
+
+    return result
+
+
+def get_plot_hashes_from_workspace(
+    paths: Sequence[str],
+) -> dict[str, str]:
+    """Compute current file hashes for plot files.
+
+    Paths are relative to project root.
+    """
+    proj_root = project.get_project_root()
+    result = dict[str, str]()
+    for path_str in paths:
+        path = proj_root / path_str
+        if path.exists() and path.is_file():
+            result[path_str] = cache.hash_file(path)
+    return result
+
+
+def diff_plots(
+    old: Mapping[str, str | None],
+    new: Mapping[str, str],
+) -> list[PlotDiffEntry]:
+    """Compare lock file hashes vs workspace hashes."""
+    diffs = list[PlotDiffEntry]()
+    all_paths = set(old.keys()) | set(new.keys())
+
+    for path in sorted(all_paths):
+        old_hash = old.get(path)
+        new_hash = new.get(path)
+
+        # Not in old OR old_hash is None means no previous version
+        if path not in old or old_hash is None:
+            if new_hash is not None:
+                diffs.append(
+                    PlotDiffEntry(path=path, old_hash=None, new_hash=new_hash, change="added")
+                )
+        elif path not in new or new_hash is None:
+            diffs.append(
+                PlotDiffEntry(path=path, old_hash=old_hash, new_hash=None, change="removed")
+            )
+        elif old_hash != new_hash:
+            diffs.append(
+                PlotDiffEntry(path=path, old_hash=old_hash, new_hash=new_hash, change="modified")
+            )
+
+    return diffs
+
+
+def format_diff_table(
+    diffs: list[PlotDiffEntry],
+    output_format: OutputFormat,
+    show_path: bool = True,
+) -> str:
+    """Format diff output as plain text, JSON, or markdown."""
+    if output_format == "json":
+        return json.dumps(diffs, indent=2)
+
+    if not diffs:
+        return "No plot changes."
+
+    rows = list[list[str]]()
+    for diff in diffs:
+        old_str = "-" if diff["old_hash"] is None else diff["old_hash"][:8]
+        new_str = "-" if diff["new_hash"] is None else diff["new_hash"][:8]
+        row = [old_str, new_str, diff["change"]]
+        if show_path:
+            row.insert(0, diff["path"])
+        rows.append(row)
+
+    headers = ["Old", "New", "Change"]
+    if show_path:
+        headers.insert(0, "Path")
+
+    tablefmt = "github" if output_format == "md" else "plain"
+    return tabulate.tabulate(rows, headers=headers, tablefmt=tablefmt, disable_numparse=True)
+
+
+def render_plots_html(
+    plots: list[PlotInfo],
+    output_path: pathlib.Path,
+) -> pathlib.Path:
+    """Generate simple HTML image gallery."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    proj_root = project.get_project_root()
+
+    plot_divs = list[str]()
+    for plot in plots:
+        # Resolve path from project root
+        path = pathlib.Path(plot["path"])
+        if not path.is_absolute():
+            path = proj_root / path
+        if not path.exists():
+            continue
+
+        # Use relative path from output HTML to plot file
+        try:
+            rel_path = path.resolve().relative_to(output_path.parent.resolve())
+        except ValueError:
+            rel_path = path.resolve()
+
+        # Escape user-provided content to prevent XSS
+        safe_path = html.escape(plot["path"])
+        safe_stage = html.escape(plot["stage_name"])
+        safe_rel_path = html.escape(str(rel_path))
+
+        plot_divs.append(f"""  <div class="plot">
+    <h3>{safe_path}</h3>
+    <p><small>Stage: {safe_stage}</small></p>
+    <img src="{safe_rel_path}" alt="{safe_path}">
+  </div>""")
+
+    html_content = f"""<!DOCTYPE html>
+<html>
+<head>
+  <title>Pivot Plots</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; }}
+    .plot {{ margin-bottom: 30px; padding: 15px; border: 1px solid #ddd; border-radius: 8px; }}
+    .plot img {{ max-width: 100%; height: auto; }}
+    .plot h3 {{ margin: 0 0 5px 0; color: #333; }}
+    .plot p {{ margin: 0 0 10px 0; color: #666; }}
+  </style>
+</head>
+<body>
+  <h1>Pivot Plots</h1>
+  <p>{len(plot_divs)} plot(s)</p>
+{chr(10).join(plot_divs) if plot_divs else "  <p>No plots found.</p>"}
+</body>
+</html>"""
+
+    output_path.write_text(html_content)
+    return output_path

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -111,6 +111,9 @@ OutputMessage = tuple[str, str, bool] | None
 # Type alias for change detection status
 ChangeType = Literal["modified", "added", "removed"]
 
+# Type alias for CLI output format
+OutputFormat = Literal["json", "md"] | None
+
 
 class CodeChange(TypedDict):
     """Change info for a code component in the fingerprint."""

--- a/tests/cli/test_cli_plots.py
+++ b/tests/cli/test_cli_plots.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import click.testing
+import pytest
+
+from pivot import cli, lock, outputs, registry
+from pivot.types import LockData
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _setup_git_repo(tmp_path: pathlib.Path) -> None:
+    """Initialize a git repo with user config."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def runner() -> click.testing.CliRunner:
+    """Create a CLI runner for testing."""
+    return click.testing.CliRunner()
+
+
+# =============================================================================
+# plots group Tests
+# =============================================================================
+
+
+def test_plots_group_help(runner: click.testing.CliRunner) -> None:
+    """plots group should show available commands."""
+    result = runner.invoke(cli.cli, ["plots", "--help"])
+    assert result.exit_code == 0
+    assert "show" in result.output
+    assert "diff" in result.output
+
+
+def test_plots_in_main_help(runner: click.testing.CliRunner) -> None:
+    """plots command should appear in main help."""
+    result = runner.invoke(cli.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "plots" in result.output
+
+
+# =============================================================================
+# plots show Tests
+# =============================================================================
+
+
+def test_plots_show_help(runner: click.testing.CliRunner) -> None:
+    """plots show should show its help."""
+    result = runner.invoke(cli.cli, ["plots", "show", "--help"])
+    assert result.exit_code == 0
+    assert "--output" in result.output
+    assert "--open" in result.output
+
+
+def test_plots_show_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """plots show with no registered plots should report empty."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(cli.cli, ["plots", "show"])
+        assert result.exit_code == 0
+        assert "No plots found" in result.output
+
+
+def test_plots_show_creates_html(
+    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """plots show creates HTML output file."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    with runner.isolated_filesystem(temp_dir=set_project_root):
+        result = runner.invoke(cli.cli, ["plots", "show"])
+        assert result.exit_code == 0
+        assert "Rendered 1 plot(s)" in result.output
+
+
+def test_plots_show_custom_output_path(
+    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """plots show with custom output path."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    with runner.isolated_filesystem(temp_dir=set_project_root):
+        result = runner.invoke(cli.cli, ["plots", "show", "-o", "custom/output.html"])
+        assert result.exit_code == 0
+        assert "custom/output.html" in result.output
+
+
+# =============================================================================
+# plots diff Tests
+# =============================================================================
+
+
+def test_plots_diff_help(runner: click.testing.CliRunner) -> None:
+    """plots diff should show its help."""
+    result = runner.invoke(cli.cli, ["plots", "diff", "--help"])
+    assert result.exit_code == 0
+    assert "--json" in result.output
+    assert "--md" in result.output
+    assert "--no-path" in result.output
+
+
+def test_plots_diff_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """plots diff with no registered plots should report empty."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(cli.cli, ["plots", "diff"])
+        assert result.exit_code == 0
+        assert "No plots found" in result.output
+
+
+def test_plots_diff_json_format(
+    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """plots diff --json returns valid JSON."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    with runner.isolated_filesystem(temp_dir=set_project_root):
+        # Create lock file using proper API
+        cache_dir = set_project_root / ".pivot" / "cache"
+        stage_lock = lock.StageLock("test_stage", cache_dir)
+        stage_lock.write(
+            LockData(
+                code_manifest={},
+                params={},
+                dep_hashes={},
+                output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+            )
+        )
+
+        # Commit lock file to git
+        subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=set_project_root,
+            check=True,
+            capture_output=True,
+        )
+
+        result = runner.invoke(cli.cli, ["plots", "diff", "--json"])
+        assert result.exit_code == 0
+        # Output should be valid JSON
+        try:
+            parsed = json.loads(result.output)
+            assert isinstance(parsed, list)
+        except json.JSONDecodeError:
+            pytest.fail(f"Output is not valid JSON: {result.output}")
+
+
+def test_plots_diff_md_format(
+    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """plots diff --md returns markdown table."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    with runner.isolated_filesystem(temp_dir=set_project_root):
+        cache_dir = set_project_root / ".pivot" / "cache"
+        stage_lock = lock.StageLock("test_stage", cache_dir)
+        stage_lock.write(
+            LockData(
+                code_manifest={},
+                params={},
+                dep_hashes={},
+                output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+            )
+        )
+
+        # Commit lock file to git
+        subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=set_project_root,
+            check=True,
+            capture_output=True,
+        )
+
+        result = runner.invoke(cli.cli, ["plots", "diff", "--md"])
+        assert result.exit_code == 0
+        assert "|" in result.output  # Markdown table uses pipes
+
+
+def test_plots_diff_no_path_flag(
+    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """plots diff --no-path hides path column."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    with runner.isolated_filesystem(temp_dir=set_project_root):
+        cache_dir = set_project_root / ".pivot" / "cache"
+        stage_lock = lock.StageLock("test_stage", cache_dir)
+        stage_lock.write(
+            LockData(
+                code_manifest={},
+                params={},
+                dep_hashes={},
+                output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+            )
+        )
+
+        # Commit lock file to git
+        subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=set_project_root,
+            check=True,
+            capture_output=True,
+        )
+
+        result = runner.invoke(cli.cli, ["plots", "diff", "--no-path"])
+        assert result.exit_code == 0
+        assert "Path" not in result.output

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from pivot import git, project
+
+if TYPE_CHECKING:
+    import pathlib
+
+    import pytest
+
+
+# =============================================================================
+# read_file_from_head Tests
+# =============================================================================
+
+
+def test_read_file_from_head_no_git_repo(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns None when not in a git repo."""
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("somefile.txt")
+
+    assert result is None
+
+
+def test_read_file_from_head_file_not_in_head(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns None when file doesn't exist in HEAD."""
+    # Create a git repo with initial commit
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True
+    )
+    (tmp_path / "other.txt").write_text("content")
+    subprocess.run(["git", "add", "other.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("nonexistent.txt")
+
+    assert result is None
+
+
+def test_read_file_from_head_returns_content(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns file content from HEAD."""
+    # Create a git repo with committed file
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True
+    )
+    (tmp_path / "file.txt").write_text("committed content")
+    subprocess.run(["git", "add", "file.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("file.txt")
+
+    assert result == b"committed content"
+
+
+def test_read_file_from_head_uncommitted_changes_not_visible(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns committed content, not uncommitted changes."""
+    # Create a git repo with committed file
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True
+    )
+    (tmp_path / "file.txt").write_text("original content")
+    subprocess.run(["git", "add", "file.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    # Modify file but don't commit
+    (tmp_path / "file.txt").write_text("modified content")
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("file.txt")
+
+    assert result == b"original content"
+
+
+def test_read_file_from_head_subdirectory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Can read files in subdirectories."""
+    # Create a git repo with file in subdirectory
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True
+    )
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "nested.txt").write_text("nested content")
+    subprocess.run(
+        ["git", "add", "subdir/nested.txt"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("subdir/nested.txt")
+
+    assert result == b"nested content"
+
+
+def test_read_file_from_head_empty_repo(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns None for empty repo (no commits)."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_file_from_head("file.txt")
+
+    assert result is None
+
+
+# =============================================================================
+# read_files_from_head Tests
+# =============================================================================
+
+
+def test_read_files_from_head_empty_list(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns empty dict for empty path list."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_files_from_head([])
+
+    assert result == {}
+
+
+def test_read_files_from_head_multiple_files(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns content for multiple files."""
+    # Create a git repo with multiple files
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, capture_output=True
+    )
+    (tmp_path / "file1.txt").write_text("content1")
+    (tmp_path / "file2.txt").write_text("content2")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_files_from_head(["file1.txt", "file2.txt", "missing.txt"])
+
+    assert result == {"file1.txt": b"content1", "file2.txt": b"content2"}
+
+
+def test_read_files_from_head_no_git_repo(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns empty dict when not in a git repo."""
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = git.read_files_from_head(["file.txt"])
+
+    assert result == {}

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,633 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+from pivot import lock, outputs, plots, registry
+from pivot.types import LockData
+
+if TYPE_CHECKING:
+    import pathlib
+
+# =============================================================================
+# collect_plots_from_stages Tests
+# =============================================================================
+
+
+def test_collect_plots_from_stages_empty(clean_registry: None) -> None:
+    """Empty registry returns empty list."""
+    result = plots.collect_plots_from_stages()
+
+    assert result == []
+
+
+def test_collect_plots_from_stages_finds_plots(set_project_root: pathlib.Path) -> None:
+    """Finds Plot outputs from registered stages."""
+    plot_path = set_project_root / "plot.png"
+    plot_path.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="my_stage",
+        outs=[outputs.Plot(path=str(plot_path), x="epoch", y="loss")],
+    )
+
+    result = plots.collect_plots_from_stages()
+
+    assert len(result) == 1
+    assert result[0]["stage_name"] == "my_stage"
+    assert result[0]["x"] == "epoch"
+    assert result[0]["y"] == "loss"
+
+
+def test_collect_plots_from_stages_ignores_non_plots(set_project_root: pathlib.Path) -> None:
+    """Ignores Out and Metric outputs, only returns Plot outputs."""
+    out_file = set_project_root / "output.txt"
+    metric_file = set_project_root / "metrics.json"
+    plot_file = set_project_root / "chart.png"
+    out_file.write_text("data")
+    metric_file.write_text("{}")
+    plot_file.write_bytes(b"png")
+
+    def _stage_with_mixed_outputs() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_mixed_outputs,
+        name="mixed_stage",
+        outs=[
+            outputs.Out(path=str(out_file)),
+            outputs.Metric(path=str(metric_file)),
+            outputs.Plot(path=str(plot_file)),
+        ],
+    )
+
+    result = plots.collect_plots_from_stages()
+
+    assert len(result) == 1
+    assert result[0]["path"] == str(plot_file)
+
+
+# =============================================================================
+# get_plot_hashes_from_lock Tests
+# =============================================================================
+
+
+def test_get_plot_hashes_from_lock_no_lock_file(set_project_root: pathlib.Path) -> None:
+    """Returns None for plots without lock files."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    result = plots.get_plot_hashes_from_lock()
+
+    # Result keys are relative to project root
+    assert "plot.png" in result
+    assert result["plot.png"] is None
+
+
+def test_get_plot_hashes_from_lock_with_hash(set_project_root: pathlib.Path) -> None:
+    """Returns hash from lock file."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    # Create lock file with hash
+    cache_dir = set_project_root / ".pivot" / "cache"
+    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stage_lock.write(
+        LockData(
+            code_manifest={},
+            params={},
+            dep_hashes={},
+            output_hashes={str(plot_file): {"hash": "abc123def456"}},
+        )
+    )
+
+    result = plots.get_plot_hashes_from_lock()
+
+    # Result keys are relative to project root
+    assert result["plot.png"] == "abc123def456"
+
+
+def test_get_plot_hashes_from_lock_with_none_hash(set_project_root: pathlib.Path) -> None:
+    """Returns None for plots with null hash in lock file."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    # Create lock file with None hash (uncached output)
+    cache_dir = set_project_root / ".pivot" / "cache"
+    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stage_lock.write(
+        LockData(
+            code_manifest={},
+            params={},
+            dep_hashes={},
+            output_hashes={str(plot_file): None},
+        )
+    )
+
+    result = plots.get_plot_hashes_from_lock()
+
+    # Result keys are relative to project root
+    assert result["plot.png"] is None
+
+
+# =============================================================================
+# get_plot_hashes_from_head Tests
+# =============================================================================
+
+
+def _setup_git_repo(tmp_path: pathlib.Path) -> None:
+    """Initialize a git repo with user config."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_get_plot_hashes_from_head_no_git_repo(set_project_root: pathlib.Path) -> None:
+    """Returns empty dict when not in a git repo."""
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    result = plots.get_plot_hashes_from_head()
+
+    # No git repo, so all plots have None hash
+    assert "plot.png" in result
+    assert result["plot.png"] is None
+
+
+def test_get_plot_hashes_from_head_returns_committed_hash(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Returns hash from lock file committed to HEAD."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    # Create and commit lock file with hash
+    cache_dir = set_project_root / ".pivot" / "cache"
+    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stage_lock.write(
+        LockData(
+            code_manifest={},
+            params={},
+            dep_hashes={},
+            output_hashes={str(plot_file): {"hash": "committed_hash_123"}},
+        )
+    )
+
+    subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=set_project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    result = plots.get_plot_hashes_from_head()
+
+    assert result["plot.png"] == "committed_hash_123"
+
+
+def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Returns committed hash, not uncommitted changes."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    # Create and commit lock file with original hash
+    cache_dir = set_project_root / ".pivot" / "cache"
+    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stage_lock.write(
+        LockData(
+            code_manifest={},
+            params={},
+            dep_hashes={},
+            output_hashes={str(plot_file): {"hash": "original_hash"}},
+        )
+    )
+
+    subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=set_project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    # Update lock file but don't commit
+    stage_lock.write(
+        LockData(
+            code_manifest={},
+            params={},
+            dep_hashes={},
+            output_hashes={str(plot_file): {"hash": "modified_hash"}},
+        )
+    )
+
+    result = plots.get_plot_hashes_from_head()
+
+    assert result["plot.png"] == "original_hash", "Should return committed hash, not modified"
+
+
+def test_get_plot_hashes_from_head_no_lock_in_head(set_project_root: pathlib.Path) -> None:
+    """Returns None for plots with no lock file in HEAD."""
+    _setup_git_repo(set_project_root)
+
+    plot_file = set_project_root / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    # Create initial commit with something else
+    (set_project_root / "readme.txt").write_text("readme")
+    subprocess.run(["git", "add", "."], cwd=set_project_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=set_project_root,
+        check=True,
+        capture_output=True,
+    )
+
+    def _stage_with_plot() -> None:
+        pass
+
+    registry.REGISTRY.register(
+        _stage_with_plot,
+        name="test_stage",
+        outs=[outputs.Plot(path=str(plot_file))],
+    )
+
+    result = plots.get_plot_hashes_from_head()
+
+    assert "plot.png" in result
+    assert result["plot.png"] is None
+
+
+# =============================================================================
+# get_plot_hashes_from_workspace Tests
+# =============================================================================
+
+
+def test_get_plot_hashes_from_workspace_existing_file(tmp_path: pathlib.Path) -> None:
+    """Computes hash for existing files."""
+    plot_file = tmp_path / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    result = plots.get_plot_hashes_from_workspace([str(plot_file)])
+
+    assert str(plot_file) in result
+    assert len(result[str(plot_file)]) == 16  # xxhash64 hex length
+
+
+def test_get_plot_hashes_from_workspace_missing_file(tmp_path: pathlib.Path) -> None:
+    """Missing files are not included in result."""
+    missing_path = str(tmp_path / "nonexistent.png")
+
+    result = plots.get_plot_hashes_from_workspace([missing_path])
+
+    assert missing_path not in result
+
+
+def test_get_plot_hashes_from_workspace_multiple_files(tmp_path: pathlib.Path) -> None:
+    """Handles multiple files."""
+    file1 = tmp_path / "plot1.png"
+    file2 = tmp_path / "plot2.png"
+    file1.write_bytes(b"data1")
+    file2.write_bytes(b"data2")
+
+    result = plots.get_plot_hashes_from_workspace([str(file1), str(file2)])
+
+    assert len(result) == 2
+    assert result[str(file1)] != result[str(file2)]
+
+
+# =============================================================================
+# diff_plots Tests
+# =============================================================================
+
+
+def test_diff_plots_no_changes() -> None:
+    """No changes when hashes match."""
+    old = {"plot.png": "abc123"}
+    new = {"plot.png": "abc123"}
+
+    result = plots.diff_plots(old, new)
+
+    assert result == []
+
+
+def test_diff_plots_modified() -> None:
+    """Detects modified files (different hashes)."""
+    old = {"plot.png": "abc123"}
+    new = {"plot.png": "def456"}
+
+    result = plots.diff_plots(old, new)
+
+    assert len(result) == 1
+    assert result[0]["path"] == "plot.png"
+    assert result[0]["old_hash"] == "abc123"
+    assert result[0]["new_hash"] == "def456"
+    assert result[0]["change"] == "modified"
+
+
+def test_diff_plots_added() -> None:
+    """Detects added files (in new but not old)."""
+    old: dict[str, str | None] = {}
+    new = {"plot.png": "abc123"}
+
+    result = plots.diff_plots(old, new)
+
+    assert len(result) == 1
+    assert result[0]["path"] == "plot.png"
+    assert result[0]["old_hash"] is None
+    assert result[0]["new_hash"] == "abc123"
+    assert result[0]["change"] == "added"
+
+
+def test_diff_plots_added_from_none_hash() -> None:
+    """Detects added when old hash is None (uncached output)."""
+    old: dict[str, str | None] = {"plot.png": None}
+    new = {"plot.png": "abc123"}
+
+    result = plots.diff_plots(old, new)
+
+    assert len(result) == 1
+    assert result[0]["path"] == "plot.png"
+    assert result[0]["old_hash"] is None
+    assert result[0]["new_hash"] == "abc123"
+    assert result[0]["change"] == "added", "Should report 'added' when old hash is None"
+
+
+def test_diff_plots_removed() -> None:
+    """Detects removed files (in old but not new)."""
+    old = {"plot.png": "abc123"}
+    new: dict[str, str] = {}
+
+    result = plots.diff_plots(old, new)
+
+    assert len(result) == 1
+    assert result[0]["path"] == "plot.png"
+    assert result[0]["old_hash"] == "abc123"
+    assert result[0]["new_hash"] is None
+    assert result[0]["change"] == "removed"
+
+
+def test_diff_plots_multiple_changes() -> None:
+    """Handles multiple changes (modified, added, removed)."""
+    old = {"a.png": "hash_a", "b.png": "hash_b"}
+    new = {"a.png": "hash_a_modified", "c.png": "hash_c"}
+
+    result = plots.diff_plots(old, new)
+
+    assert len(result) == 3
+    paths = {r["path"]: r for r in result}
+
+    assert paths["a.png"]["change"] == "modified"
+    assert paths["b.png"]["change"] == "removed"
+    assert paths["c.png"]["change"] == "added"
+
+
+def test_diff_plots_sorted_by_path() -> None:
+    """Results are sorted by path."""
+    old = {"z.png": "1", "a.png": "2", "m.png": "3"}
+    new = {"z.png": "x", "a.png": "y", "m.png": "z"}
+
+    result = plots.diff_plots(old, new)
+
+    assert [r["path"] for r in result] == ["a.png", "m.png", "z.png"]
+
+
+# =============================================================================
+# format_diff_table Tests
+# =============================================================================
+
+
+def test_format_diff_table_empty() -> None:
+    """Empty diffs returns 'No plot changes.'"""
+    result = plots.format_diff_table([], None)
+
+    assert result == "No plot changes."
+
+
+def test_format_diff_table_plain() -> None:
+    """Plain text format uses tabulate."""
+    diffs = [
+        plots.PlotDiffEntry(
+            path="plot.png", old_hash="abc123", new_hash="def456", change="modified"
+        )
+    ]
+
+    result = plots.format_diff_table(diffs, None)
+
+    assert "plot.png" in result
+    assert "abc123"[:8] in result  # Truncated hash
+    assert "modified" in result
+
+
+def test_format_diff_table_json() -> None:
+    """JSON format returns valid JSON."""
+    diffs = [
+        plots.PlotDiffEntry(
+            path="plot.png", old_hash="abc123", new_hash="def456", change="modified"
+        )
+    ]
+
+    result = plots.format_diff_table(diffs, "json")
+
+    parsed = json.loads(result)
+    assert len(parsed) == 1
+    assert parsed[0]["path"] == "plot.png"
+    assert parsed[0]["change"] == "modified"
+
+
+def test_format_diff_table_markdown() -> None:
+    """Markdown format uses github tablefmt."""
+    diffs = [
+        plots.PlotDiffEntry(
+            path="plot.png", old_hash="abc123", new_hash="def456", change="modified"
+        )
+    ]
+
+    result = plots.format_diff_table(diffs, "md")
+
+    assert "|" in result
+    assert "---" in result
+
+
+def test_format_diff_table_no_path() -> None:
+    """show_path=False hides path column."""
+    diffs = [
+        plots.PlotDiffEntry(
+            path="plot.png", old_hash="abc123", new_hash="def456", change="modified"
+        )
+    ]
+
+    result = plots.format_diff_table(diffs, None, show_path=False)
+
+    assert "Path" not in result
+
+
+# =============================================================================
+# render_plots_html Tests
+# =============================================================================
+
+
+def test_render_plots_html_creates_file(tmp_path: pathlib.Path) -> None:
+    """Creates HTML output file."""
+    plot_file = tmp_path / "plot.png"
+    plot_file.write_bytes(b"fake png data")
+
+    plot_info = plots.PlotInfo(
+        path=str(plot_file),
+        stage_name="test_stage",
+        x=None,
+        y=None,
+        template=None,
+    )
+    output_path = tmp_path / "output" / "index.html"
+
+    result = plots.render_plots_html([plot_info], output_path)
+
+    assert result.exists()
+    content = result.read_text()
+    assert "<title>Pivot Plots</title>" in content
+    assert "test_stage" in content
+
+
+def test_render_plots_html_empty_list(tmp_path: pathlib.Path) -> None:
+    """Handles empty plot list."""
+    output_path = tmp_path / "index.html"
+
+    result = plots.render_plots_html([], output_path)
+
+    assert result.exists()
+    content = result.read_text()
+    assert "No plots found." in content
+
+
+def test_render_plots_html_skips_missing_files(tmp_path: pathlib.Path) -> None:
+    """Skips plots whose files don't exist."""
+    plot_info = plots.PlotInfo(
+        path=str(tmp_path / "nonexistent.png"),
+        stage_name="test_stage",
+        x=None,
+        y=None,
+        template=None,
+    )
+    output_path = tmp_path / "index.html"
+
+    result = plots.render_plots_html([plot_info], output_path)
+
+    content = result.read_text()
+    assert "0 plot(s)" in content
+
+
+def test_render_plots_html_creates_parent_dirs(tmp_path: pathlib.Path) -> None:
+    """Creates parent directories if they don't exist."""
+    plot_file = tmp_path / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    plot_info = plots.PlotInfo(
+        path=str(plot_file),
+        stage_name="test",
+        x=None,
+        y=None,
+        template=None,
+    )
+    output_path = tmp_path / "deep" / "nested" / "index.html"
+
+    result = plots.render_plots_html([plot_info], output_path)
+
+    assert result.exists()
+    assert result.parent.exists()
+
+
+def test_render_plots_html_escapes_xss(tmp_path: pathlib.Path) -> None:
+    """Escapes HTML special characters to prevent XSS."""
+    plot_file = tmp_path / "plot.png"
+    plot_file.write_bytes(b"data")
+
+    plot_info = plots.PlotInfo(
+        path=str(plot_file),
+        stage_name="<script>alert('xss')</script>",
+        x=None,
+        y=None,
+        template=None,
+    )
+    output_path = tmp_path / "index.html"
+
+    result = plots.render_plots_html([plot_info], output_path)
+
+    content = result.read_text()
+    assert "<script>" not in content, "Script tags should be escaped"
+    assert "&lt;script&gt;" in content, "HTML entities should be used"

--- a/uv.lock
+++ b/uv.lock
@@ -1016,12 +1016,14 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "deepmerge" },
+    { name = "dulwich" },
     { name = "lmdb" },
     { name = "loky" },
     { name = "networkx" },
     { name = "pydantic" },
     { name = "pygtrie" },
     { name = "pyyaml" },
+    { name = "tabulate" },
     { name = "watchfiles" },
     { name = "xxhash" },
 ]
@@ -1047,6 +1049,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "deepmerge", specifier = ">=2.0" },
+    { name = "dulwich", specifier = ">=0.22.0" },
     { name = "dvc", marker = "extra == 'dvc'", specifier = ">=3.0" },
     { name = "lmdb", specifier = ">=1.4.0" },
     { name = "loky", specifier = ">=3.4" },
@@ -1054,6 +1057,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygtrie", specifier = ">=2.5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "tabulate", specifier = ">=0.8.0" },
     { name = "watchfiles", specifier = ">=1.0" },
     { name = "xxhash", specifier = ">=3.0" },
 ]


### PR DESCRIPTION
## Summary
- Adds `pivot plots show` command to render HTML image gallery from registered Plot outputs
- Adds `pivot plots diff` command to compare lock file hashes vs workspace to detect changes
- Supports `--json`, `--md`, and `--no-path` output options for diff
- Includes XSS prevention in HTML output via `html.escape()`

Closes #51

## Test plan
- [x] Unit tests for all plots.py functions (25 tests)
- [x] CLI integration tests for both commands (11 tests)
- [x] All 765 existing tests pass
- [x] Type checking with basedpyright
- [x] Linting with ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)