### PR TITLE
refactor: simplify reactive engine and fix message type consistency

### DIFF
--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -358,7 +358,7 @@ class RunTuiApp(textual.app.App[dict[str, executor.ExecutionSummary] | None]):
                 self._handle_log(msg)
             case TuiMessageType.STATUS:
                 self._handle_status(msg)
-            case "reactive":
+            case TuiMessageType.REACTIVE:
                 pass  # Reactive messages handled separately in reactive mode
 
     def _handle_log(self, msg: TuiLogMessage) -> None:  # pragma: no cover

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -322,6 +322,7 @@ class TuiMessageType(enum.StrEnum):
 
     LOG = "log"
     STATUS = "status"
+    REACTIVE = "reactive"
 
 
 class TuiLogMessage(TypedDict):
@@ -348,7 +349,7 @@ class TuiStatusMessage(TypedDict):
 class TuiReactiveMessage(TypedDict):
     """Reactive engine status update for TUI display."""
 
-    type: Literal["reactive"]
+    type: Literal[TuiMessageType.REACTIVE]
     status: Literal["waiting", "restarting", "detecting", "error"]
     message: str
 


### PR DESCRIPTION
## Summary

Code simplification changes identified while reviewing architecture:

- **Fix message type inconsistency**: Add `REACTIVE` value to `TuiMessageType` enum - previously `TuiReactiveMessage` used a string literal `"reactive"` while other message types used enum values
- **Consolidate reactive engine reload methods**: Extract common code from three `_reload_from_*` methods into `_reload_with_registration` helper
- **Extract `_reload_stage_modules` helper**: Eliminates duplicated module reload loop

## Changes

| File | Change |
|------|--------|
| `src/pivot/types.py` | Add `REACTIVE = "reactive"` to `TuiMessageType`, update `TuiReactiveMessage` type |
| `src/pivot/tui/run.py` | Use `TuiMessageType.REACTIVE` in match statement |
| `src/pivot/reactive/engine.py` | Consolidate reload methods, extract helpers |

## Impact

- Reduces ~65 lines of duplicated code
- Improves consistency in message type handling
- Makes the codebase easier to maintain

## Test plan

- [x] All 1756 tests pass
- [x] Type checker passes with 0 errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)