### PR TITLE
feat: add pivot.yaml pipeline configuration loading

### DIFF
--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -4,6 +4,8 @@ from pivot import explain as explain
 from pivot import metrics as metrics
 from pivot import outputs as outputs
 from pivot import parameters as parameters
+from pivot import pipeline as pipeline
+from pivot import pipeline_config as pipeline_config
 from pivot import plots as plots
 from pivot import pvt as pvt
 from pivot import state as state
@@ -12,6 +14,7 @@ from pivot.outputs import IncrementalOut as IncrementalOut
 from pivot.outputs import Metric as Metric
 from pivot.outputs import Out as Out
 from pivot.outputs import Plot as Plot
+from pivot.pipeline import Pipeline as Pipeline
 from pivot.registry import REGISTRY as REGISTRY
 from pivot.registry import Variant as Variant
 from pivot.registry import stage as stage

--- a/src/pivot/discovery.py
+++ b/src/pivot/discovery.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+import runpy
+from typing import TYPE_CHECKING
+
+from pivot import pipeline_config, project, registry
+
+if TYPE_CHECKING:
+    import pathlib
+
+logger = logging.getLogger(__name__)
+
+PIVOT_YAML_NAMES = ("pivot.yaml", "pivot.yml")
+PIPELINE_PY_NAME = "pipeline.py"
+
+
+class DiscoveryError(Exception):
+    """Error during pipeline discovery."""
+
+
+def discover_and_register(project_root: pathlib.Path | None = None) -> str | None:
+    """Discover and register pipeline from pivot.yaml or pipeline.py.
+
+    Looks in project root for:
+    1. pivot.yaml (or pivot.yml) - uses pipeline_config to register
+    2. pipeline.py - imports module which should register stages
+
+    Args:
+        project_root: Override project root (default: auto-detect)
+
+    Returns:
+        Path to the discovered file, or None if nothing found
+
+    Raises:
+        DiscoveryError: If discovery or registration fails
+    """
+    root = project_root or project.get_project_root()
+
+    # Try pivot.yaml first
+    for yaml_name in PIVOT_YAML_NAMES:
+        yaml_path = root / yaml_name
+        if yaml_path.exists():
+            logger.info(f"Discovered {yaml_path}")
+            try:
+                pipeline_config.register_from_pipeline_file(yaml_path)
+                return str(yaml_path)
+            except pipeline_config.PipelineConfigError as e:
+                raise DiscoveryError(f"Failed to load {yaml_path}: {e}") from e
+
+    # Try pipeline.py
+    pipeline_path = root / PIPELINE_PY_NAME
+    if pipeline_path.exists():
+        logger.info(f"Discovered {pipeline_path}")
+        try:
+            _import_pipeline_module(pipeline_path)
+            return str(pipeline_path)
+        except Exception as e:
+            raise DiscoveryError(f"Failed to load {pipeline_path}: {e}") from e
+
+    return None
+
+
+def has_registered_stages() -> bool:
+    """Check if any stages are registered."""
+    return len(registry.REGISTRY.list_stages()) > 0
+
+
+def _import_pipeline_module(path: pathlib.Path) -> None:
+    """Execute a pipeline.py file, registering its stages."""
+    runpy.run_path(str(path), run_name="_pivot_pipeline")

--- a/src/pivot/pipeline.py
+++ b/src/pivot/pipeline.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import inspect
+import typing
+from typing import TYPE_CHECKING, Any
+
+import pydantic
+
+from pivot import outputs, parameters, registry
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable, Sequence
+
+
+class PipelineError(Exception):
+    """Error in pipeline configuration."""
+
+
+class Pipeline:
+    """Programmatic pipeline definition.
+
+    Example:
+        from mymodule import preprocess, train
+        from pivot import Pipeline
+
+        pipeline = Pipeline()
+        pipeline.add_stage(preprocess, deps=['data/raw.csv'], outs=['data/clean.csv'])
+        pipeline.add_stage(train, deps=['data/clean.csv'], outs=['models/model.pkl'],
+                           params={'learning_rate': 0.05})
+    """
+
+    def __init__(self) -> None:
+        self._stages: list[str] = []
+
+    def add_stage(
+        self,
+        func: Callable[..., Any],
+        *,
+        name: str | None = None,
+        deps: Sequence[str] = (),
+        outs: Sequence[outputs.OutSpec] = (),
+        metrics: Sequence[outputs.OutSpec] = (),
+        plots: Sequence[outputs.OutSpec] = (),
+        params: dict[str, Any] | pydantic.BaseModel | None = None,
+        mutex: Sequence[str] = (),
+        cwd: str | pathlib.Path | None = None,
+    ) -> None:
+        """Add a stage to the pipeline and register it globally."""
+        stage_name = name or func.__name__
+
+        if stage_name in self._stages:
+            raise PipelineError(f"Stage '{stage_name}' already added to pipeline")
+
+        # Combine all outputs, converting metrics/plots strings to typed outputs
+        all_outs: list[outputs.OutSpec] = list(outs)
+        all_outs += [
+            m if isinstance(m, outputs.BaseOut) else outputs.Metric(path=m) for m in metrics
+        ]
+        all_outs += [p if isinstance(p, outputs.BaseOut) else outputs.Plot(path=p) for p in plots]
+
+        # Resolve params from dict if needed
+        params_instance = _resolve_params_from_dict(func, params, stage_name)
+
+        registry.REGISTRY.register(
+            func=func,
+            name=stage_name,
+            deps=deps,
+            outs=all_outs,
+            params=params_instance,
+            mutex=mutex,
+            cwd=cwd,
+        )
+        self._stages.append(stage_name)
+
+    @property
+    def stages(self) -> list[str]:
+        """Get list of stage names in registration order."""
+        return list(self._stages)
+
+
+def _resolve_params_from_dict(
+    func: Callable[..., Any],
+    params: dict[str, Any] | pydantic.BaseModel | None,
+    stage_name: str,
+) -> pydantic.BaseModel | None:
+    """Resolve params dict to BaseModel instance by introspecting function signature."""
+    if params is None:
+        return None
+
+    # If already a BaseModel instance, use directly
+    if isinstance(params, pydantic.BaseModel):
+        return params
+
+    # At this point, params is a dict - introspect the params class from signature
+    sig = inspect.signature(func)
+    if "params" not in sig.parameters:
+        raise PipelineError(
+            f"Stage '{stage_name}': params provided but function has no 'params' parameter"
+        )
+
+    try:
+        type_hints = typing.get_type_hints(func)
+    except NameError as e:
+        raise PipelineError(
+            f"Stage '{stage_name}': failed to resolve type hints for '{func.__name__}': {e}"
+        ) from e
+
+    if "params" not in type_hints:
+        raise PipelineError(
+            f"Stage '{stage_name}': function has 'params' parameter but no type hint"
+        )
+
+    params_cls = type_hints["params"]
+
+    if not parameters.validate_params_cls(params_cls):
+        raise PipelineError(
+            f"Stage '{stage_name}': params type hint must be a Pydantic BaseModel, "
+            + f"got {params_cls}"
+        )
+
+    try:
+        return params_cls(**params)
+    except pydantic.ValidationError as e:
+        raise PipelineError(f"Stage '{stage_name}': invalid params: {e}") from e

