### PR TITLE
perf: lazy command loading in CLI for fast --help (~0.2s)

### DIFF
--- a/src/pivot/cli/decorators.py
+++ b/src/pivot/cli/decorators.py
@@ -6,10 +6,17 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from pivot import exceptions
-from pivot.cli import errors as cli_errors
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+def _handle_pivot_error(e: exceptions.PivotError) -> click.ClickException:
+    """Convert PivotError to user-friendly ClickException."""
+    message = e.format_user_message()
+    if suggestion := e.get_suggestion():
+        message = f"{message}\n\nTip: {suggestion}"
+    return click.ClickException(message)
 
 
 def with_error_handling[**P, R](func: Callable[P, R]) -> Callable[P, R]:
@@ -30,7 +37,7 @@ def with_error_handling[**P, R](func: Callable[P, R]) -> Callable[P, R]:
         except click.ClickException:
             raise
         except exceptions.PivotError as e:
-            raise cli_errors.handle_pivot_error(e) from e
+            raise _handle_pivot_error(e) from e
         except Exception as e:
             raise click.ClickException(repr(e)) from e
 

--- a/tests/cli/test_cli_performance.py
+++ b/tests/cli/test_cli_performance.py
@@ -5,16 +5,16 @@ import time
 import pytest
 from click.testing import CliRunner
 
-from pivot.cli import cli
+from pivot.cli import _LAZY_COMMANDS, cli
 
 # Maximum allowed time for --help (in seconds)
-# This is generous to account for CI variability
-MAX_HELP_TIME_SECONDS = 2.0
+# With lazy command loading, --help should complete in ~0.2s
+MAX_HELP_TIME_SECONDS = 0.25
 
 
 def _get_all_commands() -> list[str]:
     """Get all top-level CLI commands."""
-    return list(cli.commands.keys())
+    return sorted(_LAZY_COMMANDS.keys())
 
 
 # Get commands at module load time for parametrization


### PR DESCRIPTION
## Summary
- Implements lazy command loading with cached help strings in `PivotGroup`
- Reduces `pivot --help` startup time from ~0.7s to ~0.19s (3.6x improvement)
- Updates performance tests to enforce 0.25s threshold

## Approach
Instead of loading all command modules at startup, the CLI now:
1. Stores command metadata (module path, attribute name, help text) in `_LAZY_COMMANDS` registry
2. Overrides `format_commands()` to use cached help strings without importing modules
3. Only imports command modules when actually invoked via `get_command()`

## Test plan
- [x] All 18 CLI performance tests pass with 0.25s threshold
- [x] Full test suite passes (1624 tests)
- [x] Manual verification: `time pivot --help` shows ~0.19s

🤖 Generated with [Claude Code](https://claude.com/claude-code)