### PR TITLE
refactor: fix transitive deps reload, add ReactiveStatus enum, simplify reactive engine

### DIFF
--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -325,6 +325,15 @@ class TuiMessageType(enum.StrEnum):
     REACTIVE = "reactive"
 
 
+class ReactiveStatus(enum.StrEnum):
+    """Status of the reactive engine."""
+
+    WAITING = "waiting"
+    RESTARTING = "restarting"
+    DETECTING = "detecting"
+    ERROR = "error"
+
+
 class TuiLogMessage(TypedDict):
     """Log line from worker process for TUI display."""
 
@@ -350,7 +359,7 @@ class TuiReactiveMessage(TypedDict):
     """Reactive engine status update for TUI display."""
 
     type: Literal[TuiMessageType.REACTIVE]
-    status: Literal["waiting", "restarting", "detecting", "error"]
+    status: ReactiveStatus
     message: str
 
 


### PR DESCRIPTION
## Summary

- Fixes **critical bug** where changes to helper modules (imported by stage modules) weren't detected during reactive reload
- Adds `ReactiveStatus` enum for type-safe status values in reactive engine messages
- Simplifies reload logic with consolidated `_reload_with_registration()` helper

## Key Changes

### Critical Bug Fix: Transitive Dependency Reload

Previously, when a helper module changed, only stage modules were reloaded via `importlib.reload()`. But `reload()` doesn't reimport dependencies - if `stages.py` imports `helpers.py`, reloading `stages.py` still uses the old cached `helpers.py`.

**Solution:** New `_clear_project_modules()` function removes ALL project modules from `sys.modules` before registration. Then `importlib.import_module()` does a fresh import that properly loads updated transitive dependencies.

```python
def _clear_project_modules(root: pathlib.Path) -> int:
    """Remove all project modules from sys.modules to force fresh imports."""
    root_str = str(root)
    to_remove = [name for name, module in sys.modules.items()
                 if module and getattr(module, "__file__", "").startswith(root_str)]
    for name in to_remove:
        del sys.modules[name]
    return len(to_remove)
```

### Type Safety Improvements

Added `ReactiveStatus` enum:
```python
class ReactiveStatus(enum.StrEnum):
    WAITING = "waiting"
    RESTARTING = "restarting"
    DETECTING = "detecting"
    ERROR = "error"
```

Now `TuiReactiveMessage.status` is `ReactiveStatus` instead of `Literal["waiting", "restarting", "detecting", "error"]`.

## Test plan

- [x] All 1756 tests pass
- [x] Type checks pass (basedpyright)
- [x] Lint checks pass (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)