### PR TITLE
feat: add project-level cache checkout mode configuration (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,11 @@ basedpyright .         # Type check
 - Must run all four: `ruff format .`, `ruff check .`, `basedpyright .`, `pytest tests/ -n auto`
 - Never say "done" without running these first.
 
+## Before Pushing to Git (Critical)
+
+- ALWAYS run all quality checks before `jj git push`: `uv run ruff format . && uv run ruff check . && uv run basedpyright . && uv run pytest tests/ -n auto`
+- CI will fail if checks don't pass locally.
+
 ## After Completing a Feature
 
 - Update the **Development Roadmap** in `README.md` to reflect completed work

--- a/src/pivot/config.py
+++ b/src/pivot/config.py
@@ -1,0 +1,122 @@
+import logging
+import pathlib
+from typing import Any, TypedDict, cast
+
+import yaml
+
+from pivot import project, yaml_config
+
+logger = logging.getLogger(__name__)
+
+# Default fallback order when no config or config missing checkout_mode
+DEFAULT_CHECKOUT_MODE_ORDER = ["hardlink", "symlink", "copy"]
+
+_config_cache: "PivotConfig | None" = None
+
+
+class CacheConfig(TypedDict, total=False):
+    """Cache configuration options."""
+
+    checkout_mode: list[str]
+
+
+class PivotConfig(TypedDict, total=False):
+    """Top-level project configuration."""
+
+    cache: CacheConfig
+
+
+def load_config(path: pathlib.Path | None = None) -> PivotConfig:
+    """Load and cache .pivot/config.yaml from project root."""
+    global _config_cache
+
+    if _config_cache is not None:
+        return _config_cache
+
+    if path is None:
+        path = project.get_project_root() / ".pivot" / "config.yaml"
+
+    if not path.exists():
+        logger.debug(f"Config file not found: {path}")
+        _config_cache = PivotConfig()
+        return _config_cache
+
+    try:
+        with path.open() as f:
+            data = yaml.load(f, Loader=yaml_config.Loader)
+    except yaml.YAMLError as e:
+        logger.warning(f"Invalid YAML in config file {path}: {e}")
+        _config_cache = PivotConfig()
+        return _config_cache
+
+    if data is None:
+        _config_cache = PivotConfig()
+        return _config_cache
+
+    if not isinstance(data, dict):
+        logger.warning(f"Config file {path} must be a mapping, got {type(data).__name__}")
+        _config_cache = PivotConfig()
+        return _config_cache
+
+    # YAML parsing produces unknown structure, cast after isinstance validation
+    _config_cache = _parse_config(cast("dict[str, Any]", data))
+    logger.debug(f"Loaded config from {path}: {_config_cache}")
+    return _config_cache
+
+
+def _parse_config(data: dict[str, Any]) -> PivotConfig:
+    """Parse raw YAML data into typed config."""
+    config = PivotConfig()
+
+    cache_data = data.get("cache")
+    if cache_data is not None:
+        if not isinstance(cache_data, dict):
+            logger.warning(f"'cache' must be a mapping, got {type(cache_data).__name__}")
+        else:
+            cache_config = CacheConfig()
+            cache_dict = cast("dict[str, Any]", cache_data)
+            checkout_mode = cache_dict.get("checkout_mode")
+            if checkout_mode is not None:
+                if isinstance(checkout_mode, list):
+                    cache_config["checkout_mode"] = [
+                        str(m) for m in cast("list[Any]", checkout_mode)
+                    ]
+                else:
+                    logger.warning(
+                        f"'cache.checkout_mode' must be a list, got {type(checkout_mode).__name__}"
+                    )
+            if cache_config:
+                config["cache"] = cache_config
+
+    return config
+
+
+def get_checkout_mode_order(config: PivotConfig | None = None) -> list[str]:
+    """Get checkout mode fallback order from config or default."""
+    from pivot import cache
+
+    if config is None:
+        config = load_config()
+
+    cache_config = config.get("cache")
+    if cache_config is None:
+        return DEFAULT_CHECKOUT_MODE_ORDER.copy()
+
+    checkout_modes = cache_config.get("checkout_mode")
+    if checkout_modes is None:
+        return DEFAULT_CHECKOUT_MODE_ORDER.copy()
+
+    # Validate each mode against CheckoutMode enum
+    valid_modes = list[str]()
+    for mode in checkout_modes:
+        try:
+            cache.CheckoutMode(mode)
+            valid_modes.append(mode)
+        except ValueError:
+            logger.warning(f"Invalid checkout mode '{mode}' in config, skipping")
+
+    if not valid_modes:
+        logger.warning("No valid checkout modes in config, using defaults")
+        return DEFAULT_CHECKOUT_MODE_ORDER.copy()
+
+    return valid_modes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pivot import console, project
+from pivot import config, console, project
 from pivot.registry import REGISTRY
 
 if TYPE_CHECKING:
@@ -45,6 +45,7 @@ def reset_pivot_state(mocker: MockerFixture) -> Generator[None]:
     CliRunner can leave console singleton pointing to closed streams,
     and project root cache pointing to old directories.
     """
+    mocker.patch.object(config, "_config_cache", None)
     mocker.patch.object(console, "_console", None)
     mocker.patch.object(project, "_project_root_cache", None)
     for name in _PIVOT_LOGGERS:

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -993,9 +993,9 @@ def test_executor_saves_outputs_to_cache(pipeline_dir: pathlib.Path) -> None:
 
     assert results["process"]["status"] == "ran"
 
-    # Output should now be a symlink to cache
+    # Output should exist with correct content (linked to cache via hardlink/symlink/copy)
     output_file = pipeline_dir / "output.txt"
-    assert output_file.is_symlink(), "Output should be symlink to cache"
+    assert output_file.exists(), "Output should exist"
     assert output_file.read_text() == "result"
 
     # Cache should contain the file

--- a/tests/execution/test_executor_worker.py
+++ b/tests/execution/test_executor_worker.py
@@ -49,6 +49,7 @@ def test_execute_stage_with_missing_deps(worker_env: pathlib.Path) -> None:
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result = executor.execute_stage(
@@ -82,6 +83,7 @@ def test_execute_stage_with_directory_dep(worker_env: pathlib.Path, tmp_path: pa
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result = executor.execute_stage(
@@ -114,6 +116,7 @@ def test_execute_stage_runs_unchanged_stage(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     # First run - creates lock file
@@ -158,6 +161,7 @@ def test_execute_stage_reruns_when_fingerprint_changes(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     # First run
@@ -205,6 +209,7 @@ def test_execute_stage_handles_stage_exception(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result = executor.execute_stage(
@@ -235,6 +240,7 @@ def test_execute_stage_handles_sys_exit(worker_env: pathlib.Path, tmp_path: path
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result = executor.execute_stage(
@@ -268,6 +274,7 @@ def test_execute_stage_handles_keyboard_interrupt(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result = executor.execute_stage(
@@ -1009,6 +1016,7 @@ def test_generation_skip_on_second_run(worker_env: pathlib.Path, tmp_path: pathl
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     # First run - creates output and records generations
@@ -1062,6 +1070,7 @@ def test_generation_mismatch_triggers_rerun(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     step2_info: WorkerStageInfo = {
@@ -1074,6 +1083,7 @@ def test_generation_mismatch_triggers_rerun(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     # First run - both stages execute
@@ -1153,6 +1163,7 @@ def test_external_file_fallback_to_hash_check(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     # First run
@@ -1215,6 +1226,7 @@ def test_deps_list_change_triggers_rerun(worker_env: pathlib.Path, tmp_path: pat
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result1 = executor.execute_stage(
@@ -1246,6 +1258,7 @@ def test_deps_list_change_triggers_rerun(worker_env: pathlib.Path, tmp_path: pat
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result3 = executor.execute_stage(
@@ -1284,6 +1297,7 @@ def test_deps_list_change_same_fingerprint_detected_by_hash(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result1 = executor.execute_stage(
@@ -1306,6 +1320,7 @@ def test_deps_list_change_same_fingerprint_detected_by_hash(
         "variant": None,
         "overrides": {},
         "cwd": None,
+        "checkout_modes": ["hardlink", "symlink", "copy"],
     }
 
     result2 = executor.execute_stage(

--- a/tests/storage/test_incremental_out.py
+++ b/tests/storage/test_incremental_out.py
@@ -359,7 +359,7 @@ def test_executable_bit_restored_with_copy_mode(tmp_path: pathlib.Path) -> None:
 
     # Delete and restore with COPY mode
     cache.remove_output(test_dir)
-    cache.restore_from_cache(test_dir, output_hash, cache_dir, cache.LinkMode.COPY)
+    cache.restore_from_cache(test_dir, output_hash, cache_dir, cache.CheckoutMode.COPY)
 
     # Check executable bit is restored
     restored_exec = test_dir / "script.sh"

--- a/tests/test_cli_checkout.py
+++ b/tests/test_cli_checkout.py
@@ -161,8 +161,10 @@ def test_checkout_all_restores_everything(
         REGISTRY.clear()
 
 
-def test_checkout_with_link_option(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
-    """Checkout respects --link option."""
+def test_checkout_with_checkout_mode_option(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Checkout respects --checkout-mode option."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
         project._project_root_cache = None
@@ -175,13 +177,13 @@ def test_checkout_with_link_option(runner: click.testing.CliRunner, tmp_path: pa
         pathlib.Path("data.csv").unlink()
 
         # Checkout with copy mode
-        result = runner.invoke(cli.cli, ["checkout", "--link", "copy", "data.csv"])
+        result = runner.invoke(cli.cli, ["checkout", "--checkout-mode", "copy", "data.csv"])
         assert result.exit_code == 0
 
         # File should exist and be a regular file (not symlink)
         data_file = pathlib.Path("data.csv")
         assert data_file.exists()
-        assert not data_file.is_symlink(), "With --link=copy, should not be symlink"
+        assert not data_file.is_symlink(), "With --checkout-mode=copy, should not be symlink"
 
 
 def test_checkout_with_symlink_mode(
@@ -197,13 +199,13 @@ def test_checkout_with_symlink_mode(
 
         pathlib.Path("data.csv").unlink()
 
-        result = runner.invoke(cli.cli, ["checkout", "--link", "symlink", "data.csv"])
+        result = runner.invoke(cli.cli, ["checkout", "--checkout-mode", "symlink", "data.csv"])
         assert result.exit_code == 0
 
         data_file = pathlib.Path("data.csv")
         assert data_file.exists()
         # With symlink mode, file should be a symlink
-        assert data_file.is_symlink(), "With --link=symlink, should be symlink"
+        assert data_file.is_symlink(), "With --checkout-mode=symlink, should be symlink"
 
 
 # =============================================================================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,201 @@
+import pathlib
+
+import pytest
+
+from pivot import config
+
+# --- load_config tests ---
+
+
+def test_load_config_missing_file_returns_empty(tmp_path: pathlib.Path) -> None:
+    result = config.load_config(tmp_path / "nonexistent.yaml")
+    assert result == config.PivotConfig()
+
+
+def test_load_config_parses_checkout_mode(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode:\n    - symlink\n    - copy\n")
+
+    result = config.load_config(config_file)
+
+    assert "cache" in result
+    assert "checkout_mode" in result["cache"]
+    assert result["cache"]["checkout_mode"] == ["symlink", "copy"]
+
+
+def test_load_config_empty_file_returns_empty(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("")
+
+    result = config.load_config(config_file)
+
+    assert result == config.PivotConfig()
+
+
+def test_load_config_invalid_yaml_returns_empty(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("invalid: yaml: content: [")
+
+    result = config.load_config(config_file)
+
+    assert result == config.PivotConfig()
+
+
+def test_load_config_non_dict_returns_empty(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("- just a list")
+
+    result = config.load_config(config_file)
+
+    assert result == config.PivotConfig()
+
+
+def test_load_config_cache_non_dict_ignored(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("cache: not_a_dict")
+
+    result = config.load_config(config_file)
+
+    assert "cache" not in result
+
+
+def test_load_config_checkout_mode_non_list_ignored(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode: symlink\n")
+
+    result = config.load_config(config_file)
+
+    assert "cache" not in result
+
+
+def test_load_config_cached_per_process(tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode:\n    - hardlink\n")
+
+    first = config.load_config(config_file)
+
+    # Modify file - should not affect cached result
+    config_file.write_text("cache:\n  checkout_mode:\n    - copy\n")
+
+    second = config.load_config(config_file)
+
+    assert first is second, "Should return same cached instance"
+    assert "cache" in first
+    assert "checkout_mode" in first["cache"]
+    assert first["cache"]["checkout_mode"] == ["hardlink"]
+
+
+def test_load_config_uses_project_root(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pivot import project
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".pivot").mkdir()
+    config_file = tmp_path / ".pivot" / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode:\n    - copy\n")
+
+    result = config.load_config()
+
+    assert "cache" in result
+    assert "checkout_mode" in result["cache"]
+    assert result["cache"]["checkout_mode"] == ["copy"]
+
+
+# --- get_checkout_mode_order tests ---
+
+
+def test_get_checkout_mode_order_default() -> None:
+    empty_config = config.PivotConfig()
+
+    result = config.get_checkout_mode_order(empty_config)
+
+    assert result == ["hardlink", "symlink", "copy"]
+
+
+def test_get_checkout_mode_order_from_config() -> None:
+    test_config = config.PivotConfig(
+        cache=config.CacheConfig(checkout_mode=["symlink", "hardlink"])
+    )
+
+    result = config.get_checkout_mode_order(test_config)
+
+    assert result == ["symlink", "hardlink"]
+
+
+def test_get_checkout_mode_order_invalid_mode_skipped() -> None:
+    test_config = config.PivotConfig(
+        cache=config.CacheConfig(checkout_mode=["hardlink", "invalid_mode", "copy"])
+    )
+
+    result = config.get_checkout_mode_order(test_config)
+
+    assert result == ["hardlink", "copy"], "Invalid mode should be skipped"
+
+
+def test_get_checkout_mode_order_all_invalid_returns_default() -> None:
+    test_config = config.PivotConfig(
+        cache=config.CacheConfig(checkout_mode=["invalid1", "invalid2"])
+    )
+
+    result = config.get_checkout_mode_order(test_config)
+
+    assert result == ["hardlink", "symlink", "copy"], "Should fallback to defaults"
+
+
+def test_get_checkout_mode_order_empty_list_returns_default() -> None:
+    test_config = config.PivotConfig(cache=config.CacheConfig(checkout_mode=[]))
+
+    result = config.get_checkout_mode_order(test_config)
+
+    assert result == ["hardlink", "symlink", "copy"]
+
+
+def test_get_checkout_mode_order_loads_config_when_none(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pivot import project
+
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".pivot").mkdir()
+    config_file = tmp_path / ".pivot" / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode:\n    - copy\n    - symlink\n")
+
+    result = config.get_checkout_mode_order()
+
+    assert result == ["copy", "symlink"]
+
+
+def test_get_checkout_mode_order_returns_copy() -> None:
+    test_config = config.PivotConfig(cache=config.CacheConfig(checkout_mode=["hardlink"]))
+
+    result1 = config.get_checkout_mode_order(test_config)
+    result2 = config.get_checkout_mode_order(test_config)
+
+    assert result1 == result2
+    assert result1 is not result2, "Should return a copy, not the same list"
+
+
+# --- Config cache behavior tests ---
+
+
+def test_config_cache_can_be_invalidated(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify config caching and invalidation via monkeypatch."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("cache:\n  checkout_mode:\n    - hardlink\n")
+    first = config.load_config(config_file)
+
+    monkeypatch.setattr(config, "_config_cache", None)
+    config_file.write_text("cache:\n  checkout_mode:\n    - copy\n")
+
+    second = config.load_config(config_file)
+
+    assert "cache" in first
+    assert "checkout_mode" in first["cache"]
+    assert first["cache"]["checkout_mode"] == ["hardlink"]
+    assert "cache" in second
+    assert "checkout_mode" in second["cache"]
+    assert second["cache"]["checkout_mode"] == ["copy"]
+    assert first is not second


### PR DESCRIPTION
## Summary
- Adds `.pivot/config.yaml` support for configuring cache checkout mode fallback order
- Renames all "link" terminology to "checkout" for clarity (`LinkMode` → `CheckoutMode`, `--link` → `--checkout-mode`)
- Fixes bug where `_save_directory_to_cache` silently failed for non-SYMLINK modes (HARDLINK/COPY)
- Adds validation to reject empty `checkout_modes` lists
- Simplifies code by extracting `_resolve_checkout_modes()` helper and removing dead code

## Config Format
```yaml
# .pivot/config.yaml
cache:
  checkout_mode:
    - hardlink  # Try first
    - symlink   # Fallback
    - copy      # Last resort
```

## Test Plan
- [x] All 711 tests pass (90.39% coverage)
- [x] `ruff format`, `ruff check`, `basedpyright` all pass
- [x] Directory caching works correctly with HARDLINK/COPY modes
- [x] Empty checkout_modes validation works
- [x] CLI `--checkout-mode` flag works

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)