### PR TITLE
feat: add TUI display mode for pivot run (Issue #79)

### DIFF
--- a/src/pivot/run_tui.py
+++ b/src/pivot/run_tui.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import collections
+import dataclasses
+import queue
+import threading
+from typing import TYPE_CHECKING, Any, ClassVar, override
+
+import textual.app
+import textual.binding
+import textual.containers
+import textual.message
+import textual.widgets
+
+from pivot import executor
+from pivot.types import (
+    DisplayMode,
+    StageStatus,
+    TuiLogMessage,
+    TuiMessage,
+    TuiStatusMessage,
+)
+
+if TYPE_CHECKING:
+    import multiprocessing as mp
+    from collections.abc import Callable
+
+
+def _format_elapsed(elapsed: float | None) -> str:
+    """Format elapsed time as (M:SS) or empty string if None."""
+    if elapsed is None:
+        return ""
+    mins, secs = divmod(int(elapsed), 60)
+    return f"({mins}:{secs:02d})"
+
+
+# Status display with colors
+STATUS_STYLES: dict[StageStatus, tuple[str, str]] = {
+    StageStatus.READY: ("PENDING", "dim"),
+    StageStatus.IN_PROGRESS: ("RUNNING", "blue bold"),
+    StageStatus.COMPLETED: ("SUCCESS", "green bold"),
+    StageStatus.RAN: ("SUCCESS", "green bold"),
+    StageStatus.SKIPPED: ("SKIP", "yellow"),
+    StageStatus.FAILED: ("FAILED", "red bold"),
+    StageStatus.UNKNOWN: ("UNKNOWN", "dim"),
+}
+
+
+@dataclasses.dataclass
+class StageInfo:
+    """Mutable state for a single stage."""
+
+    name: str
+    index: int
+    total: int
+    status: StageStatus = StageStatus.READY
+    reason: str = ""
+    elapsed: float | None = None
+    logs: collections.deque[tuple[str, bool]] = dataclasses.field(
+        default_factory=lambda: collections.deque(maxlen=1000)
+    )
+
+
+class TuiUpdate(textual.message.Message):
+    """Custom message for executor updates."""
+
+    msg: TuiLogMessage | TuiStatusMessage
+
+    def __init__(self, msg: TuiLogMessage | TuiStatusMessage) -> None:
+        self.msg = msg
+        super().__init__()
+
+
+class ExecutorComplete(textual.message.Message):
+    """Signal that executor has finished."""
+
+    results: dict[str, executor.ExecutionSummary]
+    error: Exception | None
+
+    def __init__(
+        self, results: dict[str, executor.ExecutionSummary], error: Exception | None
+    ) -> None:
+        self.results = results
+        self.error = error
+        super().__init__()
+
+
+class StageRow(textual.widgets.Static):
+    """Single stage row showing index, name, status, and reason."""
+
+    _info: StageInfo
+
+    def __init__(self, info: StageInfo) -> None:
+        super().__init__()
+        self._info = info
+
+    def update_display(self) -> None:  # pragma: no cover
+        label, style = STATUS_STYLES.get(self._info.status, ("?", "dim"))
+        index_str = f"[{self._info.index}/{self._info.total}]"
+        elapsed_str = _format_elapsed(self._info.elapsed)
+        if elapsed_str:
+            elapsed_str = f" {elapsed_str}"
+        reason_str = f"  ({self._info.reason})" if self._info.reason else ""
+        text = f"{index_str} {self._info.name:<20} [{style}]{label}[/]{elapsed_str}{reason_str}"
+        self.update(text)
+
+    def on_mount(self) -> None:  # pragma: no cover
+        self.update_display()
+
+
+class StageListPanel(textual.widgets.Static):
+    """Panel showing all stages with their status."""
+
+    _stages: list[StageInfo]
+    _rows: dict[str, StageRow]
+
+    def __init__(self, stages: list[StageInfo], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._stages = stages
+        self._rows = {}
+
+    @override
+    def compose(self) -> textual.app.ComposeResult:  # pragma: no cover
+        yield textual.widgets.Static("[bold]Stages[/]", classes="section-header")
+        for stage in self._stages:
+            row = StageRow(stage)
+            self._rows[stage.name] = row
+            yield row
+
+    def update_stage(self, name: str) -> None:  # pragma: no cover
+        if name in self._rows:
+            self._rows[name].update_display()
+
+
+class DetailPanel(textual.widgets.Static):
+    """Panel showing details of selected stage."""
+
+    _stage: StageInfo | None
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._stage = None
+
+    def set_stage(self, stage: StageInfo | None) -> None:  # pragma: no cover
+        self._stage = stage
+        self._update_display()
+
+    def _update_display(self) -> None:  # pragma: no cover
+        if self._stage is None:
+            self.update("[dim]No stage selected[/]")
+            return
+
+        label, style = STATUS_STYLES.get(self._stage.status, ("?", "dim"))
+        elapsed_str = _format_elapsed(self._stage.elapsed)
+        if elapsed_str:
+            elapsed_str = f" {elapsed_str} elapsed"
+
+        lines = [
+            f"[bold]Stage:[/] {self._stage.name}",
+            f"[bold]Status:[/] [{style}]{label}[/]{elapsed_str}",
+        ]
+        if self._stage.reason:
+            lines.append(f"[bold]Reason:[/] {self._stage.reason}")
+
+        self.update("\n".join(lines))
+
+
+class LogPanel(textual.widgets.RichLog):
+    """Panel showing streaming logs."""
+
+    _filter_stage: str | None
+    _all_logs: collections.deque[tuple[str, str, bool]]
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(highlight=True, markup=True, **kwargs)
+        self._filter_stage = None
+        self._all_logs = collections.deque(maxlen=5000)
+
+    def add_log(self, stage: str, line: str, is_stderr: bool) -> None:  # pragma: no cover
+        self._all_logs.append((stage, line, is_stderr))
+        if self._filter_stage is None or self._filter_stage == stage:
+            self._write_log_line(stage, line, is_stderr)
+
+    def _write_log_line(self, stage: str, line: str, is_stderr: bool) -> None:  # pragma: no cover
+        prefix = f"[cyan][{stage}][/] "
+        if is_stderr:
+            self.write(f"{prefix}[red]{line}[/]")
+        else:
+            self.write(f"{prefix}{line}")
+
+    def set_filter(self, stage: str | None) -> None:  # pragma: no cover
+        """Filter logs to a specific stage or show all (None)."""
+        self._filter_stage = stage
+        self.clear()
+        for s, line, is_stderr in self._all_logs:
+            if stage is None or s == stage:
+                self._write_log_line(s, line, is_stderr)
+
+
+class RunTuiApp(textual.app.App[dict[str, executor.ExecutionSummary] | None]):
+    """TUI for pipeline execution."""
+
+    CSS: ClassVar[str] = """
+    #stage-list {
+        height: auto;
+        max-height: 50%;
+        border: solid green;
+        padding: 1;
+    }
+
+    #detail-panel {
+        height: auto;
+        border: solid blue;
+        padding: 1;
+        margin-top: 1;
+    }
+
+    #log-panel {
+        height: 1fr;
+        border: solid yellow;
+        margin-top: 1;
+    }
+
+    .section-header {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #status-view {
+        height: 100%;
+    }
+
+    #logs-view {
+        height: 100%;
+        display: none;
+    }
+
+    .view-active {
+        display: block;
+    }
+
+    .view-hidden {
+        display: none;
+    }
+    """
+
+    BINDINGS: ClassVar[list[textual.binding.BindingType]] = [
+        textual.binding.Binding("q", "quit", "Quit"),
+        textual.binding.Binding("j", "next_stage", "Next"),
+        textual.binding.Binding("k", "prev_stage", "Prev"),
+        textual.binding.Binding("down", "next_stage", "Next", show=False),
+        textual.binding.Binding("up", "prev_stage", "Prev", show=False),
+        textual.binding.Binding("tab", "toggle_view", "Toggle View"),
+        textual.binding.Binding("a", "show_all_logs", "All Logs"),
+        *[
+            textual.binding.Binding(str(i), f"filter_stage({i - 1})", f"Stage {i}", show=False)
+            for i in range(1, 10)
+        ],
+    ]
+
+    _stage_names: list[str]
+    _tui_queue: mp.Queue[TuiMessage]
+    _executor_func: Callable[[], dict[str, executor.ExecutionSummary]]
+    _stages: dict[str, StageInfo]
+    _stage_order: list[str]
+    _selected_idx: int
+    _show_logs: bool
+    _results: dict[str, executor.ExecutionSummary] | None
+    _error: Exception | None
+    _reader_thread: threading.Thread | None
+    _executor_thread: threading.Thread | None
+    _shutdown_event: threading.Event
+
+    def __init__(
+        self,
+        stage_names: list[str],
+        message_queue: mp.Queue[TuiMessage],
+        executor_func: Callable[[], dict[str, executor.ExecutionSummary]],
+    ) -> None:
+        super().__init__()
+        self._stage_names = stage_names
+        self._tui_queue = message_queue
+        self._executor_func = executor_func
+
+        # Stage state
+        self._stages = {}
+        self._stage_order = []
+        for i, name in enumerate(stage_names, 1):
+            info = StageInfo(name, i, len(stage_names))
+            self._stages[name] = info
+            self._stage_order.append(name)
+
+        self._selected_idx = 0
+        self._show_logs = False
+        self._results = None
+        self._error = None
+
+        # Threading
+        self._reader_thread = None
+        self._executor_thread = None
+        self._shutdown_event = threading.Event()
+
+    @override
+    def compose(self) -> textual.app.ComposeResult:  # pragma: no cover
+        yield textual.widgets.Header()
+
+        # Status view (default)
+        with textual.containers.VerticalScroll(id="status-view", classes="view-active"):
+            yield StageListPanel(list(self._stages.values()), id="stage-list")
+            yield DetailPanel(id="detail-panel")
+
+        # Logs view (hidden by default)
+        with textual.containers.Vertical(id="logs-view", classes="view-hidden"):
+            yield LogPanel(id="log-panel")
+
+        yield textual.widgets.Footer()
+
+    async def on_mount(self) -> None:  # pragma: no cover
+        self._update_detail_panel()
+
+        # Start background threads
+        self._reader_thread = threading.Thread(target=self._read_queue, daemon=True)
+        self._reader_thread.start()
+
+        self._executor_thread = threading.Thread(target=self._run_executor, daemon=True)
+        self._executor_thread.start()
+
+    def _read_queue(self) -> None:  # pragma: no cover
+        """Read from queue and post messages to Textual (runs in background thread)."""
+        while not self._shutdown_event.is_set():
+            try:
+                msg = self._tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                self.post_message(TuiUpdate(msg))
+            except queue.Empty:
+                continue
+
+    def _run_executor(self) -> None:  # pragma: no cover
+        """Run the executor (runs in background thread)."""
+        results: dict[str, executor.ExecutionSummary] = {}
+        error: Exception | None = None
+        try:
+            results = self._executor_func()
+        except Exception as e:
+            error = e
+        finally:
+            self._tui_queue.put(None)
+            self.post_message(ExecutorComplete(results, error))
+
+    def on_tui_update(self, event: TuiUpdate) -> None:  # pragma: no cover
+        """Handle executor updates in Textual's event loop."""
+        msg = event.msg
+        if msg["type"] == "log":
+            self._handle_log(msg)
+        elif msg["type"] == "status":
+            self._handle_status(msg)
+
+    def _handle_log(self, msg: TuiLogMessage) -> None:  # pragma: no cover
+        stage = msg["stage"]
+        line = msg["line"]
+        is_stderr = msg["is_stderr"]
+
+        # Add to stage's log buffer
+        if stage in self._stages:
+            self._stages[stage].logs.append((line, is_stderr))
+
+        # Add to log panel
+        log_panel = self.query_one("#log-panel", LogPanel)
+        log_panel.add_log(stage, line, is_stderr)
+
+    def _handle_status(self, msg: TuiStatusMessage) -> None:  # pragma: no cover
+        stage = msg["stage"]
+        if stage not in self._stages:
+            return
+
+        info = self._stages[stage]
+        info.status = msg["status"]
+        info.reason = msg["reason"]
+        info.elapsed = msg["elapsed"]
+
+        # Update UI
+        stage_list = self.query_one("#stage-list", StageListPanel)
+        stage_list.update_stage(stage)
+        self._update_detail_panel()
+
+        # Update title with progress
+        completed = sum(
+            1
+            for s in self._stages.values()
+            if s.status
+            in (StageStatus.COMPLETED, StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED)
+        )
+        # Textual's Reactive[str] title doesn't work with strict type checking
+        self.title = f"pivot run ({completed}/{len(self._stages)})"  # pyright: ignore[reportUnannotatedClassAttribute]
+
+    def on_executor_complete(self, event: ExecutorComplete) -> None:  # pragma: no cover
+        """Handle executor completion."""
+        self._results = event.results
+        self._error = event.error
+        if event.error:
+            self.title = f"pivot run - FAILED: {event.error}"
+        else:
+            self.title = "pivot run - Complete"
+
+    def _update_detail_panel(self) -> None:  # pragma: no cover
+        if self._stage_order:
+            selected_name = self._stage_order[self._selected_idx]
+            stage = self._stages.get(selected_name)
+        else:
+            stage = None
+        detail = self.query_one("#detail-panel", DetailPanel)
+        detail.set_stage(stage)
+
+    def action_next_stage(self) -> None:  # pragma: no cover
+        if self._selected_idx < len(self._stage_order) - 1:
+            self._selected_idx += 1
+            self._update_detail_panel()
+
+    def action_prev_stage(self) -> None:  # pragma: no cover
+        if self._selected_idx > 0:
+            self._selected_idx -= 1
+            self._update_detail_panel()
+
+    def action_toggle_view(self) -> None:  # pragma: no cover
+        self._show_logs = not self._show_logs
+        status_view = self.query_one("#status-view")
+        logs_view = self.query_one("#logs-view")
+        if self._show_logs:
+            status_view.set_classes("view-hidden")
+            logs_view.set_classes("view-active")
+        else:
+            status_view.set_classes("view-active")
+            logs_view.set_classes("view-hidden")
+
+    def action_show_all_logs(self) -> None:  # pragma: no cover
+        log_panel = self.query_one("#log-panel", LogPanel)
+        log_panel.set_filter(None)
+        if not self._show_logs:
+            self.action_toggle_view()
+
+    def action_filter_stage(self, idx: int) -> None:  # pragma: no cover
+        """Filter logs to stage at index idx (0-based)."""
+        if idx < len(self._stage_order):
+            stage_name = self._stage_order[idx]
+            log_panel = self.query_one("#log-panel", LogPanel)
+            log_panel.set_filter(stage_name)
+            if not self._show_logs:
+                self.action_toggle_view()
+
+    @override
+    async def action_quit(self) -> None:  # pragma: no cover
+        self._shutdown_event.set()
+        await super().action_quit()
+
+
+def run_with_tui(
+    stage_names: list[str],
+    message_queue: mp.Queue[TuiMessage],
+    executor_func: Callable[[], dict[str, executor.ExecutionSummary]],
+) -> dict[str, executor.ExecutionSummary] | None:  # pragma: no cover
+    """Run pipeline with TUI display."""
+    app = RunTuiApp(stage_names, message_queue, executor_func)
+    return app.run()
+
+
+def should_use_tui(display_mode: DisplayMode | None) -> bool:
+    """Determine if TUI should be used based on display mode and TTY."""
+    import sys
+
+    if display_mode == DisplayMode.TUI:
+        return True
+    if display_mode == DisplayMode.PLAIN:
+        return False
+    # Auto-detect: use TUI if stdout is a TTY
+    return sys.stdout.isatty()

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -284,3 +284,39 @@ class DataDiffResult(TypedDict):
     reorder_only: bool  # True if same content, different row order
     truncated: bool  # True if large file, showing sample
     summary_only: bool  # True if no row-level diff available
+
+
+# =============================================================================
+# TUI Message Types
+# =============================================================================
+
+
+class DisplayMode(enum.StrEnum):
+    """Display mode for pivot run output."""
+
+    TUI = "tui"
+    PLAIN = "plain"
+
+
+class TuiLogMessage(TypedDict):
+    """Log line from worker process for TUI display."""
+
+    type: Literal["log"]
+    stage: str
+    line: str
+    is_stderr: bool
+
+
+class TuiStatusMessage(TypedDict):
+    """Stage status update for TUI display."""
+
+    type: Literal["status"]
+    stage: str
+    index: int
+    total: int
+    status: StageStatus
+    reason: str
+    elapsed: float | None
+
+
+TuiMessage = TuiLogMessage | TuiStatusMessage | None

--- a/tests/test_run_tui.py
+++ b/tests/test_run_tui.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import collections
+import multiprocessing as mp
+import pathlib
+import queue
+
+import pytest
+
+import pivot
+from pivot import executor, project, registry, run_tui
+from pivot.types import (
+    DisplayMode,
+    StageStatus,
+    TuiLogMessage,
+    TuiMessage,
+    TuiStatusMessage,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry() -> None:
+    """Reset registry before each test."""
+    registry.REGISTRY.clear()
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Set up a temporary pipeline directory."""
+    (tmp_path / ".pivot").mkdir()
+    monkeypatch.chdir(tmp_path)
+    project._project_root_cache = None
+    return tmp_path
+
+
+# =============================================================================
+# _format_elapsed Tests
+# =============================================================================
+
+
+def test_format_elapsed_none() -> None:
+    """_format_elapsed returns empty string for None."""
+    assert run_tui._format_elapsed(None) == ""
+
+
+def test_format_elapsed_seconds() -> None:
+    """_format_elapsed formats seconds correctly."""
+    assert run_tui._format_elapsed(5.0) == "(0:05)"
+    assert run_tui._format_elapsed(59.9) == "(0:59)"
+
+
+def test_format_elapsed_minutes() -> None:
+    """_format_elapsed formats minutes correctly."""
+    assert run_tui._format_elapsed(60.0) == "(1:00)"
+    assert run_tui._format_elapsed(125.5) == "(2:05)"
+
+
+def test_format_elapsed_large_values() -> None:
+    """_format_elapsed handles large values."""
+    assert run_tui._format_elapsed(3661.0) == "(61:01)"
+
+
+# =============================================================================
+# should_use_tui Tests
+# =============================================================================
+
+
+def test_should_use_tui_explicit_tui() -> None:
+    """should_use_tui returns True when display mode is TUI."""
+    assert run_tui.should_use_tui(DisplayMode.TUI) is True
+
+
+def test_should_use_tui_explicit_plain() -> None:
+    """should_use_tui returns False when display mode is PLAIN."""
+    assert run_tui.should_use_tui(DisplayMode.PLAIN) is False
+
+
+# =============================================================================
+# StageInfo Tests
+# =============================================================================
+
+
+def test_stage_info_initialization() -> None:
+    """StageInfo initializes with correct defaults."""
+    info = run_tui.StageInfo("test_stage", 1, 5)
+
+    assert info.name == "test_stage"
+    assert info.index == 1
+    assert info.total == 5
+    assert info.status == StageStatus.READY
+    assert info.reason == ""
+    assert info.elapsed is None
+    assert isinstance(info.logs, collections.deque)
+    assert len(info.logs) == 0
+
+
+def test_stage_info_logs_bounded() -> None:
+    """StageInfo logs deque has maxlen of 1000."""
+    info = run_tui.StageInfo("test", 1, 1)
+
+    for i in range(1500):
+        info.logs.append((f"line {i}", False))
+
+    assert len(info.logs) == 1000, "Logs should be bounded to 1000 entries"
+    assert info.logs[0] == ("line 500", False), "Oldest entries should be dropped"
+
+
+# =============================================================================
+# TuiUpdate Message Tests
+# =============================================================================
+
+
+def test_tui_update_with_log_message() -> None:
+    """TuiUpdate can wrap log messages."""
+    log_msg = TuiLogMessage(type="log", stage="test", line="output", is_stderr=False)
+    update = run_tui.TuiUpdate(log_msg)
+
+    assert update.msg == log_msg
+    assert update.msg["type"] == "log"
+
+
+def test_tui_update_with_status_message() -> None:
+    """TuiUpdate can wrap status messages."""
+    status_msg = TuiStatusMessage(
+        type="status",
+        stage="test",
+        index=1,
+        total=5,
+        status=StageStatus.IN_PROGRESS,
+        reason="",
+        elapsed=None,
+    )
+    update = run_tui.TuiUpdate(status_msg)
+
+    assert update.msg == status_msg
+    assert update.msg["type"] == "status"
+
+
+# =============================================================================
+# ExecutorComplete Message Tests
+# =============================================================================
+
+
+def test_executor_complete_success() -> None:
+    """ExecutorComplete stores results on success."""
+    results = {"stage1": executor.ExecutionSummary(status=StageStatus.RAN, reason="code changed")}
+    complete = run_tui.ExecutorComplete(results, error=None)
+
+    assert complete.results == results
+    assert complete.error is None
+
+
+def test_executor_complete_with_error() -> None:
+    """ExecutorComplete stores error on failure."""
+    error = ValueError("something went wrong")
+    complete = run_tui.ExecutorComplete({}, error=error)
+
+    assert complete.results == {}
+    assert complete.error is error
+
+
+# =============================================================================
+# RunTuiApp Initialization Tests
+# =============================================================================
+
+
+def test_run_tui_app_init() -> None:
+    """RunTuiApp initializes with stage names and queue."""
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+        stage_names = ["stage1", "stage2", "stage3"]
+
+        def executor_func() -> dict[str, executor.ExecutionSummary]:
+            return {}
+
+        app = run_tui.RunTuiApp(stage_names, tui_queue, executor_func)
+
+        assert app._stage_names == stage_names
+        assert len(app._stages) == 3
+        assert list(app._stage_order) == stage_names
+        assert app._selected_idx == 0
+        assert app._show_logs is False
+        assert app._results is None
+        assert app._error is None
+    finally:
+        manager.shutdown()
+
+
+def test_run_tui_app_stage_info_indexes() -> None:
+    """RunTuiApp assigns correct 1-based indexes to stages."""
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+        stage_names = ["first", "second", "third"]
+
+        def executor_func() -> dict[str, executor.ExecutionSummary]:
+            return {}
+
+        app = run_tui.RunTuiApp(stage_names, tui_queue, executor_func)
+
+        assert app._stages["first"].index == 1
+        assert app._stages["second"].index == 2
+        assert app._stages["third"].index == 3
+
+        for _name, info in app._stages.items():
+            assert info.total == 3
+    finally:
+        manager.shutdown()
+
+
+# =============================================================================
+# TUI Queue Integration Tests
+# =============================================================================
+
+
+def test_executor_emits_status_messages_to_queue(pipeline_dir: pathlib.Path) -> None:
+    """Executor emits TuiStatusMessage for stage start and completion."""
+    (pipeline_dir / "input.txt").write_text("hello")
+
+    @pivot.stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        pathlib.Path("output.txt").write_text("done")
+
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+
+        executor.run(show_output=False, tui_queue=tui_queue)
+
+        messages = list[TuiMessage]()
+        while True:
+            try:
+                msg = tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                messages.append(msg)
+            except queue.Empty:
+                break
+
+        status_messages = [m for m in messages if m is not None and m["type"] == "status"]
+
+        assert len(status_messages) >= 2, "Should have at least start and complete status"
+
+        start_msg = status_messages[0]
+        assert start_msg["stage"] == "process"
+        assert start_msg["status"] == StageStatus.IN_PROGRESS
+        assert start_msg["index"] == 1
+        assert start_msg["total"] == 1
+
+        end_msg = status_messages[-1]
+        assert end_msg["stage"] == "process"
+        assert end_msg["status"] in (StageStatus.RAN, StageStatus.SKIPPED, StageStatus.COMPLETED)
+        assert end_msg["elapsed"] is not None or end_msg["elapsed"] is None
+    finally:
+        manager.shutdown()
+
+
+def test_executor_emits_log_messages_to_queue(pipeline_dir: pathlib.Path) -> None:
+    """Executor emits TuiLogMessage for stage output."""
+    (pipeline_dir / "input.txt").write_text("hello")
+
+    @pivot.stage(deps=["input.txt"], outs=["output.txt"])
+    def process() -> None:
+        print("Processing data")
+        pathlib.Path("output.txt").write_text("done")
+
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+
+        executor.run(show_output=False, tui_queue=tui_queue)
+
+        messages = list[TuiMessage]()
+        while True:
+            try:
+                msg = tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                messages.append(msg)
+            except queue.Empty:
+                break
+
+        log_messages = [m for m in messages if m is not None and m["type"] == "log"]
+
+        assert len(log_messages) >= 1, "Should have at least one log message"
+        assert any("Processing data" in m["line"] for m in log_messages if m is not None), (
+            "Log should contain stdout"
+        )
+    finally:
+        manager.shutdown()
+
+
+def test_executor_emits_failed_status_on_stage_failure(pipeline_dir: pathlib.Path) -> None:
+    """Executor emits FAILED status when stage raises an exception."""
+    (pipeline_dir / "input.txt").write_text("hello")
+
+    @pivot.stage(deps=["input.txt"], outs=["output.txt"])
+    def failing_stage() -> None:
+        raise RuntimeError("Stage failed!")
+
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+
+        executor.run(show_output=False, tui_queue=tui_queue)
+
+        messages = list[TuiMessage]()
+        while True:
+            try:
+                msg = tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                messages.append(msg)
+            except queue.Empty:
+                break
+
+        status_messages = [m for m in messages if m is not None and m["type"] == "status"]
+
+        failed_msgs = [m for m in status_messages if m["status"] == StageStatus.FAILED]
+        assert len(failed_msgs) >= 1, "Should have at least one FAILED status message"
+        assert failed_msgs[0]["stage"] == "failing_stage"
+    finally:
+        manager.shutdown()
+
+
+def test_executor_emits_status_for_multiple_stages(pipeline_dir: pathlib.Path) -> None:
+    """Executor emits status messages for all stages in multi-stage pipeline."""
+    (pipeline_dir / "input.txt").write_text("hello")
+
+    @pivot.stage(deps=["input.txt"], outs=["step1.txt"])
+    def step1() -> None:
+        pathlib.Path("step1.txt").write_text("step1")
+
+    @pivot.stage(deps=["step1.txt"], outs=["step2.txt"])
+    def step2() -> None:
+        pathlib.Path("step2.txt").write_text("step2")
+
+    @pivot.stage(deps=["step2.txt"], outs=["step3.txt"])
+    def step3() -> None:
+        pathlib.Path("step3.txt").write_text("step3")
+
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+
+        executor.run(show_output=False, tui_queue=tui_queue)
+
+        messages = list[TuiMessage]()
+        while True:
+            try:
+                msg = tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                messages.append(msg)
+            except queue.Empty:
+                break
+
+        status_messages = [m for m in messages if m is not None and m["type"] == "status"]
+        stages_with_status = {m["stage"] for m in status_messages}
+
+        assert "step1" in stages_with_status
+        assert "step2" in stages_with_status
+        assert "step3" in stages_with_status
+    finally:
+        manager.shutdown()
+
+
+def test_executor_status_includes_correct_index_and_total(pipeline_dir: pathlib.Path) -> None:
+    """Executor status messages include correct index and total counts."""
+    (pipeline_dir / "input.txt").write_text("hello")
+
+    @pivot.stage(deps=["input.txt"], outs=["step1.txt"])
+    def step1() -> None:
+        pathlib.Path("step1.txt").write_text("step1")
+
+    @pivot.stage(deps=["step1.txt"], outs=["step2.txt"])
+    def step2() -> None:
+        pathlib.Path("step2.txt").write_text("step2")
+
+    manager = mp.Manager()
+    try:
+        tui_queue: mp.Queue[TuiMessage] = manager.Queue()  # pyright: ignore[reportAssignmentType]
+
+        executor.run(show_output=False, tui_queue=tui_queue)
+
+        messages = list[TuiMessage]()
+        while True:
+            try:
+                msg = tui_queue.get(timeout=0.1)
+                if msg is None:
+                    break
+                messages.append(msg)
+            except queue.Empty:
+                break
+
+        status_messages = [m for m in messages if m is not None and m["type"] == "status"]
+
+        for msg in status_messages:
+            assert msg["total"] == 2, "Total should be 2 stages"
+            assert msg["index"] in (1, 2), "Index should be 1 or 2"
+    finally:
+        manager.shutdown()
+
+
+# =============================================================================
+# STATUS_STYLES Tests
+# =============================================================================
+
+
+def test_status_styles_covers_all_statuses() -> None:
+    """STATUS_STYLES dict has entries for all relevant StageStatus values."""
+    assert StageStatus.READY in run_tui.STATUS_STYLES
+    assert StageStatus.IN_PROGRESS in run_tui.STATUS_STYLES
+    assert StageStatus.COMPLETED in run_tui.STATUS_STYLES
+    assert StageStatus.RAN in run_tui.STATUS_STYLES
+    assert StageStatus.SKIPPED in run_tui.STATUS_STYLES
+    assert StageStatus.FAILED in run_tui.STATUS_STYLES
+    assert StageStatus.UNKNOWN in run_tui.STATUS_STYLES
+
+
+def test_status_styles_returns_tuple() -> None:
+    """STATUS_STYLES values are (label, style) tuples."""
+    for status, (label, style) in run_tui.STATUS_STYLES.items():
+        assert isinstance(label, str), f"Label for {status} should be string"
+        assert isinstance(style, str), f"Style for {status} should be string"
+        assert len(label) > 0, f"Label for {status} should not be empty"


### PR DESCRIPTION
## Summary

Adds an interactive TUI display mode for `pivot run` with real-time stage status and streaming logs.

### Features
- **Stage status view**: Shows all stages with status (PENDING, RUNNING, SUCCESS, FAILED, SKIP), elapsed time, and trigger reasons
- **Logs view**: Streaming logs with per-stage filtering (keys 1-9) or all logs (key a)
- **Navigation**: j/k for stage selection, Tab to toggle views, q to quit
- **Auto-detection**: Uses TUI when stdout is TTY, plain text otherwise
- **CLI option**: `--display=tui|plain` to override auto-detection

### Bug Fixes & Improvements
- Fixed timeout status not being reported to TUI (continue statement was skipping emission)
- Added `StageState.index` field for O(1) lookup instead of O(n) `list().index()` calls
- Consolidated duplicated duration calculations in executor
- Extracted `_format_elapsed()` helper for DRY elapsed time formatting
- Replaced 9 filter methods with single parameterized `action_filter_stage(idx)`
- Fixed Manager lifetime - now properly stored and shutdown in finally block

### CLAUDE.md Updates
- Added error handling philosophy: "Let errors propagate, catch at appropriate boundaries"
- Added Enums vs Literals guidance: "Prefer enums for fixed sets of programmatic values"

## Test Plan
- [x] All 1274 tests pass
- [x] ruff format/check pass
- [x] basedpyright passes (1 warning for inherited Textual `title` attribute - expected)

## Notes for Reviewers
- TUI code is mostly `# pragma: no cover` since it's UI rendering code
- Uses `mp.Manager().Queue()` for loky compatibility (regular `mp.Queue()` can't be pickled)
- Thread architecture: Main (Textual) + queue reader thread + executor thread + worker processes

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)