### PR TITLE
fix: prevent TOCTOU race in stage execution skip decision

### DIFF
--- a/src/pivot/lock.py
+++ b/src/pivot/lock.py
@@ -158,8 +158,20 @@ class StageLock:
         current_params: dict[str, Any],
         dep_hashes: dict[str, HashInfo],
     ) -> tuple[bool, str]:
-        """Check if stage needs re-run."""
+        """Check if stage needs re-run (reads lock file)."""
         lock_data = self.read()
+        return self.is_changed_with_lock_data(
+            lock_data, current_fingerprint, current_params, dep_hashes
+        )
+
+    def is_changed_with_lock_data(
+        self,
+        lock_data: LockData | None,
+        current_fingerprint: dict[str, str],
+        current_params: dict[str, Any],
+        dep_hashes: dict[str, HashInfo],
+    ) -> tuple[bool, str]:
+        """Check if stage needs re-run (pure comparison, no I/O)."""
         if lock_data is None:
             return True, "No previous run"
 


### PR DESCRIPTION
## Summary

- Move lock data reading inside execution lock to prevent TOCTOU races
- Restructure `execute_stage()` with check-lock-recheck pattern
- Add `is_changed_with_lock_data()` pure method to `StageLock` for testability
- Consolidate skip logic into single `_check_skip_or_run()` function
- Rename `_try_generation_skip` → `_can_skip_via_generation` (returns `bool`)

## Test plan

- [x] All 1372 tests pass
- [x] Type checking passes with 0 errors, 0 warnings
- [x] Lint and format checks pass
- [x] Existing TOCTOU tests verify lock is acquired for skipped stages
- [x] Existing TOCTOU tests verify restoration happens inside lock

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)