### PR TITLE
feat: typed dependencies and outputs for StageDef (Issue #80)

### DIFF
--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -9,6 +9,8 @@ __version__ = "0.1.0-dev"
 # via their full paths (e.g., pivot.registry.REGISTRY) for advanced use
 
 if TYPE_CHECKING:
+    from pivot import loaders as loaders
+    from pivot import stage_def as stage_def
     from pivot.outputs import IncrementalOut as IncrementalOut
     from pivot.outputs import Metric as Metric
     from pivot.outputs import Out as Out
@@ -17,8 +19,10 @@ if TYPE_CHECKING:
     from pivot.registry import Variant as Variant
     from pivot.registry import stage as stage
 
-# Lazy import mapping for runtime
-_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+# Lazy import mapping for runtime: (module_path, attr_name or None for module import)
+_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    "loaders": ("pivot.loaders", None),
+    "stage_def": ("pivot.stage_def", None),
     "IncrementalOut": ("pivot.outputs", "IncrementalOut"),
     "Metric": ("pivot.outputs", "Metric"),
     "Out": ("pivot.outputs", "Out"),
@@ -36,7 +40,7 @@ def __getattr__(name: str) -> object:
         import importlib
 
         module = importlib.import_module(module_path)
-        value = getattr(module, attr_name)
+        value = module if attr_name is None else getattr(module, attr_name)
         # Cache in module globals for subsequent access
         globals()[name] = value
         return value

--- a/src/pivot/loaders.py
+++ b/src/pivot/loaders.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import abc
+import dataclasses
+import json
+import pathlib
+import pickle
+from typing import override
+
+import pandas
+import yaml
+
+
+@dataclasses.dataclass(frozen=True)
+class Loader[T](abc.ABC):
+    """Base class for file loaders providing typed dependency/output access.
+
+    Loaders are immutable, picklable, and their code is fingerprinted.
+    Changes to loader implementation trigger stage re-runs.
+    """
+
+    @abc.abstractmethod
+    def load(self, path: pathlib.Path) -> T:
+        """Load data from file path."""
+        ...
+
+    @abc.abstractmethod
+    def save(self, data: T, path: pathlib.Path) -> None:
+        """Save data to file path."""
+        ...
+
+
+@dataclasses.dataclass(frozen=True)
+class CSV[T](Loader[T]):
+    """CSV file loader using pandas.
+
+    Generic type parameter indicates the DataFrame type for type checking.
+    Always returns pandas.DataFrame at runtime.
+    """
+
+    index_col: int | str | None = None
+    sep: str = ","
+    dtype: dict[str, str] | None = None
+
+    @override
+    def load(self, path: pathlib.Path) -> T:
+        result = pandas.read_csv(  # pyright: ignore[reportUnknownMemberType] - pandas read_csv has complex overloads
+            path,
+            index_col=self.index_col,
+            sep=self.sep,
+            dtype=self.dtype,  # pyright: ignore[reportArgumentType] - dtype accepts more types at runtime
+        )
+        return result  # pyright: ignore[reportReturnType] - returns DataFrame, user specifies T for type checking
+
+    @override
+    def save(self, data: T, path: pathlib.Path) -> None:
+        if not isinstance(data, pandas.DataFrame):
+            raise TypeError(f"CSV loader expects DataFrame, got {type(data).__name__}")
+        data.to_csv(path, index=self.index_col is not None)
+
+
+@dataclasses.dataclass(frozen=True)
+class JSON[T](Loader[T]):
+    """JSON file loader.
+
+    Generic type parameter indicates the expected dict type for type checking.
+    Always returns dict at runtime.
+    """
+
+    indent: int | None = 2
+
+    @override
+    def load(self, path: pathlib.Path) -> T:
+        with open(path) as f:
+            return json.load(f)  # type: ignore[return-value] - json.load returns Any, user specifies T
+
+    @override
+    def save(self, data: T, path: pathlib.Path) -> None:
+        with open(path, "w") as f:
+            json.dump(data, f, indent=self.indent)
+
+
+@dataclasses.dataclass(frozen=True)
+class YAML[T](Loader[T]):
+    """YAML file loader.
+
+    Generic type parameter indicates the expected type for type checking.
+    Returns parsed YAML (typically dict) at runtime.
+    """
+
+    @override
+    def load(self, path: pathlib.Path) -> T:
+        with open(path) as f:
+            return yaml.safe_load(f)  # type: ignore[return-value] - yaml returns Any, user specifies T
+
+    @override
+    def save(self, data: T, path: pathlib.Path) -> None:
+        with open(path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+
+
+@dataclasses.dataclass(frozen=True)
+class Pickle[T](Loader[T]):
+    """Pickle file loader for arbitrary Python objects.
+
+    WARNING: Loading pickle files from untrusted sources is a security risk.
+    Pickle can execute arbitrary code during deserialization.
+    """
+
+    protocol: int = pickle.HIGHEST_PROTOCOL
+
+    @override
+    def load(self, path: pathlib.Path) -> T:
+        with open(path, "rb") as f:
+            return pickle.load(f)  # type: ignore[return-value] - pickle returns Any, user specifies T
+
+    @override
+    def save(self, data: T, path: pathlib.Path) -> None:
+        with open(path, "wb") as f:
+            pickle.dump(data, f, protocol=self.protocol)
+
+
+@dataclasses.dataclass(frozen=True)
+class PathOnly(Loader[pathlib.Path]):
+    """No-op loader that returns the path itself for manual loading.
+
+    Use when you need custom loading logic that doesn't fit standard loaders.
+    The save() method validates the file exists (user must create it manually).
+    """
+
+    @override
+    def load(self, path: pathlib.Path) -> pathlib.Path:
+        return path
+
+    @override
+    def save(self, data: pathlib.Path, path: pathlib.Path) -> None:
+        _ = data  # PathOnly doesn't save data; just validates file exists
+        if not path.exists():
+            raise FileNotFoundError(f"Output file not created: {path}")

--- a/src/pivot/stage_def.py
+++ b/src/pivot/stage_def.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import pathlib  # noqa: TC003 - used at runtime in _load/_save methods
+import sys
+import weakref
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    NamedTuple,
+    Protocol,
+    cast,
+    get_origin,
+    get_type_hints,
+    overload,
+    override,
+)
+
+import pydantic
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pivot import loaders
+
+
+class DepSpec(NamedTuple):
+    """Specification for a dependency."""
+
+    path: str
+    loader: loaders.Loader[Any]
+
+
+class OutSpec(NamedTuple):
+    """Specification for an output."""
+
+    path: str
+    loader: loaders.Loader[Any]
+
+
+class _BaseDescriptor[T]:
+    """Base descriptor for typed file access with WeakKeyDictionary storage."""
+
+    name: str
+    path: str
+    loader: loaders.Loader[T]
+    _data: weakref.WeakKeyDictionary[object, T]
+    _error_template: str
+
+    def __init__(
+        self, name: str, path: str, loader: loaders.Loader[T], error_template: str
+    ) -> None:
+        self.name = name
+        self.path = path
+        self.loader = loader
+        self._data = weakref.WeakKeyDictionary()
+        self._error_template = error_template
+
+    @overload
+    def __get__(self, obj: None, owner: type[object]) -> _BaseDescriptor[T]: ...
+
+    @overload
+    def __get__(self, obj: object, owner: type[object]) -> T: ...
+
+    def __get__(self, obj: object | None, owner: type[object]) -> _BaseDescriptor[T] | T:
+        if obj is None:
+            return self
+        if obj not in self._data:
+            raise RuntimeError(self._error_template.format(name=self.name))
+        return self._data[obj]
+
+    def _clear(self, obj: object) -> None:
+        """Clear data for the given instance."""
+        self._data.pop(obj, None)
+
+
+class DepDescriptor[T](_BaseDescriptor[T]):
+    """Descriptor for typed dependency access."""
+
+    def __init__(self, name: str, path: str, loader: loaders.Loader[T]) -> None:
+        super().__init__(
+            name, path, loader, "Dependency '{name}' not loaded - ensure _load_deps() was called"
+        )
+
+    def _load(self, obj: object, project_root: pathlib.Path) -> None:
+        """Load data for the given instance."""
+        full_path = project_root / self.path
+        data = self.loader.load(full_path)
+        self._data[obj] = data
+
+
+class OutDescriptor[T](_BaseDescriptor[T]):
+    """Descriptor for typed output access."""
+
+    def __init__(self, name: str, path: str, loader: loaders.Loader[T]) -> None:
+        super().__init__(
+            name, path, loader, "Output '{name}' not assigned - set it before calling _save_outs()"
+        )
+
+    def __set__(self, obj: object, value: T) -> None:
+        self._data[obj] = value
+        # Track assignment on the StageDef instance
+        parent: StageDef | None = getattr(obj, "_parent_stage_def", None)
+        if parent is not None:
+            parent._assigned_outs.add(self.name)  # pyright: ignore[reportPrivateUsage] - internal tracking
+
+    def _save(self, obj: object, project_root: pathlib.Path) -> None:
+        """Save data for the given instance."""
+        if obj not in self._data:
+            raise RuntimeError(f"Output '{self.name}' was never assigned")
+        full_path = project_root / self.path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        self.loader.save(self._data[obj], full_path)
+
+
+def _create_loader_from_annotation(
+    annotation: type[Any],
+) -> loaders.Loader[Any]:
+    """Create a loader instance from a type annotation like CSV[DataFrame]."""
+    from pivot import loaders
+
+    origin = get_origin(annotation)
+    if origin is None:
+        # Direct class reference (e.g., PathOnly without type param)
+        if issubclass(annotation, loaders.Loader):
+            return annotation()  # pyright: ignore[reportUnknownVariableType] - generic loader
+        raise TypeError(f"Invalid loader annotation: {annotation}")
+
+    # Generic type like CSV[DataFrame]
+    if isinstance(origin, type) and issubclass(origin, loaders.Loader):
+        return origin()  # pyright: ignore[reportUnknownVariableType] - generic loader
+
+    raise TypeError(f"Invalid loader annotation: {annotation}")
+
+
+def _process_nested_class(
+    nested_cls: type[object],
+    descriptor_cls: type[DepDescriptor[Any]] | type[OutDescriptor[Any]],
+    spec_cls: type[DepSpec] | type[OutSpec],
+    parent_globals: dict[str, Any],
+) -> tuple[dict[str, DepSpec | OutSpec], type[object]]:
+    """Process a nested deps/outs class and create descriptors."""
+    specs: dict[str, DepSpec | OutSpec] = {}
+
+    # Get annotations from the nested class, resolving string annotations
+    try:
+        annotations = get_type_hints(nested_cls, globalns=parent_globals)
+    except NameError:
+        # Forward reference couldn't be resolved - fall back to raw annotations
+        raw_annotations = getattr(nested_cls, "__annotations__", {})
+        # Check for unresolved string annotations
+        for name, ann in raw_annotations.items():
+            if isinstance(ann, str):
+                msg = f"Cannot resolve type annotation '{ann}' for '{name}'. "
+                msg += "Ensure all loader types are imported."
+                raise TypeError(msg) from None
+        annotations = raw_annotations
+
+    # Create a new namespace class with descriptors
+    namespace_dict: dict[str, DepDescriptor[Any] | OutDescriptor[Any] | Callable[..., None]] = {}
+
+    for name, annotation in annotations.items():
+        # Get default value (the path string)
+        default = getattr(nested_cls, name, None)
+        if default is None:
+            raise ValueError(f"Missing default path for '{name}'")
+
+        path = str(default)
+        loader = _create_loader_from_annotation(annotation)
+
+        specs[name] = spec_cls(path=path, loader=loader)
+        descriptor = descriptor_cls(name=name, path=path, loader=loader)
+        namespace_dict[name] = descriptor
+
+    # Add __init__ that takes parent reference
+    def namespace_init(self: _NamespaceInstance) -> None:
+        self._parent_stage_def = None  # pyright: ignore[reportPrivateUsage] - protocol attribute
+
+    namespace_dict["__init__"] = namespace_init
+
+    # Create namespace class dynamically
+    namespace_cls = type(f"{nested_cls.__name__}Namespace", (object,), namespace_dict)
+
+    return specs, namespace_cls
+
+
+class _NamespaceInstance(Protocol):
+    """Protocol for namespace instances that track their parent StageDef."""
+
+    _parent_stage_def: StageDef | None
+
+
+class _NamespaceDescriptor:
+    """Descriptor for accessing deps/outs namespace from class or instance."""
+
+    _cls_attr: str
+    _instance_attr: str
+    _name: str
+
+    def __init__(self, cls_attr: str, instance_attr: str, name: str) -> None:
+        self._cls_attr = cls_attr
+        self._instance_attr = instance_attr
+        self._name = name
+
+    @overload
+    def __get__(self, obj: None, owner: type[StageDef]) -> type[object]: ...
+
+    @overload
+    def __get__(self, obj: StageDef, owner: type[StageDef]) -> _NamespaceInstance: ...
+
+    def __get__(
+        self, obj: StageDef | None, owner: type[StageDef]
+    ) -> type[object] | _NamespaceInstance:
+        if obj is None:
+            # Class access - return the namespace class with descriptors
+            namespace_cls: type[object] | None = getattr(owner, self._cls_attr)
+            if namespace_cls is None:
+                raise AttributeError(f"No {self._name} defined for this StageDef")
+            return namespace_cls
+        # Instance access - return the instance namespace
+        namespace_instance: _NamespaceInstance | None = getattr(obj, self._instance_attr)
+        if namespace_instance is None:
+            raise AttributeError(f"No {self._name} defined for this StageDef")
+        return namespace_instance
+
+
+class StageDef(pydantic.BaseModel):
+    """Base class for stage definitions with typed deps/outs."""
+
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        ignored_types=(_NamespaceDescriptor,),
+    )
+
+    _deps_specs: ClassVar[dict[str, DepSpec]] = {}
+    _outs_specs: ClassVar[dict[str, OutSpec]] = {}
+    _deps_namespace_cls: ClassVar[type[object] | None] = None
+    _outs_namespace_cls: ClassVar[type[object] | None] = None
+
+    _deps_instance: _NamespaceInstance | None = pydantic.PrivateAttr(default=None)
+    _outs_instance: _NamespaceInstance | None = pydantic.PrivateAttr(default=None)
+    _assigned_outs: set[str] = pydantic.PrivateAttr(default_factory=set)
+
+    # Use parameterized descriptors for deps/outs access
+    deps: ClassVar[_NamespaceDescriptor] = _NamespaceDescriptor(
+        "_deps_namespace_cls", "_deps_instance", "dependencies"
+    )
+    outs: ClassVar[_NamespaceDescriptor] = _NamespaceDescriptor(
+        "_outs_namespace_cls", "_outs_instance", "outputs"
+    )
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
+        module = sys.modules.get(cls.__module__)
+        parent_globals = vars(module) if module else {}
+
+        # Process nested deps class if defined
+        nested_deps = cls.__dict__.get("deps")
+        if nested_deps is not None and isinstance(nested_deps, type):
+            specs, namespace_cls = _process_nested_class(
+                nested_deps, DepDescriptor, DepSpec, parent_globals
+            )
+            cls._deps_specs = cast("dict[str, DepSpec]", specs)
+            cls._deps_namespace_cls = namespace_cls
+            delattr(cls, "deps")
+        elif not hasattr(cls, "_deps_specs") or cls._deps_specs is StageDef._deps_specs:
+            cls._deps_specs = {}
+            cls._deps_namespace_cls = None
+
+        # Process nested outs class if defined
+        nested_outs = cls.__dict__.get("outs")
+        if nested_outs is not None and isinstance(nested_outs, type):
+            specs, namespace_cls = _process_nested_class(
+                nested_outs, OutDescriptor, OutSpec, parent_globals
+            )
+            cls._outs_specs = cast("dict[str, OutSpec]", specs)
+            cls._outs_namespace_cls = namespace_cls
+            delattr(cls, "outs")
+        elif not hasattr(cls, "_outs_specs") or cls._outs_specs is StageDef._outs_specs:
+            cls._outs_specs = {}
+            cls._outs_namespace_cls = None
+
+    @override
+    def model_post_init(self, context: Any) -> None:
+        """Initialize deps and outs namespace instances after pydantic init."""
+        if self._deps_namespace_cls is not None:
+            self._deps_instance = self._deps_namespace_cls()  # pyright: ignore[reportAttributeAccessIssue] - dynamic namespace class
+            self._deps_instance._parent_stage_def = self  # pyright: ignore[reportOptionalMemberAccess,reportPrivateUsage] - just assigned above, protocol attribute
+
+        if self._outs_namespace_cls is not None:
+            self._outs_instance = self._outs_namespace_cls()  # pyright: ignore[reportAttributeAccessIssue] - dynamic namespace class
+            self._outs_instance._parent_stage_def = self  # pyright: ignore[reportOptionalMemberAccess,reportPrivateUsage] - just assigned above, protocol attribute
+
+    def _load_deps(self, project_root: pathlib.Path) -> None:
+        """Load all dependencies from disk."""
+        if self._deps_namespace_cls is None or self._deps_instance is None:
+            return
+
+        loaded_names: list[str] = []
+        try:
+            for name in self._deps_specs:
+                descriptor = cast("DepDescriptor[Any]", getattr(self._deps_namespace_cls, name))
+                descriptor._load(self._deps_instance, project_root)  # pyright: ignore[reportPrivateUsage] - internal API
+                loaded_names.append(name)
+        except Exception:
+            # Clear any partially loaded state
+            for loaded_name in loaded_names:
+                descriptor = cast(
+                    "DepDescriptor[Any]", getattr(self._deps_namespace_cls, loaded_name)
+                )
+                descriptor._clear(self._deps_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+            raise
+
+    def _clear_deps(self) -> None:
+        """Clear all loaded dependency data."""
+        if self._deps_namespace_cls is None or self._deps_instance is None:
+            return
+        for name in self._deps_specs:
+            descriptor = cast("DepDescriptor[Any]", getattr(self._deps_namespace_cls, name))
+            descriptor._clear(self._deps_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+
+    def _clear_outs(self) -> None:
+        """Clear all output data."""
+        if self._outs_namespace_cls is None or self._outs_instance is None:
+            return
+        for name in self._outs_specs:
+            descriptor = cast("OutDescriptor[Any]", getattr(self._outs_namespace_cls, name))
+            descriptor._clear(self._outs_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+
+    def _save_outs(self, project_root: pathlib.Path) -> None:
+        """Save all outputs to disk."""
+        if self._outs_namespace_cls is None or self._outs_instance is None:
+            return
+
+        # Check all outputs were assigned
+        for name in self._outs_specs:
+            if name not in self._assigned_outs:
+                msg = f"Output '{name}' was declared but never assigned. "
+                msg += f"Assign a value to params.outs.{name} before the stage function returns."
+                raise RuntimeError(msg)
+
+        for name in self._outs_specs:
+            descriptor = cast("OutDescriptor[Any]", getattr(self._outs_namespace_cls, name))
+            descriptor._save(self._outs_instance, project_root)  # pyright: ignore[reportPrivateUsage] - internal API
+
+    @classmethod
+    def get_deps_paths(cls) -> dict[str, str]:
+        """Get dict of dependency names to paths."""
+        return {name: spec.path for name, spec in cls._deps_specs.items()}
+
+    @classmethod
+    def get_outs_paths(cls) -> dict[str, str]:
+        """Get dict of output names to paths."""
+        return {name: spec.path for name, spec in cls._outs_specs.items()}

--- a/tests/core/test_pipeline_config.py
+++ b/tests/core/test_pipeline_config.py
@@ -1,0 +1,1564 @@
+"""Tests for pivot.yaml configuration loading and stage registration."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import registry
+from pivot.pipeline import yaml as pipeline_config
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_mock import MockerFixture
+
+FIXTURES_DIR = pathlib.Path(__file__).parent.parent / "fixtures" / "pipeline_config"
+
+
+# =============================================================================
+# Fixture Helpers
+# =============================================================================
+
+
+@pytest.fixture
+def simple_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy simple pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "simple"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "models").mkdir(exist_ok=True)
+
+    # Set project root so paths resolve correctly
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    # Add fixture dir to sys.path so stages module can be imported
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+@pytest.fixture
+def params_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy params pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "with_params"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "models").mkdir(exist_ok=True)
+    (tmp_path / "metrics").mkdir(exist_ok=True)
+
+    # Set project root
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+@pytest.fixture
+def matrix_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Copy matrix pipeline fixture to tmp_path and set up imports."""
+    fixture_dir = FIXTURES_DIR / "with_matrix"
+    shutil.copytree(fixture_dir, tmp_path, dirs_exist_ok=True)
+
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "raw.csv").write_text("id,value\n1,10\n2,20\n")
+    (tmp_path / "data" / "gpt_tokenizer.json").write_text("{}")
+    (tmp_path / "configs").mkdir(exist_ok=True)
+    (tmp_path / "configs" / "bert.yaml").write_text("model: bert")
+    (tmp_path / "configs" / "gpt.yaml").write_text("model: gpt")
+    (tmp_path / "models").mkdir(exist_ok=True)
+    (tmp_path / "metrics").mkdir(exist_ok=True)
+
+    # Set project root
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+# =============================================================================
+# Basic Loading Tests
+# =============================================================================
+
+
+def test_load_simple_config(simple_pipeline: pathlib.Path) -> None:
+    """Load a simple pivot.yaml with two stages."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    assert len(config.stages) == 2
+    assert "preprocess" in config.stages
+    assert "train" in config.stages
+
+
+def test_load_pipeline_file_parses_stage_fields(simple_pipeline: pathlib.Path) -> None:
+    """Stage config contains python, deps, and outs fields."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    preprocess = config.stages["preprocess"]
+    assert preprocess.python == "stages.preprocess"
+    assert preprocess.deps == ["data/raw.csv"]
+    assert preprocess.outs == ["data/clean.csv"]
+
+
+def test_load_pipeline_file_with_metrics(params_pipeline: pathlib.Path) -> None:
+    """Stage config with metrics field is parsed correctly."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    train = config.stages["train"]
+    assert train.metrics == ["metrics/train.json"]
+
+
+def test_load_pipeline_file_with_params(params_pipeline: pathlib.Path) -> None:
+    """Stage config with params overrides is parsed correctly."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    config = pipeline_config.load_pipeline_file(pipeline_file)
+
+    train = config.stages["train"]
+    assert train.params["learning_rate"] == 0.05
+    assert train.params["epochs"] == 50
+
+
+# =============================================================================
+# Stage Registration Tests
+# =============================================================================
+
+
+def test_register_simple_stages(simple_pipeline: pathlib.Path) -> None:
+    """Register stages from simple pivot.yaml into registry."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "preprocess" in stages
+    assert "train" in stages
+
+
+def test_registered_stage_has_correct_deps(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage has correct dependencies."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    # Deps should be normalized to absolute paths
+    assert any("data/raw.csv" in dep for dep in info["deps"])
+
+
+def test_registered_stage_has_correct_outs(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage has correct outputs."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert any("data/clean.csv" in out for out in info["outs_paths"])
+
+
+def test_registered_stage_function_is_callable(simple_pipeline: pathlib.Path) -> None:
+    """Registered stage function is the actual imported function."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert callable(info["func"])
+    assert info["func"].__name__ == "preprocess"
+
+
+# =============================================================================
+# Params Introspection Tests
+# =============================================================================
+
+
+def test_params_introspected_from_signature(params_pipeline: pathlib.Path) -> None:
+    """Params class is introspected from function signature."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train")
+    params = info["params"]
+    assert params is not None
+    assert params.__class__.__name__ == "TrainParams"
+
+
+def test_params_values_from_yaml_override_defaults(params_pipeline: pathlib.Path) -> None:
+    """Params values from pivot.yaml override class defaults."""
+    pipeline_file = params_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train")
+    params = info["params"]
+    assert params is not None, "Expected params to be set"
+
+    # These should be overridden by pivot.yaml
+    assert params.model_dump()["learning_rate"] == 0.05
+    assert params.model_dump()["epochs"] == 50
+    # This should be the class default (not in pivot.yaml)
+    assert params.model_dump()["batch_size"] == 32
+
+
+def test_stage_without_params_has_none(simple_pipeline: pathlib.Path) -> None:
+    """Stage without params parameter has params=None."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    assert info["params"] is None
+
+
+def test_error_if_params_in_yaml_but_no_signature(simple_pipeline: pathlib.Path) -> None:
+    """Error if pivot.yaml has params but function has no params parameter."""
+    # Modify the config to add params to preprocess (which has no params parameter)
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    config_text = pipeline_file.read_text()
+    config_text = config_text.replace(
+        "python: stages.preprocess",
+        "python: stages.preprocess\n    params:\n      foo: bar",
+    )
+    pipeline_file.write_text(config_text)
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no 'params' parameter"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_error_if_params_parameter_has_no_type_hint(
+    params_pipeline: pathlib.Path,
+) -> None:
+    """Error if function has params parameter without type hint."""
+    # Create a stage with untyped params
+    stages_file = params_pipeline / "stages.py"
+    content = stages_file.read_text()
+    content = content.replace("def train(params: TrainParams)", "def train(params)")
+    stages_file.write_text(content)
+
+    # Need to reload the module
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    pipeline_file = params_pipeline / "pivot.yaml"
+    with pytest.raises(pipeline_config.PipelineConfigError, match="type hint"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Matrix Expansion Tests
+# =============================================================================
+
+
+def test_matrix_expands_to_variants(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix config expands to multiple variant stages."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+
+    # Should have preprocess + 4 train variants (2 models x 2 datasets)
+    assert "preprocess" in stages
+    assert "train@bert_swe" in stages
+    assert "train@bert_human" in stages
+    assert "train@gpt_swe" in stages
+    assert "train@gpt_human" in stages
+    assert len(stages) == 5
+
+
+def test_matrix_variant_has_interpolated_deps(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in deps."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    deps_str = " ".join(info["deps"])
+
+    assert "configs/bert.yaml" in deps_str
+    # Should NOT have ${model} or ${dataset} - should be interpolated
+    assert "${model}" not in deps_str
+    assert "${dataset}" not in deps_str
+
+
+def test_matrix_variant_has_interpolated_outs(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in outs."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    outs_str = " ".join(info["outs_paths"])
+
+    assert "models/bert_swe.pkl" in outs_str
+    assert "${model}" not in outs_str
+
+
+def test_matrix_variant_has_interpolated_params(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variant has ${dim} interpolated in params values."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert_swe")
+    params = info["params"]
+    assert params is not None
+
+    assert params.model_dump()["model_type"] == "bert"
+
+
+def test_matrix_dict_dimension_applies_overrides(matrix_pipeline: pathlib.Path) -> None:
+    """Dict dimension applies overrides to specific variants."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert_swe")
+    gpt_info = registry.REGISTRY.get("train@gpt_swe")
+    bert_params = bert_info["params"]
+    gpt_params = gpt_info["params"]
+    assert bert_params is not None
+    assert gpt_params is not None
+
+    # bert has hidden_size=768, gpt has hidden_size=1024
+    assert bert_params.model_dump()["hidden_size"] == 768
+    assert gpt_params.model_dump()["hidden_size"] == 1024
+
+
+def test_matrix_append_override_adds_deps(matrix_pipeline: pathlib.Path) -> None:
+    """deps+ override appends to deps list."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    gpt_info = registry.REGISTRY.get("train@gpt_swe")
+    deps_str = " ".join(gpt_info["deps"])
+
+    # gpt variants should have the extra dep
+    assert "data/gpt_tokenizer.json" in deps_str
+
+    # bert variants should NOT have it
+    bert_info = registry.REGISTRY.get("train@bert_swe")
+    bert_deps_str = " ".join(bert_info["deps"])
+    assert "data/gpt_tokenizer.json" not in bert_deps_str
+
+
+def test_matrix_list_dimension_uses_value_as_key(matrix_pipeline: pathlib.Path) -> None:
+    """List dimension uses primitive value as key (no overrides)."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    # Both swe and human variants should exist
+    assert "train@bert_swe" in registry.REGISTRY.list_stages()
+    assert "train@bert_human" in registry.REGISTRY.list_stages()
+
+
+# =============================================================================
+# DAG Building Tests
+# =============================================================================
+
+
+def test_dag_built_from_registered_stages(simple_pipeline: pathlib.Path) -> None:
+    """DAG can be built from registered stages."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    dag = registry.REGISTRY.build_dag()
+
+    # train depends on preprocess (via data/clean.csv)
+    assert dag.has_edge("train", "preprocess")
+
+
+def test_matrix_dag_has_correct_dependencies(matrix_pipeline: pathlib.Path) -> None:
+    """Matrix variants have correct dependencies in DAG."""
+    pipeline_file = matrix_pipeline / "pivot.yaml"
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    dag = registry.REGISTRY.build_dag()
+
+    # All train variants depend on preprocess (via data/clean.csv)
+    assert dag.has_edge("train@bert_swe", "preprocess")
+    assert dag.has_edge("train@gpt_human", "preprocess")
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+def test_load_nonexistent_file_raises(tmp_path: pathlib.Path) -> None:
+    """Loading a non-existent file raises PipelineConfigError."""
+    with pytest.raises(pipeline_config.PipelineConfigError, match="not found"):
+        pipeline_config.load_pipeline_file(tmp_path / "nonexistent.yaml")
+
+
+def test_load_empty_file_raises(tmp_path: pathlib.Path) -> None:
+    """Loading an empty file raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text("")
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_load_invalid_yaml_raises(tmp_path: pathlib.Path) -> None:
+    """Loading invalid YAML structure raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text("stages: not_a_dict")
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="Invalid"):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_cwd_with_path_traversal_raises(tmp_path: pathlib.Path) -> None:
+    """cwd with path traversal (..) raises validation error."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.getcwd
+    outs: [out.txt]
+    cwd: "../escape"
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="\\.\\."):
+        pipeline_config.load_pipeline_file(pipeline_file)
+
+
+def test_import_function_invalid_path_raises(tmp_path: pathlib.Path) -> None:
+    """Import path without dot raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: no_module_path
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="module.function"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_nonexistent_module_raises(tmp_path: pathlib.Path) -> None:
+    """Importing from non-existent module raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: nonexistent_module_xyz.func
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="import module"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_nonexistent_function_raises(tmp_path: pathlib.Path) -> None:
+    """Importing non-existent function raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.nonexistent_function_xyz
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no function"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_import_non_callable_raises(tmp_path: pathlib.Path) -> None:
+    """Importing a non-callable raises PipelineConfigError."""
+    pipeline_file = tmp_path / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  bad_stage:
+    python: os.name
+    outs: [out.txt]
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="not callable"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Output Options Tests
+# =============================================================================
+
+
+def test_output_with_cache_false(simple_pipeline: pathlib.Path) -> None:
+    """Output with cache: false option is parsed correctly."""
+    from pivot import outputs
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps: [data/raw.csv]
+    outs:
+      - data/clean.csv: {cache: false}
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    out = info["outs"][0]
+    assert isinstance(out, outputs.Out)
+    assert out.cache is False
+
+
+def test_plot_with_options(simple_pipeline: pathlib.Path) -> None:
+    """Plot with x, y, template options is parsed correctly."""
+    from pivot import outputs
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  preprocess:
+    python: stages.preprocess
+    deps: [data/raw.csv]
+    outs: [data/clean.csv]
+    plots:
+      - plots/curve.json: {x: epoch, y: loss, template: linear}
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("preprocess")
+    plot_outs = [o for o in info["outs"] if isinstance(o, outputs.Plot)]
+    assert len(plot_outs) == 1
+    plot = plot_outs[0]
+    assert plot.x == "epoch"
+    assert plot.y == "loss"
+    assert plot.template == "linear"
+
+
+# =============================================================================
+# Matrix Error Tests
+# =============================================================================
+
+
+def test_matrix_empty_dimension_list_raises(simple_pipeline: pathlib.Path) -> None:
+    """Empty matrix dimension list raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    matrix:
+      model: []
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_empty_dimension_dict_raises(simple_pipeline: pathlib.Path) -> None:
+    """Empty matrix dimension dict raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    matrix:
+      model: {}
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="empty"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_unresolved_variable_raises(simple_pipeline: pathlib.Path) -> None:
+    """Unresolved ${var} in deps/outs raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - "data/${unknown}.csv"
+    outs:
+      - models/out.pkl
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="unresolved"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_template_missing_dimensions_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name template missing matrix dimensions raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  "train@{model}":
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}_${dataset}.pkl"
+    matrix:
+      model:
+        - bert
+        - gpt
+      dataset:
+        - swe
+        - human
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="missing dimensions"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_template_unknown_variables_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name template with unknown variables raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  "train@{model}_{unknown}":
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        - bert
+        - gpt
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="unknown variables"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_matrix_name_with_at_but_no_template_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """Name with @ but no template variables raises PipelineConfigError."""
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train@variant:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="no template"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+# =============================================================================
+# Variants (Python Escape Hatch) Tests
+# =============================================================================
+
+
+def test_variants_function_registers_stages(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants function returns list of dicts to register."""
+    # Create a variants generator function
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return [
+        {"name": "v1", "deps": ["a.txt"], "outs": ["b.txt"]},
+        {"name": "v2", "deps": ["c.txt"], "outs": ["d.txt"]},
+    ]
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@v1" in stages
+    assert "train@v2" in stages
+
+
+def test_variants_function_not_list_raises(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants function returning non-list raises PipelineConfigError."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return "not a list"
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    with pytest.raises(pipeline_config.PipelineConfigError, match="must return a list"):
+        pipeline_config.register_from_pipeline_file(pipeline_file)
+
+
+def test_variants_with_cwd(
+    simple_pipeline: pathlib.Path,
+) -> None:
+    """variants with cwd override is applied correctly."""
+    (simple_pipeline / "subdir").mkdir()
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+
+def get_variants():
+    return [
+        {"name": "v1", "deps": ["a.txt"], "outs": ["b.txt"], "cwd": "subdir"},
+    ]
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    variants: stages.get_variants
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@v1")
+    assert "subdir" in str(info["cwd"])
+
+
+# =============================================================================
+# Matrix Override Tests (Additional Coverage)
+# =============================================================================
+
+
+def test_matrix_metrics_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override metrics list."""
+    from pivot import outputs
+
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    metrics:
+      - metrics/base.json
+    matrix:
+      model:
+        bert:
+          metrics:
+            - metrics/bert.json
+        gpt:
+          metrics+:
+            - metrics/gpt_extra.json
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    bert_metrics = [o for o in bert_info["outs"] if isinstance(o, outputs.Metric)]
+    gpt_metrics = [o for o in gpt_info["outs"] if isinstance(o, outputs.Metric)]
+
+    # bert has override (replaces)
+    assert len(bert_metrics) == 1
+    assert "bert.json" in bert_metrics[0].path
+
+    # gpt has append
+    assert len(gpt_metrics) == 2
+    metric_paths = " ".join(m.path for m in gpt_metrics)
+    assert "base.json" in metric_paths
+    assert "gpt_extra.json" in metric_paths
+
+
+def test_matrix_plots_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override plots list."""
+    from pivot import outputs
+
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    plots:
+      - plots/base.json
+    matrix:
+      model:
+        bert:
+          plots:
+            - plots/bert.json
+        gpt:
+          plots+:
+            - plots/gpt_extra.json
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    bert_plots = [o for o in bert_info["outs"] if isinstance(o, outputs.Plot)]
+    gpt_plots = [o for o in gpt_info["outs"] if isinstance(o, outputs.Plot)]
+
+    assert len(bert_plots) == 1
+    assert "bert.json" in bert_plots[0].path
+
+    assert len(gpt_plots) == 2
+
+
+def test_matrix_mutex_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override mutex list."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    mutex:
+      - gpu
+    matrix:
+      model:
+        bert:
+          mutex:
+            - cpu
+        gpt:
+          mutex+:
+            - memory
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    # bert has override (replaces)
+    assert bert_info["mutex"] == ["cpu"]
+
+    # gpt has append
+    assert "gpu" in gpt_info["mutex"]
+    assert "memory" in gpt_info["mutex"]
+
+
+def test_matrix_cwd_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override cwd."""
+    (simple_pipeline / "bert_dir").mkdir()
+    (simple_pipeline / "gpt_dir").mkdir()
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    matrix:
+      model:
+        bert:
+          cwd: bert_dir
+        gpt:
+          cwd: gpt_dir
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    assert "bert_dir" in str(bert_info["cwd"])
+    assert "gpt_dir" in str(gpt_info["cwd"])
+
+
+def test_matrix_outs_override(simple_pipeline: pathlib.Path) -> None:
+    """Matrix dimension can override outs list."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/base.pkl
+    matrix:
+      model:
+        bert:
+          outs:
+            - models/bert_specific.pkl
+        gpt:
+          outs+:
+            - models/gpt_extra.pkl
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    bert_info = registry.REGISTRY.get("train@bert")
+    gpt_info = registry.REGISTRY.get("train@gpt")
+
+    # bert has override (replaces)
+    assert len(bert_info["outs_paths"]) == 1
+    assert "bert_specific.pkl" in bert_info["outs_paths"][0]
+
+    # gpt has append
+    assert len(gpt_info["outs_paths"]) == 2
+
+
+def test_matrix_interpolates_nested_params(simple_pipeline: pathlib.Path) -> None:
+    """Matrix interpolates ${dim} in nested params structures."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class TrainParams(pydantic.BaseModel):
+    config: dict
+
+def preprocess():
+    pass
+
+def train(params: TrainParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl"
+    params:
+      config:
+        model_name: "${model}"
+        paths:
+          - "path/${model}/a"
+          - "path/${model}/b"
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert")
+    params = info["params"]
+    assert params is not None
+
+    config = params.model_dump()["config"]
+    assert config["model_name"] == "bert"
+    assert config["paths"] == ["path/bert/a", "path/bert/b"]
+
+
+def test_matrix_interpolates_output_dict_keys(simple_pipeline: pathlib.Path) -> None:
+    """Matrix interpolates ${dim} in output dict keys."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${model}.pkl":
+          cache: false
+    matrix:
+      model:
+        - bert
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@bert")
+    assert "models/bert.pkl" in info["outs_paths"][0]
+
+
+# =============================================================================
+# Non-String Matrix Dimension Tests
+# =============================================================================
+
+
+def test_matrix_boolean_values(simple_pipeline: pathlib.Path) -> None:
+    """Boolean matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class FlagParams(pydantic.BaseModel):
+    enabled: bool
+
+def preprocess():
+    pass
+
+def train(params: FlagParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/${flag}.pkl"
+    params:
+      enabled: "${flag}"
+    matrix:
+      flag:
+        - true
+        - false
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@True" in stages
+    assert "train@False" in stages
+
+    true_info = registry.REGISTRY.get("train@True")
+    false_info = registry.REGISTRY.get("train@False")
+
+    # Params should preserve boolean type
+    assert true_info["params"] is not None
+    assert false_info["params"] is not None
+    true_params = true_info["params"].model_dump()
+    false_params = false_info["params"].model_dump()
+    assert true_params["enabled"] is True
+    assert false_params["enabled"] is False
+
+    # Paths should use string conversion
+    assert "models/True.pkl" in true_info["outs_paths"][0]
+    assert "models/False.pkl" in false_info["outs_paths"][0]
+
+
+def test_matrix_integer_values(simple_pipeline: pathlib.Path) -> None:
+    """Integer matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class SizeParams(pydantic.BaseModel):
+    batch_size: int
+
+def preprocess():
+    pass
+
+def train(params: SizeParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/batch_${size}.pkl"
+    params:
+      batch_size: "${size}"
+    matrix:
+      size:
+        - 16
+        - 32
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@16" in stages
+    assert "train@32" in stages
+
+    info_16 = registry.REGISTRY.get("train@16")
+    info_32 = registry.REGISTRY.get("train@32")
+
+    # Params should preserve int type
+    assert info_16["params"] is not None
+    params_16 = info_16["params"].model_dump()
+    assert params_16["batch_size"] == 16
+    assert isinstance(params_16["batch_size"], int)
+
+    assert info_32["params"] is not None
+    params_32 = info_32["params"].model_dump()
+    assert params_32["batch_size"] == 32
+
+    # Paths should use string conversion
+    assert "models/batch_16.pkl" in info_16["outs_paths"][0]
+    assert "models/batch_32.pkl" in info_32["outs_paths"][0]
+
+
+def test_matrix_float_values(simple_pipeline: pathlib.Path) -> None:
+    """Float matrix values generate correct variants and preserve type in params."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class LRParams(pydantic.BaseModel):
+    learning_rate: float
+
+def preprocess():
+    pass
+
+def train(params: LRParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - "models/lr_${lr}.pkl"
+    params:
+      learning_rate: "${lr}"
+    matrix:
+      lr:
+        - 0.001
+        - 0.01
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    stages = registry.REGISTRY.list_stages()
+    assert "train@0.001" in stages
+    assert "train@0.01" in stages
+
+    info_001 = registry.REGISTRY.get("train@0.001")
+    info_01 = registry.REGISTRY.get("train@0.01")
+
+    # Params should preserve float type
+    assert info_001["params"] is not None
+    params_001 = info_001["params"].model_dump()
+    assert params_001["learning_rate"] == 0.001
+    assert isinstance(params_001["learning_rate"], float)
+
+    assert info_01["params"] is not None
+    params_01 = info_01["params"].model_dump()
+    assert params_01["learning_rate"] == 0.01
+
+    # Paths should use string conversion
+    assert "models/lr_0.001.pkl" in info_001["outs_paths"][0]
+    assert "models/lr_0.01.pkl" in info_01["outs_paths"][0]
+
+
+def test_matrix_mixed_interpolation(simple_pipeline: pathlib.Path) -> None:
+    """String containing ${var} uses string conversion, exact ${var} preserves type."""
+    stages_file = simple_pipeline / "stages.py"
+    stages_file.write_text(
+        """\
+import pydantic
+
+class MixedParams(pydantic.BaseModel):
+    rate: float
+    path: str
+
+def preprocess():
+    pass
+
+def train(params: MixedParams):
+    pass
+"""
+    )
+
+    pipeline_file = simple_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+  train:
+    python: stages.train
+    deps:
+      - data/clean.csv
+    outs:
+      - models/out.pkl
+    params:
+      rate: "${lr}"
+      path: "models/${lr}.pkl"
+    matrix:
+      lr:
+        - 0.001
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("train@0.001")
+
+    # Params validation
+    assert info["params"] is not None
+    params = info["params"].model_dump()
+
+    # Exact match preserves type
+    assert params["rate"] == 0.001
+    assert isinstance(params["rate"], float)
+
+    # String with interpolation becomes string
+    assert params["path"] == "models/0.001.pkl"
+    assert isinstance(params["path"], str)
+
+
+# =============================================================================
+# StageDef Integration Tests
+# =============================================================================
+
+
+@pytest.fixture
+def stage_def_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
+    """Set up a pipeline with StageDef-based stages."""
+    # Create data directory structure
+    (tmp_path / "data").mkdir(exist_ok=True)
+    (tmp_path / "data" / "input.csv").write_text("a,b\n1,2\n3,4\n")
+    (tmp_path / "output").mkdir(exist_ok=True)
+
+    # Create stages.py with StageDef
+    stages_file = tmp_path / "stages.py"
+    stages_file.write_text(
+        """\
+import pandas
+from pivot import loaders, stage_def
+
+
+class ProcessParams(stage_def.StageDef):
+   class deps:
+       data: loaders.CSV[pandas.DataFrame] = "data/input.csv"
+
+   class outs:
+       result: loaders.JSON[dict[str, int]] = "output/result.json"
+
+   threshold: float = 0.5
+
+
+def process(params: ProcessParams) -> None:
+   df = params.deps.data
+   result = {"count": len(df[df["a"] > params.threshold])}
+   params.outs.result = result
+"""
+    )
+
+    # Set project root
+    mocker.patch("pivot.project._project_root_cache", tmp_path)
+
+    # Clear any cached stages module from previous tests
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    if "stages" in sys.modules:
+        del sys.modules["stages"]
+
+
+def test_stage_def_extracts_deps_from_class(stage_def_pipeline: pathlib.Path) -> None:
+    """StageDef deps are auto-extracted when not specified in YAML."""
+    pipeline_file = stage_def_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+ process:
+   python: stages.process
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("process")
+    # Deps should be extracted from StageDef
+    assert any("data/input.csv" in dep for dep in info["deps"])
+
+
+def test_stage_def_extracts_outs_from_class(stage_def_pipeline: pathlib.Path) -> None:
+    """StageDef outs are auto-extracted when not specified in YAML."""
+    pipeline_file = stage_def_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+ process:
+   python: stages.process
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("process")
+    # Outs should be extracted from StageDef
+    assert any("output/result.json" in out for out in info["outs_paths"])
+
+
+def test_stage_def_yaml_deps_override(stage_def_pipeline: pathlib.Path) -> None:
+    """Explicit YAML deps completely replace StageDef deps."""
+    pipeline_file = stage_def_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+ process:
+   python: stages.process
+   deps:
+     - data/override.csv
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("process")
+    deps_str = " ".join(info["deps"])
+    # Should use YAML deps, not StageDef deps
+    assert "data/override.csv" in deps_str
+    # Should NOT have StageDef deps (complete replacement)
+    assert "data/input.csv" not in deps_str
+
+
+def test_stage_def_yaml_outs_override(stage_def_pipeline: pathlib.Path) -> None:
+    """Explicit YAML outs completely replace StageDef outs."""
+    pipeline_file = stage_def_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+ process:
+   python: stages.process
+   outs:
+     - output/override.json
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("process")
+    outs_str = " ".join(info["outs_paths"])
+    # Should use YAML outs, not StageDef outs
+    assert "output/override.json" in outs_str
+    # Should NOT have StageDef outs (complete replacement)
+    assert "output/result.json" not in outs_str
+
+
+def test_stage_def_params_available(stage_def_pipeline: pathlib.Path) -> None:
+    """StageDef params are available in registered stage."""
+    pipeline_file = stage_def_pipeline / "pivot.yaml"
+    pipeline_file.write_text(
+        """\
+stages:
+ process:
+   python: stages.process
+   params:
+     threshold: 0.8
+"""
+    )
+
+    pipeline_config.register_from_pipeline_file(pipeline_file)
+
+    info = registry.REGISTRY.get("process")
+    params = info["params"]
+    assert params is not None
+    assert params.model_dump()["threshold"] == 0.8

--- a/tests/fingerprint/README.md
+++ b/tests/fingerprint/README.md
@@ -175,6 +175,20 @@ This document exhaustively catalogs what code changes are and are not detected b
 
 ---
 
+## 11. Loader Fingerprinting
+
+| Change Type                     | Detected? | Test Reference                                                              |
+| ------------------------------- | --------- | --------------------------------------------------------------------------- |
+| Loader load() method change     | ✅        | `test_fingerprint.py::test_loader_fingerprint_includes_load_method`         |
+| Loader save() method change     | ✅        | `test_fingerprint.py::test_loader_fingerprint_includes_save_method`         |
+| Loader config field change      | ✅        | `test_fingerprint.py::test_loader_config_change_changes_fingerprint`        |
+| Different loader types          | ✅        | `test_fingerprint.py::test_different_loader_types_different_fingerprint`    |
+| Custom loader code change       | ✅        | `test_fingerprint.py::test_custom_loader_code_change_detected`              |
+| Custom loader fingerprinting    | ✅        | `test_fingerprint.py::test_custom_loader_fingerprint`                       |
+| Fingerprint stability           | ✅        | `test_fingerprint.py::test_loader_fingerprint_stable`                       |
+
+---
+
 ## Summary: Gaps Requiring New Tests
 
 | Gap                                              | Priority | Difficulty                    |

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,372 @@
+# pyright: reportAbstractUsage=false, reportImplicitAbstractClass=false, reportImplicitOverride=false, reportUnknownArgumentType=false
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import pickle
+import typing
+from typing import Any
+
+import pandas
+import pytest
+
+from pivot import loaders
+
+# ==============================================================================
+# Loader base class tests
+# ==============================================================================
+
+
+def test_loader_is_abstract() -> None:
+    """Loader base class cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="abstract"):
+        loaders.Loader()  # type: ignore[abstract]
+
+
+def test_loader_requires_load_method() -> None:
+    """Subclasses must implement load()."""
+
+    @dataclasses.dataclass(frozen=True)
+    class PartialLoader(loaders.Loader[str]):
+        def save(self, data: str, path: pathlib.Path) -> None:
+            pass
+
+    with pytest.raises(TypeError, match="abstract"):
+        PartialLoader()  # type: ignore[abstract]
+
+
+def test_loader_requires_save_method() -> None:
+    """Subclasses must implement save()."""
+
+    @dataclasses.dataclass(frozen=True)
+    class PartialLoader(loaders.Loader[str]):
+        def load(self, path: pathlib.Path) -> str:
+            return ""
+
+    with pytest.raises(TypeError, match="abstract"):
+        PartialLoader()  # type: ignore[abstract]
+
+
+# ==============================================================================
+# CSV loader tests
+# ==============================================================================
+
+
+def test_csv_loader_load(tmp_path: pathlib.Path) -> None:
+    """CSV loader reads DataFrame from file."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n3,4\n")
+
+    loader = loaders.CSV()
+    df = loader.load(csv_file)
+
+    assert isinstance(df, pandas.DataFrame)
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 2
+
+
+def test_csv_loader_save(tmp_path: pathlib.Path) -> None:
+    """CSV loader writes DataFrame to file."""
+    csv_file = tmp_path / "output.csv"
+    df = pandas.DataFrame({"x": [1, 2], "y": [3, 4]})
+
+    loader = loaders.CSV()
+    loader.save(df, csv_file)
+
+    assert csv_file.exists()
+    loaded = pandas.read_csv(csv_file)
+    assert list(loaded.columns) == ["x", "y"]
+
+
+def test_csv_loader_with_index_col(tmp_path: pathlib.Path) -> None:
+    """CSV loader respects index_col option."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("idx,val\na,1\nb,2\n")
+
+    loader = loaders.CSV(index_col="idx")
+    df = loader.load(csv_file)
+
+    assert df.index.name == "idx"
+    assert list(df.index) == ["a", "b"]
+
+
+def test_csv_loader_with_sep(tmp_path: pathlib.Path) -> None:
+    """CSV loader respects sep option."""
+    csv_file = tmp_path / "data.tsv"
+    csv_file.write_text("a\tb\n1\t2\n")
+
+    loader = loaders.CSV(sep="\t")
+    df = loader.load(csv_file)
+
+    assert list(df.columns) == ["a", "b"]
+
+
+# ==============================================================================
+# JSON loader tests
+# ==============================================================================
+
+
+def test_json_loader_load(tmp_path: pathlib.Path) -> None:
+    """JSON loader reads dict from file."""
+    json_file = tmp_path / "data.json"
+    json_file.write_text('{"key": "value", "num": 42}')
+
+    loader = loaders.JSON()
+    data = loader.load(json_file)
+
+    assert data == {"key": "value", "num": 42}
+
+
+def test_json_loader_save(tmp_path: pathlib.Path) -> None:
+    """JSON loader writes dict to file."""
+    json_file = tmp_path / "output.json"
+    data = {"foo": [1, 2, 3]}
+
+    loader = loaders.JSON()
+    loader.save(data, json_file)
+
+    assert json_file.exists()
+    content = json_file.read_text()
+    assert '"foo"' in content
+    assert "[1, 2, 3]" in content or "[\n" in content
+
+
+def test_json_loader_with_indent(tmp_path: pathlib.Path) -> None:
+    """JSON loader respects indent option."""
+    json_file = tmp_path / "output.json"
+    data = {"a": 1}
+
+    loader = loaders.JSON(indent=4)
+    loader.save(data, json_file)
+
+    content = json_file.read_text()
+    assert "    " in content  # 4-space indent
+
+
+# ==============================================================================
+# YAML loader tests
+# ==============================================================================
+
+
+def test_yaml_loader_load(tmp_path: pathlib.Path) -> None:
+    """YAML loader reads dict from file."""
+    yaml_file = tmp_path / "data.yaml"
+    yaml_file.write_text("key: value\nlist:\n  - a\n  - b\n")
+
+    loader = loaders.YAML()
+    data = loader.load(yaml_file)
+
+    assert data == {"key": "value", "list": ["a", "b"]}
+
+
+def test_yaml_loader_save(tmp_path: pathlib.Path) -> None:
+    """YAML loader writes dict to file."""
+    yaml_file = tmp_path / "output.yaml"
+    data = {"setting": True, "items": [1, 2]}
+
+    loader = loaders.YAML()
+    loader.save(data, yaml_file)
+
+    assert yaml_file.exists()
+    content = yaml_file.read_text()
+    assert "setting:" in content
+
+
+# ==============================================================================
+# Pickle loader tests
+# ==============================================================================
+
+
+def test_pickle_loader_load(tmp_path: pathlib.Path) -> None:
+    """Pickle loader reads object from file."""
+    pkl_file = tmp_path / "data.pkl"
+    obj = {"complex": [1, 2, {"nested": True}]}
+    pkl_file.write_bytes(pickle.dumps(obj))
+
+    loader = loaders.Pickle[dict[str, Any]]()
+    loaded = loader.load(pkl_file)
+
+    assert loaded == obj
+
+
+def test_pickle_loader_save(tmp_path: pathlib.Path) -> None:
+    """Pickle loader writes object to file."""
+    pkl_file = tmp_path / "output.pkl"
+    obj = {"data": [1, 2, 3]}
+
+    loader = loaders.Pickle[dict[str, Any]]()
+    loader.save(obj, pkl_file)
+
+    assert pkl_file.exists()
+    loaded = pickle.loads(pkl_file.read_bytes())
+    assert loaded == obj
+
+
+# ==============================================================================
+# PathOnly loader tests
+# ==============================================================================
+
+
+def test_pathonly_loader_load_returns_path(tmp_path: pathlib.Path) -> None:
+    """PathOnly loader returns the path itself."""
+    file = tmp_path / "file.bin"
+    file.write_bytes(b"binary data")
+
+    loader = loaders.PathOnly()
+    result = loader.load(file)
+
+    assert result == file
+    assert isinstance(result, pathlib.Path)
+
+
+def test_pathonly_loader_save_validates_exists(tmp_path: pathlib.Path) -> None:
+    """PathOnly save validates file exists (user must create it)."""
+    file = tmp_path / "output.bin"
+    file.write_bytes(b"data")
+
+    loader = loaders.PathOnly()
+    loader.save(file, file)  # No error - file exists
+
+
+def test_pathonly_loader_save_raises_if_missing(tmp_path: pathlib.Path) -> None:
+    """PathOnly save raises if file doesn't exist."""
+    file = tmp_path / "missing.bin"
+
+    loader = loaders.PathOnly()
+    with pytest.raises(FileNotFoundError):
+        loader.save(file, file)
+
+
+# ==============================================================================
+# Pickling tests (required for ProcessPoolExecutor)
+# ==============================================================================
+
+
+def test_csv_loader_is_picklable() -> None:
+    """CSV loader can be pickled and unpickled."""
+    loader = loaders.CSV(index_col="id", sep=";")
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert restored.index_col == "id"
+    assert restored.sep == ";"
+
+
+def test_json_loader_is_picklable() -> None:
+    """JSON loader can be pickled and unpickled."""
+    loader = loaders.JSON(indent=4)
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert restored.indent == 4
+
+
+def test_yaml_loader_is_picklable() -> None:
+    """YAML loader can be pickled and unpickled."""
+    loader = loaders.YAML()
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert isinstance(restored, loaders.YAML)
+
+
+def test_pickle_loader_is_picklable() -> None:
+    """Pickle loader can be pickled and unpickled."""
+    loader = loaders.Pickle[dict[str, int]]()
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert isinstance(restored, loaders.Pickle)
+
+
+def test_pathonly_loader_is_picklable() -> None:
+    """PathOnly loader can be pickled and unpickled."""
+    loader = loaders.PathOnly()
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert isinstance(restored, loaders.PathOnly)
+
+
+# ==============================================================================
+# Generic type parameter tests
+# ==============================================================================
+
+
+def test_csv_generic_type_preserved() -> None:
+    """CSV generic type parameter can be extracted."""
+    # The type annotation CSV[pandas.DataFrame] should preserve DataFrame
+    hint = loaders.CSV[pandas.DataFrame]
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+
+    assert origin is loaders.CSV
+    assert args == (pandas.DataFrame,)
+
+
+def test_json_generic_type_preserved() -> None:
+    """JSON generic type parameter can be extracted."""
+    hint = loaders.JSON[dict[str, int]]
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+
+    assert origin is loaders.JSON
+    assert args == (dict[str, int],)
+
+
+def test_pickle_generic_type_preserved() -> None:
+    """Pickle generic type parameter can be extracted."""
+
+    class MyModel:
+        pass
+
+    hint = loaders.Pickle[MyModel]
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+
+    assert origin is loaders.Pickle
+    assert args == (MyModel,)
+
+
+# ==============================================================================
+# Custom loader subclassing tests
+# ==============================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class _CustomTextLoader(loaders.Loader[str]):
+    """Custom loader for testing - loads text with prefix."""
+
+    prefix: str = ""
+
+    def load(self, path: pathlib.Path) -> str:
+        return self.prefix + path.read_text()
+
+    def save(self, data: str, path: pathlib.Path) -> None:
+        path.write_text(data)
+
+
+def test_custom_loader_works(tmp_path: pathlib.Path) -> None:
+    """Custom loader subclass works correctly."""
+    file = tmp_path / "test.txt"
+    file.write_text("hello")
+
+    loader = _CustomTextLoader(prefix="PREFIX:")
+    result = loader.load(file)
+
+    assert result == "PREFIX:hello"
+
+
+def test_custom_loader_is_picklable() -> None:
+    """Custom loader subclass can be pickled."""
+    loader = _CustomTextLoader(prefix="TEST:")
+    pickled = pickle.dumps(loader)
+    restored = pickle.loads(pickled)
+
+    assert restored.prefix == "TEST:"
+
+
+def test_custom_loader_generic_type() -> None:
+    """Custom loader is subclass of Loader."""
+    assert issubclass(_CustomTextLoader, loaders.Loader)

--- a/tests/test_stage_def.py
+++ b/tests/test_stage_def.py
@@ -1,0 +1,393 @@
+# pyright: reportUnusedFunction=false, reportPrivateUsage=false, reportAssignmentType=false, reportAttributeAccessIssue=false, reportIncompatibleVariableOverride=false, reportUnknownArgumentType=false
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING, Any
+
+import pandas
+import pydantic
+import pytest
+
+from pivot import loaders, stage_def
+
+if TYPE_CHECKING:
+    import pathlib
+
+# ==============================================================================
+# StageDef base class tests
+# ==============================================================================
+
+
+def test_stage_def_extends_base_model() -> None:
+    """StageDef should extend pydantic.BaseModel."""
+    assert issubclass(stage_def.StageDef, pydantic.BaseModel)
+
+
+def test_stage_def_with_params_only() -> None:
+    """StageDef with only params (no deps/outs) should work."""
+
+    class SimpleParams(stage_def.StageDef):
+        learning_rate: float = 0.01
+        epochs: int = 10
+
+    params = SimpleParams()
+    assert params.learning_rate == 0.01
+    assert params.epochs == 10
+
+
+def test_stage_def_discovers_deps_class() -> None:
+    """StageDef should discover nested deps class via __init_subclass__."""
+
+    class TrainParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "data/train.csv"
+
+        learning_rate: float = 0.01
+
+    # Should have deps_specs class variable
+    assert hasattr(TrainParams, "_deps_specs")
+    assert "data" in TrainParams._deps_specs
+
+
+def test_stage_def_discovers_outs_class() -> None:
+    """StageDef should discover nested outs class via __init_subclass__."""
+
+    class TrainParams(stage_def.StageDef):
+        class outs:
+            model: loaders.Pickle[dict[str, Any]] = "models/model.pkl"
+
+        learning_rate: float = 0.01
+
+    # Should have outs_specs class variable
+    assert hasattr(TrainParams, "_outs_specs")
+    assert "model" in TrainParams._outs_specs
+
+
+def test_stage_def_extracts_loader_type() -> None:
+    """StageDef should extract loader type from annotation."""
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+
+    spec = ProcessParams._deps_specs["data"]
+    assert isinstance(spec.loader, loaders.CSV)
+
+
+def test_stage_def_extracts_path_from_default() -> None:
+    """StageDef should extract file path from default value."""
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "data/input.csv"
+
+    spec = ProcessParams._deps_specs["data"]
+    assert spec.path == "data/input.csv"
+
+
+def test_stage_def_class_access_returns_descriptor() -> None:
+    """Class attribute access should return descriptor (for framework)."""
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+
+    # Class access returns descriptor with path attribute
+    descriptor = ProcessParams.deps.data
+    assert hasattr(descriptor, "path")
+    assert descriptor.path == "input.csv"
+
+
+def test_stage_def_instance_access_before_load_raises() -> None:
+    """Instance attribute access before _load_deps() should raise RuntimeError."""
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+
+    params = ProcessParams()
+
+    with pytest.raises(RuntimeError, match="not loaded"):
+        _ = params.deps.data
+
+
+def test_stage_def_instance_access_after_load_returns_data(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Instance attribute access after _load_deps() should return loaded data."""
+    # Create test CSV file
+    csv_file = tmp_path / "input.csv"
+    csv_file.write_text("a,b\n1,2\n3,4\n")
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    # Should return loaded DataFrame
+    df = params.deps.data
+    assert isinstance(df, pandas.DataFrame)
+    assert list(df.columns) == ["a", "b"]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Classes defined in test functions cannot be pickled by Python. "
+        "In real usage, StageDef subclasses are module-level and can be pickled."
+    )
+)
+def test_stage_def_is_picklable() -> None:
+    """StageDef should be picklable (paths only, not loaded data)."""
+
+    class SimpleParams(stage_def.StageDef):
+        threshold: float = 0.5
+
+    params = SimpleParams(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert restored.threshold == 0.7
+
+
+def test_stage_def_output_assignment_tracking() -> None:
+    """StageDef should track output assignments."""
+
+    class ProcessParams(stage_def.StageDef):
+        class outs:
+            result: loaders.JSON[dict[str, int]] = "output.json"
+
+    params = ProcessParams()
+    params.outs.result = {"value": 42}
+
+    # Should be marked as assigned
+    assert "result" in params._assigned_outs
+
+
+def test_stage_def_save_outs_raises_if_not_assigned(tmp_path: pathlib.Path) -> None:
+    """_save_outs() should raise if output was declared but never assigned."""
+
+    class ProcessParams(stage_def.StageDef):
+        class outs:
+            result: loaders.JSON[dict[str, int]] = "output.json"
+
+    params = ProcessParams()
+    # Never assign params.outs.result
+
+    with pytest.raises(RuntimeError, match="never assigned"):
+        params._save_outs(tmp_path)
+
+
+def test_stage_def_save_outs_writes_file(tmp_path: pathlib.Path) -> None:
+    """_save_outs() should write assigned outputs to files."""
+
+    class ProcessParams(stage_def.StageDef):
+        class outs:
+            result: loaders.JSON[dict[str, int]] = "output.json"
+
+    params = ProcessParams()
+    params.outs.result = {"value": 42}
+    params._save_outs(tmp_path)
+
+    # Should have written the file
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    assert "42" in output_file.read_text()
+
+
+def test_stage_def_get_deps_paths() -> None:
+    """get_deps_paths() should return dict of name -> path."""
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            train: loaders.CSV[pandas.DataFrame] = "data/train.csv"
+            test: loaders.CSV[pandas.DataFrame] = "data/test.csv"
+
+    paths = ProcessParams.get_deps_paths()
+
+    assert paths == {"train": "data/train.csv", "test": "data/test.csv"}
+
+
+def test_stage_def_get_outs_paths() -> None:
+    """get_outs_paths() should return dict of name -> path."""
+
+    class ProcessParams(stage_def.StageDef):
+        class outs:
+            model: loaders.Pickle[dict[str, Any]] = "models/model.pkl"
+            metrics: loaders.JSON[dict[str, float]] = "metrics.json"
+
+    paths = ProcessParams.get_outs_paths()
+
+    assert paths == {"model": "models/model.pkl", "metrics": "metrics.json"}
+
+
+def test_stage_def_multiple_deps_loaded(tmp_path: pathlib.Path) -> None:
+    """Multiple deps should all be loadable."""
+    # Create test files
+    (tmp_path / "train.csv").write_text("x,y\n1,2\n")
+    (tmp_path / "test.csv").write_text("x,y\n3,4\n")
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            train: loaders.CSV[pandas.DataFrame] = "train.csv"
+            test: loaders.CSV[pandas.DataFrame] = "test.csv"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    assert isinstance(params.deps.train, pandas.DataFrame)
+    assert isinstance(params.deps.test, pandas.DataFrame)
+
+
+def test_stage_def_multiple_outs_saved(tmp_path: pathlib.Path) -> None:
+    """Multiple outs should all be saveable."""
+
+    class ProcessParams(stage_def.StageDef):
+        class outs:
+            model: loaders.JSON[dict[str, int]] = "model.json"
+            metrics: loaders.JSON[dict[str, float]] = "metrics.json"
+
+    params = ProcessParams()
+    params.outs.model = {"weights": 1}
+    params.outs.metrics = {"accuracy": 0.95}
+    params._save_outs(tmp_path)
+
+    assert (tmp_path / "model.json").exists()
+    assert (tmp_path / "metrics.json").exists()
+
+
+def test_stage_def_json_loader_roundtrip(tmp_path: pathlib.Path) -> None:
+    """JSON loader should work for deps and outs."""
+    # Create input file
+    input_file = tmp_path / "config.json"
+    input_file.write_text('{"key": "value"}')
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            config: loaders.JSON[dict[str, str]] = "config.json"
+
+        class outs:
+            result: loaders.JSON[dict[str, str]] = "result.json"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    assert params.deps.config == {"key": "value"}
+
+    params.outs.result = {"processed": "data"}
+    params._save_outs(tmp_path)
+
+    assert (tmp_path / "result.json").exists()
+
+
+def test_stage_def_yaml_loader(tmp_path: pathlib.Path) -> None:
+    """YAML loader should work for deps."""
+    # Create YAML file
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text("key: value\nlist:\n  - a\n  - b\n")
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            config: loaders.YAML[dict[str, Any]] = "config.yaml"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    assert params.deps.config == {"key": "value", "list": ["a", "b"]}
+
+
+def test_stage_def_pickle_loader(tmp_path: pathlib.Path) -> None:
+    """Pickle loader should work for deps and outs."""
+    # Create pickle file
+    pkl_file = tmp_path / "data.pkl"
+    pkl_file.write_bytes(pickle.dumps({"complex": [1, 2, 3]}))
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.Pickle[dict[str, list[int]]] = "data.pkl"
+
+        class outs:
+            result: loaders.Pickle[dict[str, int]] = "result.pkl"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    assert params.deps.data == {"complex": [1, 2, 3]}
+
+    params.outs.result = {"value": 42}
+    params._save_outs(tmp_path)
+
+    loaded = pickle.loads((tmp_path / "result.pkl").read_bytes())
+    assert loaded == {"value": 42}
+
+
+def test_stage_def_pathonly_loader(tmp_path: pathlib.Path) -> None:
+    """PathOnly loader should return path for manual handling."""
+    # Create a file
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"binary data")
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.PathOnly = "data.bin"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    # Should return the path itself
+    path = params.deps.data
+    assert path == tmp_path / "data.bin"
+    assert path.exists()
+
+
+def test_stage_def_csv_with_default_config(tmp_path: pathlib.Path) -> None:
+    """CSV loader uses default config from annotation."""
+    # Create CSV file
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            data: loaders.CSV[pandas.DataFrame] = "data.csv"
+
+    params = ProcessParams()
+    params._load_deps(tmp_path)
+
+    assert list(params.deps.data.columns) == ["a", "b"]
+
+
+def test_stage_def_load_failure_clears_state(tmp_path: pathlib.Path) -> None:
+    """If loading fails partway, state should be cleared for GC."""
+    # Create only first file
+    (tmp_path / "first.csv").write_text("a,b\n1,2\n")
+    # Don't create second.csv
+
+    class ProcessParams(stage_def.StageDef):
+        class deps:
+            first: loaders.CSV[pandas.DataFrame] = "first.csv"
+            second: loaders.CSV[pandas.DataFrame] = "second.csv"
+
+    params = ProcessParams()
+
+    with pytest.raises(FileNotFoundError):
+        params._load_deps(tmp_path)
+
+    # Should have cleared any partial state
+    with pytest.raises(RuntimeError, match="not loaded"):
+        _ = params.deps.first
+
+
+def test_stage_def_params_validation() -> None:
+    """StageDef should validate params via pydantic."""
+
+    class ProcessParams(stage_def.StageDef):
+        threshold: float = pydantic.Field(gt=0, le=1.0)
+
+    # Valid
+    params = ProcessParams(threshold=0.5)
+    assert params.threshold == 0.5
+
+    # Invalid
+    with pytest.raises(pydantic.ValidationError):
+        ProcessParams(threshold=2.0)


### PR DESCRIPTION
## Summary

- Add `StageDef` base class for stages with typed dependencies and outputs
- Deps auto-load before stage function, outs auto-save after
- Built-in loaders: CSV, JSON, YAML, Pickle, PathOnly
- Loader code fingerprinting for change detection
- WeakKeyDictionary storage for proper garbage collection
- Cleanup on exception to prevent memory leaks

## Example

```python
from pivot import loaders
from pivot.stage_def import StageDef

class TrainParams(StageDef):
    class deps:
        data: loaders.CSV[pd.DataFrame] = "data/train.csv"
    class outs:
        model: loaders.Pickle = "models/model.pkl"
    learning_rate: float = 0.01

@stage
def train(params: TrainParams):
    df = params.deps.data  # Auto-loaded DataFrame
    model = fit(df, params.learning_rate)
    params.outs.model = model  # Auto-saved after function returns
```

## Test plan

- [x] Unit tests for all loaders (CSV, JSON, YAML, Pickle, PathOnly)
- [x] Unit tests for StageDef descriptor behavior
- [x] Integration tests in executor worker
- [x] Backward compatibility with plain Pydantic params
- [x] All existing tests pass (1731 passed)

## Closes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)