--- a/src/pivot/pipeline_config.py
+++ b/src/pivot/pipeline_config.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import itertools
+import re
+import typing
+from collections.abc import Callable  # noqa: TC003 Pydantic needs at runtime
+from typing import TYPE_CHECKING, Annotated, Any, TypedDict
+
+import pydantic
+import yaml
+
+from pivot import outputs, parameters, registry, yaml_config
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Sequence
+
+
+class PipelineConfigError(Exception):
+    """Error loading or processing pivot.yaml configuration."""
+
+
+class OutputOptions(TypedDict, total=False):
+    """Valid options for output specifications."""
+
+    cache: bool
+    persist: bool
+    x: str  # For plots
+    y: str  # For plots
+    template: str  # For plots
+
+
+# Union type: YAML can have "path.txt" or {"path.txt": {cache: false}}
+OutputSpec = str | dict[str, OutputOptions]
+
+# Output specs from Python escape hatch can also include BaseOut directly
+VariantOutputSpec = str | dict[str, OutputOptions] | outputs.BaseOut
+
+
+class VariantDict(TypedDict, total=False):
+    """Variant dict structure from Python escape hatch functions."""
+
+    name: str
+    deps: list[str]
+    outs: list[VariantOutputSpec]
+    params: dict[str, Any]
+    mutex: list[str]
+    cwd: str
+
+
+class DimensionOverrides(pydantic.BaseModel, extra="forbid", populate_by_name=True):
+    """Overrides that can be applied per matrix dimension value."""
+
+    deps: list[str] | None = None
+    outs: list[OutputSpec] | None = None
+    metrics: list[OutputSpec] | None = None
+    plots: list[OutputSpec] | None = None
+    params: dict[str, Any] | None = None  # JSON-compatible values from YAML
+    mutex: list[str] | None = None
+    cwd: str | None = None
+
+    # Append variants (Hydra-style)
+    deps_append: list[str] | None = pydantic.Field(default=None, alias="deps+")
+    outs_append: list[OutputSpec] | None = pydantic.Field(default=None, alias="outs+")
+    metrics_append: list[OutputSpec] | None = pydantic.Field(default=None, alias="metrics+")
+    plots_append: list[OutputSpec] | None = pydantic.Field(default=None, alias="plots+")
+    mutex_append: list[str] | None = pydantic.Field(default=None, alias="mutex+")
+
+
+# Primitive types allowed in matrix dimension lists
+MatrixPrimitive = str | int | float | bool
+
+# Matrix dimension can be a list ["a", "b", true, 0.5] or dict {"a": {overrides}, "b": {overrides}}
+MatrixDimension = list[MatrixPrimitive] | dict[str, DimensionOverrides | None]
+
+
+class StageConfig(pydantic.BaseModel, extra="forbid"):
+    """Configuration for a single stage in pivot.yaml."""
+
+    python: str
+    deps: list[str] = []
+    outs: list[OutputSpec] = []
+    metrics: list[OutputSpec] = []
+    plots: list[OutputSpec] = []
+    params: dict[str, Any] = pydantic.Field(default_factory=dict)  # JSON-compatible from YAML
+    mutex: list[str] = []
+    cwd: str | None = None
+    matrix: dict[str, MatrixDimension] | None = None
+    variants: str | None = None
+
+    @pydantic.field_validator("cwd")
+    @classmethod
+    def validate_cwd(cls, v: str | None) -> str | None:
+        """Validate cwd doesn't contain path traversal."""
+        if v is not None and ".." in v:
+            raise ValueError(f"cwd cannot contain '..' (got '{v}')")
+        return v
+
+
+class PipelineConfig(pydantic.BaseModel, extra="forbid"):
+    """Top-level pivot.yaml configuration."""
+
+    stages: dict[str, StageConfig]
+
+
+def _validate_callable(v: object) -> Callable[..., Any]:
+    """Validate that value is callable."""
+    if not callable(v):
+        raise ValueError("must be callable")
+    return v
+
+
+class ExpandedStage(pydantic.BaseModel):
+    """A stage after matrix expansion."""
+
+    name: str
+    func: Annotated[Callable[..., Any], pydantic.PlainValidator(_validate_callable)]
+    deps: list[str]
+    outs: list[outputs.BaseOut]
+    params: pydantic.BaseModel | None
+    mutex: list[str]
+    cwd: str
+    variant: str | None
+
+
+def load_pipeline_file(pipeline_file: pathlib.Path) -> PipelineConfig:
+    """Load and parse pivot.yaml pipeline file."""
+    if not pipeline_file.exists():
+        raise PipelineConfigError(f"Pipeline file not found: {pipeline_file}")
+
+    with open(pipeline_file) as f:
+        data = yaml.load(f, Loader=yaml_config.Loader)
+
+    if data is None:
+        raise PipelineConfigError(f"Pipeline file is empty: {pipeline_file}")
+
+    try:
+        return PipelineConfig.model_validate(data)
+    except pydantic.ValidationError as e:
+        raise PipelineConfigError(f"Invalid pipeline configuration: {e}") from e
+
+
+def register_from_pipeline_file(pipeline_file: pathlib.Path) -> None:
+    """Load pivot.yaml and register all stages to the global registry."""
+    pipeline = load_pipeline_file(pipeline_file)
+    pipeline_dir = pipeline_file.parent
+
+    for stage_name, stage_config in pipeline.stages.items():
+        _register_stage(stage_name, stage_config, pipeline_dir)
+
+
+def _register_stage(name: str, config: StageConfig, pipeline_dir: pathlib.Path) -> None:
+    """Register a single stage from configuration."""
+    if config.matrix is not None:
+        expanded = _expand_matrix(name, config, pipeline_dir)
+        for stage in expanded:
+            registry.REGISTRY.register(
+                func=stage.func,
+                name=stage.name,
+                deps=stage.deps,
+                outs=stage.outs,
+                params=stage.params,
+                mutex=stage.mutex,
+                variant=stage.variant,
+                cwd=stage.cwd,
+            )
+    elif config.variants is not None:
+        variants_func = _import_function(config.variants)
+        variants = variants_func()
+        if not isinstance(variants, (list, tuple)):
+            raise PipelineConfigError(
+                f"Stage '{name}': variants function '{config.variants}' must return a list, "
+                + f"got {type(variants).__name__}"
+            )
+        func = _import_function(config.python)
+        for variant in typing.cast("list[VariantDict]", variants):
+            _register_variant_from_dict(name, func, variant, pipeline_dir)
+    else:
+        _register_simple_stage(name, config, pipeline_dir)
+
+
+def _register_simple_stage(name: str, config: StageConfig, pipeline_dir: pathlib.Path) -> None:
+    """Register a simple (non-matrix) stage."""
+    func = _import_function(config.python)
+    cwd = config.cwd or str(pipeline_dir)
+    outs_spec = (
+        _normalize_output_specs(config.outs, outputs.Out)
+        + _normalize_output_specs(config.metrics, outputs.Metric)
+        + _normalize_output_specs(config.plots, outputs.Plot)
+    )
+    params_instance = _resolve_params(func, config.params, name)
+
+    registry.REGISTRY.register(
+        func=func,
+        name=name,
+        deps=config.deps,
+        outs=outs_spec,
+        params=params_instance,
+        mutex=config.mutex,
+        cwd=cwd,
+    )
+
+
+def _register_variant_from_dict(
+    base_name: str,
+    func: Callable[..., Any],
+    variant: VariantDict,
+    pipeline_dir: pathlib.Path,
+) -> None:
+    """Register a variant from Python escape hatch."""
+    variant_name = variant.get("name", "default")
+    full_name = f"{base_name}@{variant_name}"
+
+    deps = variant.get("deps", [])
+    outs_raw = variant.get("outs", [])
+    params_dict = variant.get("params", {})
+    mutex = variant.get("mutex", [])
+    cwd_raw = variant.get("cwd")
+    cwd = cwd_raw if cwd_raw is not None else str(pipeline_dir)
+
+    outs_spec = _normalize_output_specs(outs_raw, outputs.Out)
+    params_instance = _resolve_params(func, params_dict, full_name)
+
+    registry.REGISTRY.register(
+        func=func,
+        name=full_name,
+        deps=deps,
+        outs=outs_spec,
+        params=params_instance,
+        mutex=mutex,
+        variant=variant_name,
+        cwd=cwd,
+    )
+
+
+def _expand_matrix(
+    name: str, config: StageConfig, pipeline_dir: pathlib.Path
+) -> list[ExpandedStage]:
+    """Expand matrix configuration into individual variant stages."""
+    if config.matrix is None:
+        raise PipelineConfigError(f"Stage '{name}' missing 'matrix' field")
+
+    func = _import_function(config.python)
+    matrix = config.matrix
+
+    base_name, name_template = _parse_stage_name(name, matrix)
+    normalized_dims = _normalize_matrix_dimensions(name, matrix)
+    dim_names = list(normalized_dims.keys())
+
+    dim_keys = [list(normalized_dims[dim].keys()) for dim in dim_names]
+    combinations = list(itertools.product(*dim_keys))
+
+    expanded = list[ExpandedStage]()
+    for combo in combinations:
+        # combo contains string keys; build both string and typed value dicts
+        string_values = dict(zip(dim_names, combo, strict=True))
+        typed_values = {
+            dim_name: normalized_dims[dim_name][key][0] for dim_name, key in string_values.items()
+        }
+        variant_name = _generate_variant_name(name_template, dim_names, string_values)
+        full_name = f"{base_name}@{variant_name}"
+
+        deps = list(config.deps)
+        outs_raw = list(config.outs)
+        metrics_raw = list(config.metrics)
+        plots_raw = list(config.plots)
+        params_dict = dict(config.params)
+        mutex = list(config.mutex)
+        cwd: str | None = config.cwd
+
+        for dim_name, key in string_values.items():
+            overrides = normalized_dims[dim_name][key][1]
+            deps, outs_raw, metrics_raw, plots_raw, params_dict, mutex, cwd = _apply_overrides(
+                deps, outs_raw, metrics_raw, plots_raw, params_dict, mutex, cwd, overrides
+            )
+
+        cwd = cwd or str(pipeline_dir)
+
+        # Use string values for path interpolation (deps, outs, cwd)
+        deps = [_interpolate(d, string_values, full_name) for d in deps]
+        outs_raw = [_interpolate_out(o, string_values, full_name) for o in outs_raw]
+        metrics_raw = [_interpolate_out(m, string_values, full_name) for m in metrics_raw]
+        plots_raw = [_interpolate_out(p, string_values, full_name) for p in plots_raw]
+        cwd = _interpolate(cwd, string_values, full_name)
+
+        # Use typed values for params interpolation (preserves int/float/bool)
+        params_dict = {k: _interpolate_value(v, typed_values) for k, v in params_dict.items()}
+
+        outs_spec = (
+            _normalize_output_specs(outs_raw, outputs.Out)
+            + _normalize_output_specs(metrics_raw, outputs.Metric)
+            + _normalize_output_specs(plots_raw, outputs.Plot)
+        )
+        params_instance = _resolve_params(func, params_dict, full_name)
+
+        expanded.append(
+            ExpandedStage(
+                name=full_name,
+                func=func,
+                deps=deps,
+                outs=outs_spec,
+                params=params_instance,
+                mutex=mutex,
+                cwd=cwd,
+                variant=variant_name,
+            )
+        )
+
+    return expanded
+
+
+def _parse_stage_name(name: str, matrix: dict[str, MatrixDimension]) -> tuple[str, str | None]:
+    """Parse stage name for template pattern."""
+    if "@" not in name:
+        return name, None
+
+    if "@{" not in name:
+        raise PipelineConfigError(
+            f"Stage name '{name}' contains '@' but no template variables. "
+            + "Use '@{dim}' syntax or remove '@' for auto-naming."
+        )
+
+    base_name, template = name.split("@", 1)
+    dim_names = set(matrix.keys())
+    template_vars = set(re.findall(r"\{(\w+)\}", template))
+
+    missing = dim_names - template_vars
+    if missing:
+        raise PipelineConfigError(
+            f"Stage '{name}' template missing dimensions: {missing}. "
+            + "All matrix dimensions must appear in the name template."
+        )
+
+    extra = template_vars - dim_names
+    if extra:
+        raise PipelineConfigError(
+            f"Stage '{name}' template has unknown variables: {extra}. "
+            + f"Available dimensions: {dim_names}"
+        )
+
+    return base_name, template
+
+
+def _normalize_matrix_dimensions(
+    stage_name: str,
+    matrix: dict[str, MatrixDimension],
+) -> dict[str, dict[str, tuple[MatrixPrimitive, DimensionOverrides]]]:
+    """Normalize matrix dimensions to {dim: {str_key: (typed_value, overrides)}} form."""
+    normalized = dict[str, dict[str, tuple[MatrixPrimitive, DimensionOverrides]]]()
+
+    for dim_name, dim_value in matrix.items():
+        if isinstance(dim_value, list):
+            if not dim_value:
+                raise PipelineConfigError(
+                    f"Stage '{stage_name}': matrix dimension '{dim_name}' is empty"
+                )
+            normalized[dim_name] = {str(v): (v, DimensionOverrides()) for v in dim_value}
+        else:
+            if not dim_value:
+                raise PipelineConfigError(
+                    f"Stage '{stage_name}': matrix dimension '{dim_name}' is empty"
+                )
+            normalized[dim_name] = {
+                k: (k, v if v is not None else DimensionOverrides()) for k, v in dim_value.items()
+            }
+
+    return normalized
+
+
+def _generate_variant_name(
+    template: str | None, dim_names: list[str], dim_values: dict[str, str]
+) -> str:
+    """Generate variant name from template or auto-generate."""
+    if template is not None:
+        return template.format(**dim_values)
+    return "_".join(dim_values[d] for d in dim_names)
+
+
+def _apply_overrides(
+    deps: list[str],
+    outs: list[OutputSpec],
+    metrics: list[OutputSpec],
+    plots: list[OutputSpec],
+    params: dict[str, Any],
+    mutex: list[str],
+    cwd: str | None,
+    overrides: DimensionOverrides,
+) -> tuple[
+    list[str],
+    list[OutputSpec],
+    list[OutputSpec],
+    list[OutputSpec],
+    dict[str, Any],
+    list[str],
+    str | None,
+]:
+    """Apply dimension overrides to stage config."""
+    if overrides.deps is not None:
+        deps = overrides.deps
+    if overrides.deps_append:
+        deps = deps + overrides.deps_append
+    if overrides.outs is not None:
+        outs = overrides.outs
+    if overrides.outs_append:
+        outs = outs + overrides.outs_append
+    if overrides.metrics is not None:
+        metrics = overrides.metrics
+    if overrides.metrics_append:
+        metrics = metrics + overrides.metrics_append
+    if overrides.plots is not None:
+        plots = overrides.plots
+    if overrides.plots_append:
+        plots = plots + overrides.plots_append
+    if overrides.params is not None:
+        params = {**params, **overrides.params}
+    if overrides.mutex is not None:
+        mutex = overrides.mutex
+    if overrides.mutex_append:
+        mutex = mutex + overrides.mutex_append
+    if overrides.cwd is not None:
+        cwd = overrides.cwd
+
+    return deps, outs, metrics, plots, params, mutex, cwd
+
+
+def _interpolate(s: str, values: dict[str, str], stage_name: str) -> str:
+    """Interpolate ${dim} variables in a string."""
+    result = s
+    for key, val in values.items():
+        result = result.replace(f"${{{key}}}", val)
+
+    remaining = re.findall(r"\$\{(\w+)\}", result)
+    if remaining:
+        raise PipelineConfigError(
+            f"Stage '{stage_name}': unresolved variable(s) in '{s}': {remaining}"
+        )
+    return result
+
+
+def _interpolate_out(out: OutputSpec, values: dict[str, str], stage_name: str) -> OutputSpec:
+    """Interpolate ${dim} in output spec (string or dict)."""
+    if isinstance(out, str):
+        return _interpolate(out, values, stage_name)
+    return {_interpolate(k, values, stage_name): v for k, v in out.items()}
+
+
+def _interpolate_value(value: Any, values: dict[str, MatrixPrimitive]) -> Any:
+    """Interpolate ${dim} in any value, including nested structures.
+
+    When the value is exactly "${key}", returns the typed value (preserves int/float/bool).
+    When the value contains "${key}" as substring, uses string replacement.
+    """
+    if isinstance(value, str):
+        # Check for exact match first (preserves original type)
+        for key, val in values.items():
+            if value == f"${{{key}}}":
+                return val
+        # Otherwise do string replacement
+        result = value
+        for key, val in values.items():
+            result = result.replace(f"${{{key}}}", str(val))
+        return result
+    if isinstance(value, dict):
+        return {
+            k: _interpolate_value(v, values)
+            for k, v in typing.cast("dict[str, Any]", value).items()
+        }
+    if isinstance(value, list):
+        return [_interpolate_value(v, values) for v in typing.cast("list[Any]", value)]
+    return value
+
+
+def _normalize_output_specs(
+    specs: Sequence[VariantOutputSpec], out_cls: type[outputs.BaseOut]
+) -> list[outputs.BaseOut]:
+    """Convert output specs (str, dict, or BaseOut) to BaseOut objects."""
+    result = list[outputs.BaseOut]()
+    for spec in specs:
+        if isinstance(spec, str):
+            result.append(out_cls(path=spec))
+        elif isinstance(spec, dict):
+            for path, opts in spec.items():
+                result.append(_make_output_with_options(out_cls, path, opts))
+        else:
+            # spec is outputs.BaseOut (from Python escape hatch variants)
+            result.append(spec)
+    return result
+
+
+def _make_output_with_options(
+    out_cls: type[outputs.BaseOut], path: str, opts: OutputOptions
+) -> outputs.BaseOut:
+    """Create an output object, handling class-specific options."""
+    if out_cls is outputs.Plot:
+        return outputs.Plot(
+            path=path,
+            cache=opts.get("cache", True),
+            persist=opts.get("persist", True),
+            x=opts.get("x"),
+            y=opts.get("y"),
+            template=opts.get("template"),
+        )
+    return out_cls(
+        path=path,
+        cache=opts.get("cache", True),
+        persist=opts.get("persist", True),
+    )
+
+
+def _import_function(import_path: str) -> Callable[..., Any]:
+    """Import a function from module.function path."""
+    if "." not in import_path:
+        raise PipelineConfigError(
+            f"Invalid import path '{import_path}': expected 'module.function' format"
+        )
+
+    module_path, func_name = import_path.rsplit(".", 1)
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise PipelineConfigError(f"Failed to import module '{module_path}': {e}") from e
+
+    if not hasattr(module, func_name):
+        raise PipelineConfigError(f"Module '{module_path}' has no function '{func_name}'")
+
+    func = getattr(module, func_name)
+    if not callable(func):
+        raise PipelineConfigError(f"'{import_path}' is not callable")
+
+    return func
+
+
+def _resolve_params(
+    func: Callable[..., Any],
+    overrides: dict[str, Any],
+    stage_name: str,
+) -> pydantic.BaseModel | None:
+    """Resolve params from function signature + config overrides."""
+    sig = inspect.signature(func)
+
+    if "params" not in sig.parameters:
+        if overrides:
+            raise PipelineConfigError(
+                f"Stage '{stage_name}': pivot.yaml has 'params' but function "
+                + f"'{func.__name__}' has no 'params' parameter"
+            )
+        return None
+
+    try:
+        type_hints = typing.get_type_hints(func)
+    except NameError as e:
+        raise PipelineConfigError(
+            f"Stage '{stage_name}': failed to resolve type hints for '{func.__name__}': {e}"
+        ) from e
+
+    if "params" not in type_hints:
+        raise PipelineConfigError(
+            f"Stage '{stage_name}': function '{func.__name__}' has 'params' parameter "
+            + "but no type hint. Add a type hint like 'params: MyParams'"
+        )
+
+    type_hint = type_hints["params"]
+
+    if not parameters.validate_params_cls(type_hint):
+        raise PipelineConfigError(
+            f"Stage '{stage_name}': params type hint must be a Pydantic BaseModel, "
+            + f"got {type_hint}"
+        )
+
+    try:
+        return type_hint(**overrides)
+    except pydantic.ValidationError as e:
+        raise PipelineConfigError(f"Stage '{stage_name}': invalid params: {e}") from e

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -211,10 +211,16 @@ class StageRegistry:
         outs_list: Sequence[outputs.OutSpec] = outs if outs is not None else ()
         mutex_list: list[str] = [m.strip().lower() for m in mutex] if mutex else []
 
-        # Normalize cwd to absolute path
+        # Normalize cwd to absolute path and validate within project root
         cwd_path: pathlib.Path | None = None
         if cwd is not None:
             cwd_path = project.normalize_path(str(cwd))
+            project_root = project.get_project_root()
+            if not cwd_path.is_relative_to(project_root):
+                raise exceptions.InvalidPathError(
+                    f"Stage '{stage_name}': cwd '{cwd}' resolves to '{cwd_path}' "
+                    + f"which is outside project root '{project_root}'"
+                )
 
         # Normalize outputs to BaseOut objects
         outs_normalized = [outputs.normalize_out(o) for o in outs_list]

--- a/tests/core/test_discovery.py
+++ b/tests/core/test_discovery.py
@@ -1,0 +1,247 @@
+"""Tests for pivot.discovery auto-discovery functionality."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import discovery, registry
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Generator
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> Generator[None]:
+    """Clear registry before and after each test."""
+    registry.REGISTRY.clear()
+    yield
+    registry.REGISTRY.clear()
+
+
+@pytest.fixture
+def project_root(tmp_path: pathlib.Path, mocker: MockerFixture) -> pathlib.Path:
+    """Set up a mock project root."""
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+    return tmp_path
+
+
+# =============================================================================
+# Basic Discovery Tests
+# =============================================================================
+
+
+def test_discover_returns_none_when_no_files(project_root: pathlib.Path) -> None:
+    """discover_and_register returns None when no pivot.yaml or pipeline.py."""
+    result = discovery.discover_and_register(project_root)
+    assert result is None
+
+
+def test_discover_pivot_yaml(project_root: pathlib.Path) -> None:
+    """discover_and_register finds and loads pivot.yaml."""
+    import sys
+
+    # Create stages module
+    stages_py = project_root / "stages.py"
+    stages_py.write_text(
+        """\
+def preprocess():
+    pass
+"""
+    )
+
+    # Create pivot.yaml
+    pivot_yaml = project_root / "pivot.yaml"
+    pivot_yaml.write_text(
+        """\
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps: []
+    outs: [output.txt]
+"""
+    )
+
+    # Add project root to sys.path for module imports
+    sys.path.insert(0, str(project_root))
+    try:
+        result = discovery.discover_and_register(project_root)
+
+        assert result == str(pivot_yaml)
+        assert "preprocess" in registry.REGISTRY.list_stages()
+    finally:
+        sys.path.remove(str(project_root))
+        if "stages" in sys.modules:
+            del sys.modules["stages"]
+
+
+def test_discover_pivot_yml(project_root: pathlib.Path) -> None:
+    """discover_and_register finds and loads pivot.yml (alternate extension)."""
+    import sys
+
+    # Create stages module
+    stages_py = project_root / "stages.py"
+    stages_py.write_text(
+        """\
+def analyze():
+    pass
+"""
+    )
+
+    # Create pivot.yml (note: .yml not .yaml)
+    pivot_yml = project_root / "pivot.yml"
+    pivot_yml.write_text(
+        """\
+stages:
+  analyze:
+    python: stages.analyze
+    deps: []
+    outs: [result.txt]
+"""
+    )
+
+    sys.path.insert(0, str(project_root))
+    try:
+        result = discovery.discover_and_register(project_root)
+
+        assert result == str(pivot_yml)
+        assert "analyze" in registry.REGISTRY.list_stages()
+    finally:
+        sys.path.remove(str(project_root))
+        if "stages" in sys.modules:
+            del sys.modules["stages"]
+
+
+def test_discover_pipeline_py(project_root: pathlib.Path) -> None:
+    """discover_and_register finds and loads pipeline.py."""
+    # Create pipeline.py that registers a stage
+    pipeline_py = project_root / "pipeline.py"
+    pipeline_py.write_text(
+        """\
+from pivot import Pipeline
+
+def my_stage():
+    pass
+
+pipeline = Pipeline()
+pipeline.add_stage(my_stage, outs=['output.txt'])
+"""
+    )
+
+    result = discovery.discover_and_register(project_root)
+
+    assert result == str(pipeline_py)
+    assert "my_stage" in registry.REGISTRY.list_stages()
+
+
+def test_discover_pivot_yaml_takes_precedence(project_root: pathlib.Path) -> None:
+    """pivot.yaml is preferred over pipeline.py."""
+    import sys
+
+    # Create stages module
+    stages_py = project_root / "stages.py"
+    stages_py.write_text(
+        """\
+def yaml_stage():
+    pass
+"""
+    )
+
+    # Create both pivot.yaml and pipeline.py
+    pivot_yaml = project_root / "pivot.yaml"
+    pivot_yaml.write_text(
+        """\
+stages:
+  yaml_stage:
+    python: stages.yaml_stage
+    deps: []
+    outs: [yaml_output.txt]
+"""
+    )
+
+    pipeline_py = project_root / "pipeline.py"
+    pipeline_py.write_text(
+        """\
+from pivot import Pipeline
+
+def python_stage():
+    pass
+
+pipeline = Pipeline()
+pipeline.add_stage(python_stage, outs=['python_output.txt'])
+"""
+    )
+
+    sys.path.insert(0, str(project_root))
+    try:
+        result = discovery.discover_and_register(project_root)
+
+        assert result == str(pivot_yaml)
+        assert "yaml_stage" in registry.REGISTRY.list_stages()
+        assert "python_stage" not in registry.REGISTRY.list_stages()
+    finally:
+        sys.path.remove(str(project_root))
+        if "stages" in sys.modules:
+            del sys.modules["stages"]
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+def test_discover_invalid_pivot_yaml_raises(project_root: pathlib.Path) -> None:
+    """discover_and_register raises DiscoveryError for invalid pivot.yaml."""
+    pivot_yaml = project_root / "pivot.yaml"
+    pivot_yaml.write_text(
+        """\
+stages:
+  broken:
+    python: nonexistent.module.func
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
+        discovery.discover_and_register(project_root)
+
+
+def test_discover_invalid_pipeline_py_raises(project_root: pathlib.Path) -> None:
+    """discover_and_register raises DiscoveryError for invalid pipeline.py."""
+    pipeline_py = project_root / "pipeline.py"
+    pipeline_py.write_text(
+        """\
+# This will raise an error when executed
+raise RuntimeError("intentional error")
+"""
+    )
+
+    with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
+        discovery.discover_and_register(project_root)
+
+
+# =============================================================================
+# Helper Function Tests
+# =============================================================================
+
+
+def test_has_registered_stages_false_when_empty() -> None:
+    """has_registered_stages returns False when no stages registered."""
+    registry.REGISTRY.clear()
+    assert discovery.has_registered_stages() is False
+
+
+def test_has_registered_stages_true_after_registration(
+    project_root: pathlib.Path,
+) -> None:
+    """has_registered_stages returns True after stage registration."""
+
+    def test_stage() -> None:
+        pass
+
+    registry.REGISTRY.register(test_stage, name="test", deps=[], outs=[])
+    assert discovery.has_registered_stages() is True

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -1,0 +1,246 @@
+"""Tests for pivot.Pipeline programmatic API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pydantic
+import pytest
+
+from pivot import Pipeline, outputs, registry
+from pivot.pipeline import PipelineError
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Generator
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> Generator[None]:
+    """Clear registry before and after each test."""
+    registry.REGISTRY.clear()
+    yield
+    registry.REGISTRY.clear()
+
+
+@pytest.fixture
+def mock_project_root(tmp_path: pathlib.Path, mocker: MockerFixture) -> pathlib.Path:
+    """Set up a mock project root."""
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+    return tmp_path
+
+
+# =============================================================================
+# Basic Registration Tests
+# =============================================================================
+
+
+def test_pipeline_add_stage_registers_function(mock_project_root: pathlib.Path) -> None:
+    """add_stage registers a function to the global registry."""
+
+    def my_stage() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(my_stage, deps=["input.txt"], outs=["output.txt"])
+
+    assert "my_stage" in registry.REGISTRY.list_stages()
+
+
+def test_pipeline_add_stage_with_custom_name(mock_project_root: pathlib.Path) -> None:
+    """add_stage with name parameter uses custom name."""
+
+    def process() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(process, name="custom_name", deps=["in.txt"], outs=["out.txt"])
+
+    assert "custom_name" in registry.REGISTRY.list_stages()
+    assert "process" not in registry.REGISTRY.list_stages()
+
+
+def test_pipeline_add_stage_with_deps_and_outs(mock_project_root: pathlib.Path) -> None:
+    """add_stage registers deps and outs correctly."""
+
+    def process() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(process, deps=["data/input.csv"], outs=["data/output.csv"])
+
+    info = registry.REGISTRY.get("process")
+    assert any("data/input.csv" in d for d in info["deps"])
+    assert any("data/output.csv" in o for o in info["outs_paths"])
+
+
+def test_pipeline_stages_property_returns_registration_order(
+    mock_project_root: pathlib.Path,
+) -> None:
+    """stages property returns stage names in registration order."""
+
+    def stage_a() -> None:
+        pass
+
+    def stage_b() -> None:
+        pass
+
+    def stage_c() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(stage_a, outs=["a.txt"])
+    pipeline.add_stage(stage_b, outs=["b.txt"])
+    pipeline.add_stage(stage_c, outs=["c.txt"])
+
+    assert pipeline.stages == ["stage_a", "stage_b", "stage_c"]
+
+
+def test_pipeline_add_stage_duplicate_name_raises(mock_project_root: pathlib.Path) -> None:
+    """add_stage with duplicate name raises PipelineError."""
+
+    def process() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(process, outs=["out1.txt"])
+
+    with pytest.raises(PipelineError, match="already added"):
+        pipeline.add_stage(process, outs=["out2.txt"])
+
+
+# =============================================================================
+# Params Tests
+# =============================================================================
+
+
+class TrainParams(pydantic.BaseModel):
+    learning_rate: float = 0.01
+    epochs: int = 100
+
+
+def stage_with_params(params: TrainParams) -> None:
+    pass
+
+
+def test_pipeline_add_stage_with_params_dict(mock_project_root: pathlib.Path) -> None:
+    """add_stage with params dict introspects type from signature."""
+    pipeline = Pipeline()
+    pipeline.add_stage(
+        stage_with_params,
+        outs=["model.pkl"],
+        params={"learning_rate": 0.05, "epochs": 50},
+    )
+
+    info = registry.REGISTRY.get("stage_with_params")
+    assert info["params"] is not None
+    params_dict = info["params"].model_dump()
+    assert params_dict["learning_rate"] == 0.05
+    assert params_dict["epochs"] == 50
+
+
+def test_pipeline_add_stage_with_params_instance(mock_project_root: pathlib.Path) -> None:
+    """add_stage with BaseModel instance uses it directly."""
+    params = TrainParams(learning_rate=0.1, epochs=200)
+
+    pipeline = Pipeline()
+    pipeline.add_stage(stage_with_params, outs=["model.pkl"], params=params)
+
+    info = registry.REGISTRY.get("stage_with_params")
+    assert info["params"] is params
+
+
+def test_pipeline_add_stage_params_dict_without_signature_raises(
+    mock_project_root: pathlib.Path,
+) -> None:
+    """add_stage with params dict but no params parameter raises error."""
+
+    def no_params_stage() -> None:
+        pass
+
+    pipeline = Pipeline()
+    with pytest.raises(PipelineError, match="no 'params' parameter"):
+        pipeline.add_stage(no_params_stage, outs=["out.txt"], params={"foo": "bar"})
+
+
+def test_pipeline_add_stage_params_dict_without_type_hint_raises(
+    mock_project_root: pathlib.Path,
+) -> None:
+    """add_stage with params dict but no type hint raises error."""
+
+    def untyped_params_stage(params: Any) -> None:  # noqa: ANN401
+        del params
+
+    pipeline = Pipeline()
+    with pytest.raises(PipelineError, match="Pydantic BaseModel"):
+        pipeline.add_stage(untyped_params_stage, outs=["out.txt"], params={"foo": "bar"})
+
+
+# =============================================================================
+# Metrics and Plots Tests
+# =============================================================================
+
+
+def test_pipeline_add_stage_with_metrics(mock_project_root: pathlib.Path) -> None:
+    """add_stage with metrics creates Metric outputs."""
+
+    def train() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(train, outs=["model.pkl"], metrics=["metrics/train.json"])
+
+    info = registry.REGISTRY.get("train")
+    metric_outs = [o for o in info["outs"] if isinstance(o, outputs.Metric)]
+    assert len(metric_outs) == 1
+    assert "metrics/train.json" in metric_outs[0].path
+
+
+def test_pipeline_add_stage_with_plots(mock_project_root: pathlib.Path) -> None:
+    """add_stage with plots creates Plot outputs."""
+
+    def analyze() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(analyze, outs=["report.json"], plots=["plots/curve.json"])
+
+    info = registry.REGISTRY.get("analyze")
+    plot_outs = [o for o in info["outs"] if isinstance(o, outputs.Plot)]
+    assert len(plot_outs) == 1
+    assert "plots/curve.json" in plot_outs[0].path
+
+
+# =============================================================================
+# Mutex and CWD Tests
+# =============================================================================
+
+
+def test_pipeline_add_stage_with_mutex(mock_project_root: pathlib.Path) -> None:
+    """add_stage with mutex registers mutex groups."""
+
+    def gpu_stage() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(gpu_stage, outs=["out.txt"], mutex=["gpu"])
+
+    info = registry.REGISTRY.get("gpu_stage")
+    assert "gpu" in info["mutex"]
+
+
+def test_pipeline_add_stage_with_cwd(mock_project_root: pathlib.Path) -> None:
+    """add_stage with cwd sets working directory."""
+    (mock_project_root / "subdir").mkdir()
+
+    def subdir_stage() -> None:
+        pass
+
+    pipeline = Pipeline()
+    pipeline.add_stage(subdir_stage, outs=["out.txt"], cwd="subdir")
+
+    info = registry.REGISTRY.get("subdir_stage")
+    assert info["cwd"] is not None
+    assert "subdir" in str(info["cwd"])

--- a/tests/core/test_pipeline_config.py
+++ b/tests/core/test_pipeline_config.py
@@ -1,0 +1,1408 @@
+"""Tests for pivot.yaml configuration loading and stage registration."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import pipeline_config, registry
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_mock import MockerFixture
+
+FIXTURES_DIR = pathlib.Path(__file__).parent.parent / "fixtures" / "pipeline_config"
+
+
+# =============================================================================
+# Fixture Helpers
+# =============================================================================
+
+
+@pytest.fixture
+def simple_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy simple pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "simple"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "models").mkdir(exist_ok=True)
+
+    # Set project root so paths resolve correctly
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    # Add fixture dir to sys.path so stages module can be imported
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+@pytest.fixture
+def params_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy params pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "with_params"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "models").mkdir(exist_ok=True)
+    (tmp_path / "metrics").mkdir(exist_ok=True)
+
+    # Set project root
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+@pytest.fixture
+def matrix_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy matrix pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "with_matrix"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "data" / "gpt_tokenizer.json").write_text("{}")
+    (tmp_path / "configs").mkdir(exist_ok=True)
+    (tmp_path / "configs" / "bert.yaml").write_text("model: bert")
+    (tmp_path / "configs" / "gpt.yaml").write_text("model: gpt")
+    (tmp_path / "models").mkdir(exist_ok=True)
+    (tmp_path / "metrics").mkdir(exist_ok=True)
+
+    # Set project root
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+# =============================================================================
+# Basic Loading Tests
+# =============================================================================
+
+
+def test_load_simple_config(simple_pipeline: pathlib.Path) -> None:
+    """Load a simple pivot.yaml with two stages."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    assert len(config.stages) == 2
+    assert "preprocess" in config.stages
+    assert "train" in config.stages
+
+
+def test_load_pipeline_file_parses_stage_fields(simple_pipeline: pathlib.Path) -> None:
+    """Stage config contains python, deps, and outs fields."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    preprocess = config.stages["preprocess"]
+    assert preprocess.python == "stages.preprocess"
+    assert preprocess.deps == ["data/raw.csv"]
+    assert preprocess.outs == ["data/clean.csv"]
+
+
+def test_load_pipeline_file_with_metrics(params_pipeline: pathlib.Path) -> None:
+    """Stage config with metrics field is parsed correctly."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    train = config.stages["train"]
+    assert train.metrics == ["metrics/train.json"]
+
+
+def test_load_pipeline_file_with_params(params_pipeline: pathlib.Path) -> None:
+    """Stage config with params overrides is parsed correctly."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    train = config.stages["train"]
+    assert train.params["learning_rate"] == 0.05
+    assert train.params["epochs"] == 50
+
+
+# =============================================================================
+# Stage Registration Tests
+# =============================================================================
+
+
+def test_register_simple_stages(simple_pipeline: pathlib.Path) -> None:
+    """Register stages from simple pivot.yaml into registry."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "preprocess" in stages
+    assert "train" in stages
+
+
+def test_registered_stage_has_correct_deps(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage has correct dependencies."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    # Deps should be normalized to absolute paths
+    assert any("data/raw.csv" in dep for dep in info["deps"])
+
+
+def test_registered_stage_has_correct_outs(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage has correct outputs."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert any("data/clean.csv" in out for out in info["outs_paths"])
+
+
+def test_registered_stage_function_is_callable(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage function is the actual imported function."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert callable(info["func"])
+    assert info["func"].__name__ == "preprocess"
+
+
+# =============================================================================
+# Params Introspection Tests
+# =============================================================================
+
+
+def test_params_introspected_from_signature(params_pipeline: pathlib.Path) -> None:
+    """Params class is introspected from function signature."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train")
+    params = info["params"]
+    assert params is not None
+    assert params.__class__.__name__ == "TrainParams"
+
+
+def test_params_values_from_yaml_override_defaults(params_pipeline: pathlib.Path) -> None:
+    """Params values from pivot.yaml override class defaults."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train")
+    params = info["params"]
+    assert params is not None, "Expected params to be set"
+
+    # These should be overridden by pivot.yaml
+    assert params.model_dump()["learning_rate"] == 0.05
+    assert params.model_dump()["epochs"] == 50
+    # This should be the class default (not in pivot.yaml)
+    assert params.model_dump()["batch_size"] == 32
+
+
+def test_stage_without_params_has_none(simple_pipeline: pathlib.Path) -> None:
+    """Stage without params parameter has params=None."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert info["params"] is None
+
+
+def test_error_if_params_in_yaml_but_no_signature(simple_pipeline: pathlib.Path) -> None:
+    """Error if pivot.yaml has params but function has no params parameter."""
+    # Modify the config to add params to preprocess (which has no params parameter)
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config_text = pipeline_file.read_text()
+    config_text = config_text.replace(
+        "python: stages.preprocess",
+        "python: stages.preprocess\n    params:\n      foo: bar",
+    )
+    pipeline_file.write_text(config_text)
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no 'params' parameter"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_error_if_params_parameter_has_no_type_hint(
+    params_pipeline: pathlib.Path,
+) -> None:
+    """Error if function has params parameter without type hint."""
+    # Create a stage with untyped params
+    stages_file = params_pipeline / "stages.py"
+    content = stages_file.read_text()
+    content = content.replace("def train(params: TrainParams)", "def train(params)")
+    stages_file.write_text(content)
+
+    # Need to reload the module
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    pipeline_file = params_pipeline / "pivot.yaml"
+    with pytest.raises(pipeline_config.PipelineConfigError, match="type hint"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Matrix Expansion Tests
+# =============================================================================
+
+
+def test_matrix_expands_to_variants(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix config expands to multiple variant stages."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+
+    # Should have preprocess + 4 train variants (2 models x 2 datasets)
+    assert "preprocess" in stages
+    assert "train@bert_swe" in stages
+    assert "train@bert_human" in stages
+    assert "train@gpt_swe" in stages
+    assert "train@gpt_human" in stages
+    assert len(stages) == 5
+
+
+def test_matrix_variant_has_interpolated_deps(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in deps."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    deps_str = " ".join(info["deps"])
+
+    assert "configs/bert.yaml" in deps_str
+    # Should NOT have ${model} or ${dataset} - should be interpolated
+    assert "${model}" not in deps_str
+    assert "${dataset}" not in deps_str
+
+
+def test_matrix_variant_has_interpolated_outs(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in outs."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    outs_str = " ".join(info["outs_paths"])
+
+    assert "models/bert_swe.pkl" in outs_str
+    assert "${model}" not in outs_str
+
+
+def test_matrix_variant_has_interpolated_params(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in params values."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    params = info["params"]
+    assert params is not None
+
+    assert params.model_dump()["model_type"] == "bert"
+
+
+def test_matrix_dict_dimension_applies_overrides(matrix_pipeline: pathlib.Path) -> None:
+    """Dict dimension applies overrides to specific variants."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert_swe")
+    gpt_info = registry.REGISTRY.get("train@gpt_swe")
+    bert_params = bert_info["params"]
+    gpt_params = gpt_info["params"]
+    assert bert_params is not None
+    assert gpt_params is not None
+
+    # bert has hidden_size=768, gpt has hidden_size=1024
+    assert bert_params.model_dump()["hidden_size"] == 768
+    assert gpt_params.model_dump()["hidden_size"] == 1024
+
+
+def test_matrix_append_override_adds_deps(matrix_pipeline: pathlib.Path) -> None:
+    """deps+ override appends to deps list."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    gpt_info = registry.REGISTRY.get("train@gpt_swe")
+    deps_str = " ".join(gpt_info["deps"])
+
+    # gpt variants should have the extra dep
+    assert "data/gpt_tokenizer.json" in deps_str
+
+    # bert variants should NOT have it
+    bert_info = registry.REGISTRY.get("train@bert_swe")
+    bert_deps_str = " ".join(bert_info["deps"])
+    assert "data/gpt_tokenizer.json" not in bert_deps_str
+
+
+def test_matrix_list_dimension_uses_value_as_key(matrix_pipeline: pathlib.Path) -> None:
+    """List dimension uses primitive value as key (no overrides)."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    # Both swe and human variants should exist
+    assert "train@bert_swe" in registry.REGISTRY.list_stages()
+    assert "train@bert_human" in registry.REGISTRY.list_stages()
+
+
+# =============================================================================
+# DAG Building Tests
+# =============================================================================
+
+
+def test_dag_built_from_registered_stages(simple_pipeline: pathlib.Path) -> None:
+    """DAG can be built from registered stages."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    dag = registry.REGISTRY.build_dag()
+
+    # train depends on preprocess (via data/clean.csv)
+    assert dag.has_edge("train", "preprocess")
+
+
+def test_matrix_dag_has_correct_dependencies(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variants have correct dependencies in DAG."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    dag = registry.REGISTRY.build_dag()
+
+    # All train variants depend on preprocess (via data/clean.csv)
+    assert dag.has_edge("train@bert_swe", "preprocess")
+    assert dag.has_edge("train@gpt_human", "preprocess")
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+def test_load_nonexistent_file_raises(tmp_path: pathlib.Path) -> None:
+    """Loading a non-existent file raises PipelineConfigError."""
+    with pytest.raises(pipeline_config.PipelineConfigError, match="not found"):
+        pipeline_config.load_pipeline_file(tmp_path / "nonexistent.yaml")
+
+
+def test_load_empty_file_raises(tmp_path: pathlib.Path) -> None:
+    """Loading an empty file raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text("")
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_load_invalid_yaml_raises(tmp_path: pathlib.Path) -> None:
+    """Loading invalid YAML structure raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text("stages: not_a_dict")
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="Invalid"):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_cwd_with_path_traversal_raises(tmp_path: pathlib.Path) -> None:
+    """cwd with path traversal (..) raises validation error."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.getcwd
+    outs: [out.txt]
+    cwd: "../escape"
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="\\.\\."):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_import_function_invalid_path_raises(tmp_path: pathlib.Path) -> None:
+    """Import path without dot raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: no_module_path
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="module.function"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_nonexistent_module_raises(tmp_path: pathlib.Path) -> None:
+    """Importing from non-existent module raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: nonexistent_module_xyz.func
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="import module"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_nonexistent_function_raises(tmp_path: pathlib.Path) -> None:
+    """Importing non-existent function raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.nonexistent_function_xyz
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no function"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_non_callable_raises(tmp_path: pathlib.Path) -> None:
+    """Importing a non-callable raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.name
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="not callable"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Output Options Tests
+# =============================================================================
+
+
+def test_output_with_cache_false(simple_pipeline: pathlib.Path) -> None:
+    """Output with cache: false option is parsed correctly."""
+    from pivot import outputs
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps: [data/raw.csv]
+    outs:
+      - data/clean.csv: {cache: false}
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    out = info["outs"][0]
+    assert isinstance(out, outputs.Out)
+    assert out.cache is False
+
+
+def test_plot_with_options(simple_pipeline: pathlib.Path) -> None:
+    """Plot with x, y, template options is parsed correctly."""
+    from pivot import outputs
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps: [data/raw.csv]
+    outs: [data/clean.csv]
+    plots:
+      - plots/curve.json: {x: epoch, y: loss, template: linear}
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    plot_outs = [o for o in info["outs"] if isinstance(o, outputs.Plot)]
+    assert len(plot_outs) == 1
+    plot = plot_outs[0]
+    assert plot.x == "epoch"
+    assert plot.y == "loss"
+    assert plot.template == "linear"
+
+
+# =============================================================================
+# Matrix Error Tests
+# =============================================================================
+
+
+def test_matrix_empty_dimension_list_raises(simple_pipeline: pathlib.Path) -> None:
+    """Empty matrix dimension list raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    matrix:
+      model: []
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_empty_dimension_dict_raises(simple_pipeline: pathlib.Path) -> None:
+    """Empty matrix dimension dict raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    matrix:
+      model: {}
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_unresolved_variable_raises(simple_pipeline: pathlib.Path) -> None:
+    """Unresolved ${var} in deps/outs raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - "data/${unknown}.csv"
+    outs:
+      - models/out.pkl
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="unresolved"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_template_missing_dimensions_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name template missing matrix dimensions raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  "train@{model}":
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}_${dataset}.pkl"
+    matrix:
+      model:
+        - bert
+        - gpt
+      dataset:
+        - swe
+        - human
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="missing dimensions"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_template_unknown_variables_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name template with unknown variables raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  "train@{model}_{unknown}":
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        - bert
+        - gpt
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="unknown variables"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_with_at_but_no_template_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name with @ but no template variables raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train@variant:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no template"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Variants (Python Escape Hatch) Tests
+# =============================================================================
+
+
+def test_variants_function_registers_stages(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants function returns list of dicts to register."""
+    # Create a variants generator function
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return [
+        {"name": "v1", "deps": ["a.txt"], "outs": ["b.txt"]},
+        {"name": "v2", "deps": ["c.txt"], "outs": ["d.txt"]},
+    ]
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@v1" in stages
+    assert "train@v2" in stages
+
+
+def test_variants_function_not_list_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants function returning non-list raises PipelineConfigError."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return "not a list"
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="must return a list"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_variants_with_cwd(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants with cwd override is applied correctly."""
+    (simple_pipeline / "subdir").mkdir()
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return [
+        {"name": "v1", "deps": ["a.txt"], "outs": ["b.txt"], "cwd": "subdir"},
+    ]
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@v1")
+    assert "subdir" in str(info["cwd"])
+
+
+# =============================================================================
+# Matrix Override Tests (Additional Coverage)
+# =============================================================================
+
+
+def test_matrix_metrics_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override metrics list."""
+    from pivot import outputs
+
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    metrics:
+      - metrics/base.json
+    matrix:
+      model:
+        bert:
+          metrics:
+            - metrics/bert.json
+        gpt:
+          metrics+:
+            - metrics/gpt_extra.json
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    bert_metrics = [o for o in bert_info["outs"] if isinstance(o, outputs.Metric)]
+    gpt_metrics = [o for o in gpt_info["outs"] if isinstance(o, outputs.Metric)]
+
+    # bert has override (replaces)
+    assert len(bert_metrics) == 1
+    assert "bert.json" in bert_metrics[0].path
+
+    # gpt has append
+    assert len(gpt_metrics) == 2
+    metric_paths = " ".join(m.path for m in gpt_metrics)
+    assert "base.json" in metric_paths
+    assert "gpt_extra.json" in metric_paths
+
+
+def test_matrix_plots_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override plots list."""
+    from pivot import outputs
+
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    plots:
+      - plots/base.json
+    matrix:
+      model:
+        bert:
+          plots:
+            - plots/bert.json
+        gpt:
+          plots+:
+            - plots/gpt_extra.json
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    bert_plots = [o for o in bert_info["outs"] if isinstance(o, outputs.Plot)]
+    gpt_plots = [o for o in gpt_info["outs"] if isinstance(o, outputs.Plot)]
+
+    assert len(bert_plots) == 1
+    assert "bert.json" in bert_plots[0].path
+
+    assert len(gpt_plots) == 2
+
+
+def test_matrix_mutex_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override mutex list."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    mutex:
+      - gpu
+    matrix:
+      model:
+        bert:
+          mutex:
+            - cpu
+        gpt:
+          mutex+:
+            - memory
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    # bert has override (replaces)
+    assert bert_info["mutex"] == ["cpu"]
+
+    # gpt has append
+    assert "gpu" in gpt_info["mutex"]
+    assert "memory" in gpt_info["mutex"]
+
+
+def test_matrix_cwd_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override cwd."""
+    (simple_pipeline / "bert_dir").mkdir()
+    (simple_pipeline / "gpt_dir").mkdir()
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        bert:
+          cwd: bert_dir
+        gpt:
+          cwd: gpt_dir
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    assert "bert_dir" in str(bert_info["cwd"])
+    assert "gpt_dir" in str(gpt_info["cwd"])
+
+
+def test_matrix_outs_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override outs list."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/base.pkl
+    matrix:
+      model:
+        bert:
+          outs:
+            - models/bert_specific.pkl
+        gpt:
+          outs+:
+            - models/gpt_extra.pkl
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    # bert has override (replaces)
+    assert len(bert_info["outs_paths"]) == 1
+    assert "bert_specific.pkl" in bert_info["outs_paths"][0]
+
+    # gpt has append
+    assert len(gpt_info["outs_paths"]) == 2
+
+
+def test_matrix_interpolates_nested_params(simple_pipeline: pathlib.Path) -> None:
+    """Matrix interpolates ${dim} in nested params structures."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class TrainParams(pydantic.BaseModel):
+    config: dict
+
+def preprocess():
+    pass
+
+def train(params: TrainParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    params:
+      config:
+        model_name: "${model}"
+        paths:
+          - "path/${model}/a"
+          - "path/${model}/b"
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert")
+    params = info["params"]
+    assert params is not None
+
+    config = params.model_dump()["config"]
+    assert config["model_name"] == "bert"
+    assert config["paths"] == ["path/bert/a", "path/bert/b"]
+
+
+def test_matrix_interpolates_output_dict_keys(simple_pipeline: pathlib.Path) -> None:
+    """Matrix interpolates ${dim} in output dict keys."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl":
+          cache: false
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert")
+    assert "models/bert.pkl" in info["outs_paths"][0]
+
+
+# =============================================================================
+# Non-String Matrix Dimension Tests
+# =============================================================================
+
+
+def test_matrix_boolean_values(simple_pipeline: pathlib.Path) -> None:
+    """Boolean matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class FlagParams(pydantic.BaseModel):
+    enabled: bool
+
+def preprocess():
+    pass
+
+def train(params: FlagParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${flag}.pkl"
+    params:
+      enabled: "${flag}"
+    matrix:
+      flag:
+        - true
+        - false
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@True" in stages
+    assert "train@False" in stages
+
+    true_info = registry.REGISTRY.get("train@True")
+    false_info = registry.REGISTRY.get("train@False")
+
+    # Params should preserve boolean type
+    assert true_info["params"] is not None
+    assert false_info["params"] is not None
+    true_params = true_info["params"].model_dump()
+    false_params = false_info["params"].model_dump()
+    assert true_params["enabled"] is True
+    assert false_params["enabled"] is False
+
+    # Paths should use string conversion
+    assert "models/True.pkl" in true_info["outs_paths"][0]
+    assert "models/False.pkl" in false_info["outs_paths"][0]
+
+
+def test_matrix_integer_values(simple_pipeline: pathlib.Path) -> None:
+    """Integer matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class SizeParams(pydantic.BaseModel):
+    batch_size: int
+
+def preprocess():
+    pass
+
+def train(params: SizeParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/batch_${size}.pkl"
+    params:
+      batch_size: "${size}"
+    matrix:
+      size:
+        - 16
+        - 32
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@16" in stages
+    assert "train@32" in stages
+
+    info_16 = registry.REGISTRY.get("train@16")
+    info_32 = registry.REGISTRY.get("train@32")
+
+    # Params should preserve int type
+    assert info_16["params"] is not None
+    params_16 = info_16["params"].model_dump()
+    assert params_16["batch_size"] == 16
+    assert isinstance(params_16["batch_size"], int)
+
+    assert info_32["params"] is not None
+    params_32 = info_32["params"].model_dump()
+    assert params_32["batch_size"] == 32
+
+    # Paths should use string conversion
+    assert "models/batch_16.pkl" in info_16["outs_paths"][0]
+    assert "models/batch_32.pkl" in info_32["outs_paths"][0]
+
+
+def test_matrix_float_values(simple_pipeline: pathlib.Path) -> None:
+    """Float matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class LRParams(pydantic.BaseModel):
+    learning_rate: float
+
+def preprocess():
+    pass
+
+def train(params: LRParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/lr_${lr}.pkl"
+    params:
+      learning_rate: "${lr}"
+    matrix:
+      lr:
+        - 0.001
+        - 0.01
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@0.001" in stages
+    assert "train@0.01" in stages
+
+    info_001 = registry.REGISTRY.get("train@0.001")
+    info_01 = registry.REGISTRY.get("train@0.01")
+
+    # Params should preserve float type
+    assert info_001["params"] is not None
+    params_001 = info_001["params"].model_dump()
+    assert params_001["learning_rate"] == 0.001
+    assert isinstance(params_001["learning_rate"], float)
+
+    assert info_01["params"] is not None
+    params_01 = info_01["params"].model_dump()
+    assert params_01["learning_rate"] == 0.01
+
+    # Paths should use string conversion
+    assert "models/lr_0.001.pkl" in info_001["outs_paths"][0]
+    assert "models/lr_0.01.pkl" in info_01["outs_paths"][0]
+
+
+def test_matrix_mixed_interpolation(simple_pipeline: pathlib.Path) -> None:
+    """String containing ${var} uses string conversion, exact ${var} preserves type."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class MixedParams(pydantic.BaseModel):
+    rate: float
+    path: str
+
+def preprocess():
+    pass
+
+def train(params: MixedParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    params:
+      rate: "${lr}"
+      path: "models/${lr}.pkl"
+    matrix:
+      lr:
+        - 0.001
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@0.001")
+
+    # Params validation
+    assert info["params"] is not None
+    params = info["params"].model_dump()
+
+    # Exact match preserves type
+    assert params["rate"] == 0.001
+    assert isinstance(params["rate"], float)
+
+    # String with interpolation becomes string
+    assert params["path"] == "models/0.001.pkl"
+    assert isinstance(params["path"], str)

--- a/tests/fixtures/pipeline_config/simple/pivot.yaml
+++ b/tests/fixtures/pipeline_config/simple/pivot.yaml
@@ -1,0 +1,14 @@
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps:
+      - data/raw.csv
+    outs:
+      - data/clean.csv
+
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/model.pkl

--- a/tests/fixtures/pipeline_config/simple/stages.py
+++ b/tests/fixtures/pipeline_config/simple/stages.py
@@ -1,0 +1,19 @@
+"""Simple stage functions for testing pivot.yaml loading."""
+
+from __future__ import annotations
+
+
+def preprocess() -> None:
+    """Read raw data and write clean data."""
+    with open("data/raw.csv") as f:
+        content = f.read()
+    with open("data/clean.csv", "w") as f:
+        f.write(content.upper())
+
+
+def train() -> None:
+    """Read clean data and write model."""
+    with open("data/clean.csv") as f:
+        content = f.read()
+    with open("models/model.pkl", "w") as f:
+        f.write(f"MODEL:{len(content)}")

--- a/tests/fixtures/pipeline_config/with_matrix/pivot.yaml
+++ b/tests/fixtures/pipeline_config/with_matrix/pivot.yaml
@@ -1,0 +1,34 @@
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps:
+      - data/raw.csv
+    outs:
+      - data/clean.csv
+
+  # Matrix with auto-naming: train@bert_swe, train@bert_human, train@gpt_swe, train@gpt_human
+  train:
+    python: stages.train
+    matrix:
+      model:
+        bert:
+          params:
+            hidden_size: 768
+        gpt:
+          deps+:
+            - data/gpt_tokenizer.json
+          params:
+            hidden_size: 1024
+      dataset:
+        - swe
+        - human
+    deps:
+      - data/clean.csv
+      - configs/${model}.yaml
+    outs:
+      - models/${model}_${dataset}.pkl
+    metrics:
+      - metrics/${model}_${dataset}.json
+    params:
+      model_type: ${model}
+      learning_rate: 0.001

--- a/tests/fixtures/pipeline_config/with_matrix/stages.py
+++ b/tests/fixtures/pipeline_config/with_matrix/stages.py
@@ -1,0 +1,54 @@
+"""Stage functions with matrix support for testing pivot.yaml loading."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+import pydantic
+
+
+class TrainParams(pydantic.BaseModel):
+    """Parameters for training."""
+
+    learning_rate: float = 0.01
+    model_type: str = "default"
+    hidden_size: int = 512
+
+
+def preprocess() -> None:
+    """Read raw data and write clean data."""
+    with open("data/raw.csv") as f:
+        content = f.read()
+    with open("data/clean.csv", "w") as f:
+        f.write(content.upper())
+
+
+def train(params: TrainParams) -> None:
+    """Train model with params - works for any variant."""
+    data_files = glob.glob("data/*.csv")
+    total_size = 0
+    for df in data_files:
+        with open(df) as f:
+            total_size += len(f.read())
+
+    result = {
+        "model_type": params.model_type,
+        "learning_rate": params.learning_rate,
+        "hidden_size": params.hidden_size,
+        "data_size": total_size,
+    }
+
+    os.makedirs("models", exist_ok=True)
+    os.makedirs("metrics", exist_ok=True)
+
+    # Find the output file from environment or use default
+    model_out = os.environ.get("PIVOT_OUT_MODEL", "models/model.pkl")
+    metrics_out = os.environ.get("PIVOT_OUT_METRICS", "metrics/train.json")
+
+    with open(model_out, "w") as f:
+        f.write(json.dumps(result))
+
+    with open(metrics_out, "w") as f:
+        json.dump({"loss": 0.1 / params.learning_rate, "accuracy": 0.95}, f)

--- a/tests/fixtures/pipeline_config/with_params/pivot.yaml
+++ b/tests/fixtures/pipeline_config/with_params/pivot.yaml
@@ -1,0 +1,19 @@
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps:
+      - data/raw.csv
+    outs:
+      - data/clean.csv
+
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/model.pkl
+    metrics:
+      - metrics/train.json
+    params:
+      learning_rate: 0.05
+      epochs: 50

--- a/tests/fixtures/pipeline_config/with_params/stages.py
+++ b/tests/fixtures/pipeline_config/with_params/stages.py
@@ -1,0 +1,42 @@
+"""Stage functions with Pydantic params for testing pivot.yaml loading."""
+
+from __future__ import annotations
+
+import json
+
+import pydantic
+
+
+class TrainParams(pydantic.BaseModel):
+    """Parameters for training."""
+
+    learning_rate: float = 0.01
+    epochs: int = 100
+    batch_size: int = 32
+
+
+def preprocess() -> None:
+    """Read raw data and write clean data."""
+    with open("data/raw.csv") as f:
+        content = f.read()
+    with open("data/clean.csv", "w") as f:
+        f.write(content.upper())
+
+
+def train(params: TrainParams) -> None:
+    """Train model with params."""
+    with open("data/clean.csv") as f:
+        content = f.read()
+
+    result = {
+        "model": f"trained_with_lr={params.learning_rate}",
+        "epochs": params.epochs,
+        "batch_size": params.batch_size,
+        "data_size": len(content),
+    }
+
+    with open("models/model.pkl", "w") as f:
+        f.write(json.dumps(result))
+
+    with open("metrics/train.json", "w") as f:
+        json.dump({"loss": 0.1, "accuracy": 0.95}, f)


### PR DESCRIPTION
## Summary

Add native `pivot.yaml` configuration format for defining pipeline stages with YAML instead of Python decorators. This enables declarative pipeline definitions while maintaining full type safety through Pydantic validation.

Closes #65 

### Key Features
- **YAML-based stage definitions**: Define stages with `python`, `deps`, `outs`, `params` fields
- **Matrix expansion**: Create variant stages from dimension combinations (e.g., `model × dataset`)
- **Python escape hatch**: Use `variants` function for dynamic configuration when YAML isn't enough
- **Strict validation**: Pydantic `extra='forbid'` catches typos in field names
- **Variable interpolation**: `${var}` syntax with validation for unresolved variables
- **Output types**: Support for regular outputs, metrics, and plots
- **Working directory**: `cwd` field for stage-specific working directories

### Example
```yaml
stages:
  preprocess:
    python: stages.preprocess
    deps: [data/raw.csv]
    outs: [data/clean.csv]
  
  train:
    python: stages.train
    deps: [data/clean.csv]
    outs: [models/${model}.pkl]
    params:
      learning_rate: 0.05
    matrix:
      model: [bert, gpt]
```

## Test Plan
- [x] All 879 tests pass
- [x] 22 new tests covering simple, params, and matrix configurations
- [x] Tests for error cases (missing params, invalid types, unresolved variables)
- [x] Quality checks pass (ruff format, ruff check, basedpyright)

## Notes for Reviewers
- `pipeline_config.py` uses Pydantic models for automatic validation at YAML load time
- `Callable` import kept at runtime (not in TYPE_CHECKING) because Pydantic needs it
- `_make_output_with_options()` handles Plot-specific options (x, y, template) separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)