### PR TITLE
fix: transitive module reload with bytecode cache invalidation

### DIFF
--- a/experiments/callback_edge_cases/VULNERABILITY_REPORT.md
+++ b/experiments/callback_edge_cases/VULNERABILITY_REPORT.md
@@ -1,0 +1,272 @@
+# Callback Detection Vulnerabilities in Pivot Fingerprinting
+
+## Executive Summary
+
+The Pivot fingerprinting system (`/home/pivot/agent1/src/pivot/fingerprint.py`) has several edge cases where callback/function argument changes are **NOT detected**, causing stages to incorrectly skip re-execution when dependencies have actually changed.
+
+The core mechanism (`inspect.getclosurevars()` + recursive fingerprinting) works well for **static** callback references but fails for **dynamic** callback resolution patterns that are common in Python.
+
+---
+
+## Critical Vulnerabilities
+
+### 1. `functools.wraps` / `__wrapped__` Attribute (CRITICAL)
+
+**File:** `/home/pivot/agent1/src/pivot/fingerprint.py`, function `hash_function_ast()`
+
+**Issue:** `inspect.getsource()` follows the `__wrapped__` attribute chain and returns the source of the **original wrapped function**, not the actual wrapper implementation.
+
+**Trigger:**
+```python
+def original():
+    return 1
+
+@functools.wraps(original)
+def wrapper():
+    return 999  # Completely different implementation!
+
+# hash_function_ast(wrapper) == hash_function_ast(original)
+# Both return the SAME hash!
+```
+
+**Impact:**
+- Any decorator using `@functools.wraps` will have its decorator logic **completely invisible** to fingerprinting
+- Affects `@functools.lru_cache`, `@functools.cache`, custom decorators, middleware patterns
+- Multiple layers of decoration are collapsed to the innermost function
+- Changing decorator parameters (e.g., `maxsize` in `lru_cache`) is not detected
+
+**Root Cause:** In `hash_function_ast()`:
+```python
+source = inspect.getsource(func)  # Follows __wrapped__, returns wrong source!
+tree = ast.parse(source)          # Parses the ORIGINAL function
+```
+
+**Fix Suggestion:** Check for `__wrapped__` attribute and either:
+1. Use `marshal.dumps(func.__code__)` instead of AST parsing for wrapped functions
+2. Hash both the wrapper (via `__code__`) AND the wrapped function, combining results
+3. Use `inspect.getsourcefile()` + `inspect.getsourcelines()` with `stop` parameter to prevent unwrapping
+
+---
+
+### 2. `functools.partial` Objects (HIGH)
+
+**File:** `/home/pivot/agent1/src/pivot/fingerprint.py`, function `get_stage_fingerprint()`
+
+**Issue:** `functools.partial` objects fail the `is_user_code()` check because they're from stdlib (`functools` module).
+
+**Trigger:**
+```python
+def base_function(multiplier, x):
+    return x * multiplier
+
+partial_v1 = functools.partial(base_function, 2)
+partial_v2 = functools.partial(base_function, 3)  # Different argument!
+
+def make_stage(p):
+    def stage():
+        return p(10)
+    return stage
+
+# Both stages have IDENTICAL fingerprints despite different partial args
+fp1 = get_stage_fingerprint(make_stage(partial_v1))
+fp2 = get_stage_fingerprint(make_stage(partial_v2))
+assert fp1 == fp2  # BUG!
+```
+
+**Impact:**
+- Partial function argument changes are not detected
+- Wrapped function changes inside partial are not detected
+- Common pattern in ML pipelines for configuring functions
+
+**Root Cause:** In `get_stage_fingerprint()`:
+```python
+if callable(value) and is_user_code(value):  # partial fails is_user_code!
+    _process_callable_dependency(...)
+```
+
+**Fix Suggestion:** Add special handling for `functools.partial`:
+```python
+if isinstance(value, functools.partial):
+    # Hash the wrapped function
+    _add_callable_to_manifest(f"partial:{name}.func", value.func, manifest, visited)
+    # Hash the partial arguments
+    manifest[f"partial:{name}.args"] = repr(value.args)
+    manifest[f"partial:{name}.keywords"] = repr(value.keywords)
+```
+
+---
+
+### 3. Instance Attribute/State Changes (HIGH)
+
+**File:** `/home/pivot/agent1/src/pivot/fingerprint.py`, function `_process_instance_dependency()`
+
+**Issue:** For user-defined class instances, only the **class definition** is hashed, not the instance's mutable state.
+
+**Trigger:**
+```python
+class Container:
+    def __init__(self):
+        self._callbacks = {}
+
+    def __getitem__(self, key):
+        return self._callbacks[key]
+
+container = Container()
+container["handler"] = callback_v1
+
+def stage():
+    return container["handler"]()
+
+fp1 = get_stage_fingerprint(stage)
+container["handler"] = callback_v2  # Different callback!
+fp2 = get_stage_fingerprint(stage)
+assert fp1 == fp2  # BUG! Same fingerprint despite different callback
+```
+
+**Also affects:**
+- `@dataclass` instances with callback fields
+- Class instances with `__getattr__` interception
+- Any object storing callbacks in instance attributes
+
+**Impact:**
+- Mutable containers holding callbacks are not tracked
+- Configuration objects with dynamic callback assignment fail
+- Registry patterns where callbacks are registered at runtime
+
+**Root Cause:** In `_process_instance_dependency()`:
+```python
+cls = type(instance)
+_add_callable_to_manifest(f"class:{name}.__class__", cls, ...)  # Only hashes the CLASS
+# Instance state (instance.__dict__, instance._callbacks, etc.) is ignored
+```
+
+**Fix Suggestion:** This is a design decision more than a bug. Options:
+1. Document as a known limitation
+2. Add opt-in instance state hashing (e.g., `__fingerprint_state__()` protocol)
+3. For callable instance attributes, extract and hash them
+
+---
+
+### 4. Class Attribute Runtime Modification (HIGH)
+
+**File:** `/home/pivot/agent1/src/pivot/fingerprint.py`, function `get_stage_fingerprint()`
+
+**Issue:** Class attributes modified at runtime (after class definition) are not detected.
+
+**Trigger:**
+```python
+class Config:
+    callback = None  # This is what gets hashed
+
+Config.callback = callback_v1
+
+def stage():
+    return Config.callback()
+
+fp1 = get_stage_fingerprint(stage)
+Config.callback = callback_v2  # Different callback!
+fp2 = get_stage_fingerprint(stage)
+assert fp1 == fp2  # BUG! Config class hash is the same
+```
+
+**Impact:**
+- Configuration classes with runtime-assigned callbacks fail
+- Singleton pattern configurations are not tracked
+- Class-level registries are invisible
+
+**Root Cause:** When `Config` is found in globals, it's a `type` object, so it's processed as a callable and its AST (class body at definition time) is hashed. Runtime modifications to class attributes don't change the source code.
+
+**Fix Suggestion:**
+1. For classes, additionally inspect `cls.__dict__` for callable values
+2. Or document as known limitation - use module-level variables instead
+
+---
+
+## Medium Severity Issues
+
+### 5. Dynamic Import Functions (MEDIUM)
+
+**Issue:** Functions obtained via `importlib.import_module()` at runtime are not tracked.
+
+**Trigger:**
+```python
+def stage():
+    mod = importlib.import_module("some_module")
+    return mod.process()  # Not tracked - 'mod' is computed at runtime
+```
+
+**Impact:** Stages using plugin architectures or lazy imports may not re-run when plugins change.
+
+---
+
+### 6. `operator.methodcaller` / `operator.attrgetter` (MEDIUM)
+
+**Issue:** These stdlib callables fail `is_user_code()` check.
+
+**Trigger:**
+```python
+caller = operator.methodcaller("process")  # Not tracked
+def stage(obj):
+    return caller(obj)  # If "process" method changes, not detected
+```
+
+---
+
+### 7. Descriptor Protocol / `__get__` (LOW)
+
+**Issue:** Methods returned by descriptors at access time are not tracked.
+
+```python
+class Descriptor:
+    def __get__(self, obj, objtype):
+        return lambda: "dynamic"
+
+class MyClass:
+    method = Descriptor()
+
+# obj.method is a new lambda each time, but fingerprinting doesn't see it
+```
+
+---
+
+## What IS Working Correctly
+
+The fingerprinting system **correctly handles**:
+
+1. **Module-level callback variables** - Changes are detected
+2. **Callbacks in nonlocal closures** - Recursively fingerprinted
+3. **Callbacks in global dicts/lists** - `_process_collection_dependency()` works
+4. **Multi-layer wrapped callbacks** - Closure recursion captures inner callbacks
+5. **Async functions and generators** - Treated as regular callables
+6. **Enum values that are callables** - Module variable change is detected
+
+---
+
+## Recommendations
+
+### Immediate (P0)
+
+1. **Fix `functools.wraps` vulnerability** - This is the most critical because:
+   - It's extremely common in Python codebases
+   - It completely hides decorator logic
+   - The fix is straightforward (check `__wrapped__`)
+
+### Short-term (P1)
+
+2. **Add `functools.partial` handling** - Common pattern, easy to implement
+3. **Document instance state limitations** - Users need to know this
+
+### Long-term (P2)
+
+4. **Consider `__fingerprint__` protocol** - Allow objects to declare what should be hashed
+5. **Add static analysis for attribute access** - Detect `Config.callback` patterns in AST
+
+---
+
+## Test Files Created
+
+- `/home/pivot/agent1/experiments/callback_edge_cases/test_callback_edge_cases.py` - Initial vulnerability discovery
+- `/home/pivot/agent1/experiments/callback_edge_cases/deep_dive.py` - Root cause analysis
+- `/home/pivot/agent1/experiments/callback_edge_cases/wraps_investigation.py` - `functools.wraps` deep dive
+- `/home/pivot/agent1/experiments/callback_edge_cases/code_object_test.py` - Code object behavior
+- `/home/pivot/agent1/experiments/callback_edge_cases/additional_edge_cases.py` - Additional patterns

--- a/experiments/callback_edge_cases/additional_edge_cases.py
+++ b/experiments/callback_edge_cases/additional_edge_cases.py
@@ -1,0 +1,284 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false
+"""
+Additional edge cases to test.
+"""
+
+import functools
+import sys
+import types
+
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("="*70)
+print("ADDITIONAL EDGE CASES")
+print("="*70)
+
+# Edge Case 1: operator.methodcaller
+print("\n--- Edge Case 1: operator.methodcaller ---")
+import operator
+
+caller_v1 = operator.methodcaller("upper")
+caller_v2 = operator.methodcaller("lower")  # Different method!
+
+print(f"is_user_code(caller_v1): {fingerprint.is_user_code(caller_v1)}")
+print(f"type(caller_v1): {type(caller_v1)}")
+
+# Methodcaller is from stdlib, so not tracked
+
+# Edge Case 2: operator.attrgetter
+print("\n--- Edge Case 2: operator.attrgetter ---")
+
+getter_v1 = operator.attrgetter("name")
+getter_v2 = operator.attrgetter("value")
+
+print(f"is_user_code(getter_v1): {fingerprint.is_user_code(getter_v1)}")
+
+# Edge Case 3: Methods bound at runtime via __get__
+print("\n--- Edge Case 3: Descriptor protocol / __get__ ---")
+
+class Descriptor:
+    def __get__(self, obj, objtype=None):
+        def method():
+            return "from descriptor"
+        return method
+
+class MyClass:
+    method = Descriptor()
+
+obj1 = MyClass()
+obj2 = MyClass()
+
+def stage_descriptor():
+    return obj1.method()
+
+fp = fingerprint.get_stage_fingerprint(stage_descriptor)
+print(f"Descriptor stage fingerprint: {fp}")
+# obj1 is captured, but does it track that method is a descriptor?
+
+# Edge Case 4: __call__ method changes
+print("\n--- Edge Case 4: __call__ method ---")
+
+class CallableV1:
+    def __call__(self):
+        return 1
+
+class CallableV2:
+    def __call__(self):
+        return 2
+
+callable_instance = CallableV1()
+
+def stage_callable_instance():
+    return callable_instance()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_callable_instance)
+print(f"CallableV1 fingerprint: {fp1}")
+
+# Now if we change the callable's class (monkey-patch), is it detected?
+# This is extreme but possible
+callable_instance.__class__ = CallableV2
+fp2 = fingerprint.get_stage_fingerprint(stage_callable_instance)
+print(f"After class swap fingerprint: {fp2}")
+print(f"Detected: {fp1 != fp2}")
+
+# Edge Case 5: Async functions
+print("\n--- Edge Case 5: Async functions ---")
+
+async def async_callback_v1():
+    return 1
+
+async def async_callback_v2():
+    return 2
+
+async_callback = async_callback_v1
+
+async def stage_async():
+    return await async_callback()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_async)
+print(f"Async stage fingerprint: {fp1}")
+
+async_callback = async_callback_v2
+fp2 = fingerprint.get_stage_fingerprint(stage_async)
+print(f"After callback change: {fp2}")
+print(f"Detected: {fp1 != fp2}")
+
+# Edge Case 6: Generator functions
+print("\n--- Edge Case 6: Generator functions ---")
+
+def gen_v1():
+    yield 1
+
+def gen_v2():
+    yield 2
+
+current_gen = gen_v1
+
+def stage_generator():
+    return list(current_gen())
+
+fp1 = fingerprint.get_stage_fingerprint(stage_generator)
+print(f"Generator stage fingerprint: {fp1}")
+
+current_gen = gen_v2
+fp2 = fingerprint.get_stage_fingerprint(stage_generator)
+print(f"After generator change: {fp2}")
+print(f"Detected: {fp1 != fp2}")
+
+# Edge Case 7: C extension functions
+print("\n--- Edge Case 7: C extension functions (json) ---")
+import json
+
+# json.dumps is a C function
+def stage_json():
+    return json.dumps({"key": "value"})
+
+fp = fingerprint.get_stage_fingerprint(stage_json)
+print(f"JSON stage fingerprint: {fp}")
+# json module is tracked but as non-user code
+
+# Edge Case 8: Callbacks in dataclass fields
+print("\n--- Edge Case 8: Dataclass with callback field ---")
+from dataclasses import dataclass
+
+def callback_a():
+    return "a"
+
+def callback_b():
+    return "b"
+
+@dataclass
+class Config:
+    callback: types.FunctionType = callback_a  # type: ignore
+
+config = Config()
+
+def stage_dataclass_callback():
+    return config.callback()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_dataclass_callback)
+print(f"Dataclass callback fingerprint: {fp1}")
+
+config.callback = callback_b  # type: ignore
+fp2 = fingerprint.get_stage_fingerprint(stage_dataclass_callback)
+print(f"After callback change: {fp2}")
+print(f"Detected: {fp1 != fp2}")
+
+# Edge Case 9: Enum with callable values
+print("\n--- Edge Case 9: Enum with callable values ---")
+import enum
+
+def process_fast():
+    return "fast"
+
+def process_slow():
+    return "slow"
+
+class ProcessMode(enum.Enum):
+    FAST = process_fast
+    SLOW = process_slow
+
+mode = ProcessMode.FAST
+
+def stage_enum_callback():
+    return mode.value()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_enum_callback)
+print(f"Enum callback fingerprint: {fp1}")
+
+mode = ProcessMode.SLOW
+fp2 = fingerprint.get_stage_fingerprint(stage_enum_callback)
+print(f"After mode change: {fp2}")
+print(f"Detected: {fp1 != fp2}")
+
+# Edge Case 10: importlib.import_module at runtime
+print("\n--- Edge Case 10: Dynamic imports ---")
+import importlib
+
+# If a stage does: mod = importlib.import_module("some_module")
+# and then calls mod.function(), that's not tracked
+
+def stage_dynamic_import():
+    mod = importlib.import_module("math")
+    return mod.sqrt(4)
+
+fp = fingerprint.get_stage_fingerprint(stage_dynamic_import)
+print(f"Dynamic import fingerprint: {fp}")
+# The 'mod' variable is computed at runtime, not in closure vars
+
+# Edge Case 11: exec'd code
+print("\n--- Edge Case 11: exec'd code ---")
+
+exec_code = "def dynamic_func(): return 42"
+exec(exec_code)
+dynamic_func = eval("dynamic_func")
+
+def stage_execd():
+    return dynamic_func()
+
+fp = fingerprint.get_stage_fingerprint(stage_execd)
+print(f"Exec'd function fingerprint: {fp}")
+
+# Change the exec'd code
+exec_code = "def dynamic_func(): return 999"
+exec(exec_code)
+dynamic_func_v2 = eval("dynamic_func")
+
+def stage_execd_v2():
+    return dynamic_func_v2()
+
+fp2 = fingerprint.get_stage_fingerprint(stage_execd_v2)
+print(f"Changed exec'd function fingerprint: {fp2}")
+
+# Edge Case 12: __getattr__ interception
+print("\n--- Edge Case 12: __getattr__ interception ---")
+
+class LazyModule:
+    """Module that loads callables lazily via __getattr__."""
+
+    def __init__(self):
+        self._callbacks = {}
+
+    def register(self, name, callback):
+        self._callbacks[name] = callback
+
+    def __getattr__(self, name):
+        if name in self._callbacks:
+            return self._callbacks[name]
+        raise AttributeError(name)
+
+lazy = LazyModule()
+lazy.register("process", lambda: 1)
+
+def stage_lazy_attr():
+    return lazy.process()
+
+fp = fingerprint.get_stage_fingerprint(stage_lazy_attr)
+print(f"Lazy attr fingerprint: {fp}")
+
+lazy.register("process", lambda: 2)
+fp2 = fingerprint.get_stage_fingerprint(stage_lazy_attr)
+print(f"After callback change: {fp2}")
+print(f"Detected: {fp != fp2}")
+
+print("\n" + "="*70)
+print("SUMMARY OF ADDITIONAL FINDINGS")
+print("="*70)
+print("""
+Vulnerabilities confirmed:
+1. operator.methodcaller/attrgetter - NOT tracked (stdlib)
+2. Instance attributes changed after capture - NOT tracked
+3. __call__ class changes - MAY be detected (tracks class definition)
+4. Module-level callback variables - TRACKED
+5. Dataclass instance attributes - NOT tracked
+6. Enum values - NOT tracked (enum is the instance, not callable)
+7. Dynamic imports - NOT tracked (runtime computed)
+8. exec'd code - NOT tracked (no reliable source)
+9. __getattr__ intercepted attrs - NOT tracked
+
+The core issue: Fingerprinting captures STATIC closure variables at
+function definition time, but many callbacks are resolved DYNAMICALLY
+at runtime via attribute access, dictionary lookup, or method resolution.
+""")

--- a/experiments/callback_edge_cases/code_object_test.py
+++ b/experiments/callback_edge_cases/code_object_test.py
@@ -1,0 +1,161 @@
+# pyright: reportUnusedFunction=false
+"""
+Investigation of code object behavior with functools.wraps.
+"""
+
+import functools
+import inspect
+import sys
+
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("="*70)
+print("CODE OBJECT INVESTIGATION")
+print("="*70)
+
+# The key question: Does __code__ get copied by @functools.wraps?
+
+def original():
+    return 1
+
+@functools.wraps(original)
+def wrapper():
+    return 999
+
+print(f"original.__code__: {original.__code__}")
+print(f"wrapper.__code__: {wrapper.__code__}")
+print(f"Same __code__: {original.__code__ is wrapper.__code__}")
+
+# Wait, they're the SAME code object?
+print(f"\noriginal.__code__.co_code: {original.__code__.co_code}")
+print(f"wrapper.__code__.co_code: {wrapper.__code__.co_code}")
+
+# Let me check co_consts which contains return values
+print(f"\noriginal.__code__.co_consts: {original.__code__.co_consts}")
+print(f"wrapper.__code__.co_consts: {wrapper.__code__.co_consts}")
+
+# AH HA! The co_consts ARE different - (None, 1) vs (None, 999)
+
+print("""
+DISCOVERY:
+@functools.wraps does NOT copy __code__!
+- __code__ objects are different (different co_consts)
+- But inspect.getsource() follows __wrapped__ and returns original source
+- This is why hash_function_ast sees the original source
+
+Let me verify the flow in fingerprint.hash_function_ast...
+""")
+
+# Test what hash_function_ast actually returns
+h_original = fingerprint.hash_function_ast(original)
+h_wrapper = fingerprint.hash_function_ast(wrapper)
+print(f"hash(original): {h_original}")
+print(f"hash(wrapper): {h_wrapper}")
+
+# Now let's trace through the function:
+print("\n--- Tracing hash_function_ast for wrapper ---")
+
+try:
+    source = inspect.getsource(wrapper)
+    print(f"getsource returned:\n{source}")
+    print("SUCCESS: Got source from getsource")
+except (OSError, TypeError) as e:
+    print(f"FAILED: getsource raised {e}")
+    # Falls through to marshal code object path
+
+# So getsource succeeds and returns the ORIGINAL function's source!
+# That's why the hashes are equal.
+
+print("\n" + "="*70)
+print("THE ROOT CAUSE")
+print("="*70)
+print("""
+inspect.getsource(wrapper) returns original's source because:
+1. @functools.wraps sets wrapper.__wrapped__ = original
+2. inspect.unwrap() is called by getsource to follow __wrapped__
+3. The source of the ORIGINAL function is returned
+
+This means the actual wrapper code is NEVER seen by hash_function_ast.
+
+Proof:
+""")
+
+# Let's verify with unwrap
+unwrapped = inspect.unwrap(wrapper)
+print(f"inspect.unwrap(wrapper) is original: {unwrapped is original}")
+
+# What about nested wrappers?
+print("\n--- Testing nested wrappers ---")
+
+def level0():
+    return 0
+
+@functools.wraps(level0)
+def level1():
+    return 1
+
+@functools.wraps(level1)
+def level2():
+    return 2
+
+print(f"level0 source:\n{inspect.getsource(level0)}")
+print(f"level1 source:\n{inspect.getsource(level1)}")
+print(f"level2 source:\n{inspect.getsource(level2)}")
+
+# All three return level0's source!
+
+h0 = fingerprint.hash_function_ast(level0)
+h1 = fingerprint.hash_function_ast(level1)
+h2 = fingerprint.hash_function_ast(level2)
+print(f"\nhash(level0): {h0}")
+print(f"hash(level1): {h1}")
+print(f"hash(level2): {h2}")
+
+print("""
+CONFIRMED: All three functions have the SAME hash because they all
+trace back to level0's source through the __wrapped__ chain.
+
+This is a CRITICAL vulnerability:
+- Multiple layers of decoration are invisible
+- Each layer could add significant behavior changes
+- None of it is fingerprinted
+""")
+
+# Test the marshal fallback
+print("\n--- Testing marshal fallback ---")
+
+# If we could prevent getsource from working, would marshal work?
+# Create a lambda (which doesn't have reliable source)
+lambda_func = lambda x: x * 2  # noqa: E731
+h_lambda = fingerprint.hash_function_ast(lambda_func)
+print(f"Lambda hash (should use marshal): {h_lambda}")
+
+# For a wrapped function, getsource DOES work (but returns wrong source)
+# So marshal is never tried
+
+print("\n--- Potential fix verification ---")
+
+# What if we checked for __wrapped__ and used __code__ instead?
+import marshal
+import xxhash
+
+def hash_by_code(func):
+    """Hash using __code__ directly (not getsource)."""
+    return xxhash.xxh64(marshal.dumps(func.__code__)).hexdigest()
+
+print(f"original by code: {hash_by_code(original)}")
+print(f"wrapper by code: {hash_by_code(wrapper)}")
+print(f"Different: {hash_by_code(original) != hash_by_code(wrapper)}")
+
+print("""
+FIX: Using marshal.dumps(__code__) would correctly distinguish
+original from wrapper because __code__ is NOT copied by @wraps.
+
+However, this loses the benefit of ignoring whitespace/docstrings.
+A better fix might be to:
+1. Detect __wrapped__ attribute
+2. Hash BOTH the wrapper (via __code__) AND the wrapped (via AST)
+3. Combine the hashes
+""")

--- a/experiments/callback_edge_cases/deep_dive.py
+++ b/experiments/callback_edge_cases/deep_dive.py
@@ -1,0 +1,397 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false, reportUnknownLambdaType=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
+"""
+Deep dive into the vulnerabilities found.
+"""
+
+import functools
+import sys
+import inspect
+
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+
+print("="*70)
+print("VULNERABILITY 1: functools.partial")
+print("="*70)
+print("""
+WHY: functools.partial creates a new callable that wraps the original.
+The partial object is passed as a nonlocal to the inner function.
+However, when fingerprinting processes the partial:
+1. It's callable - check
+2. is_user_code(partial_v1) - what does this return?
+""")
+
+def base_function(multiplier, x):
+    return x * multiplier
+
+partial_v1 = functools.partial(base_function, 2)
+partial_v2 = functools.partial(base_function, 3)
+
+print(f"is_user_code(partial_v1): {fingerprint.is_user_code(partial_v1)}")
+print(f"type(partial_v1): {type(partial_v1)}")
+print(f"partial_v1.__module__: {getattr(partial_v1, '__module__', 'N/A')}")
+
+# What does getclosurevars see?
+def make_stage(p):
+    def stage():
+        return p(10)
+    return stage
+
+stage1 = make_stage(partial_v1)
+cv = inspect.getclosurevars(stage1)
+print(f"\nclosurevars of stage using partial:")
+print(f"  globals: {cv.globals}")
+print(f"  nonlocals: {cv.nonlocals}")
+print(f"  builtins: {list(cv.builtins.keys())[:5]}...")
+
+# The partial is in nonlocals as 'p', but is_user_code returns False!
+# Because functools.partial is from stdlib
+
+print("""
+CONCLUSION: functools.partial objects are NOT user code (stdlib),
+so they're skipped entirely. The wrapped function and arguments are lost.
+
+IMPACT: HIGH - Any stage using functools.partial will not track:
+- Changes to the wrapped function
+- Changes to the partial arguments
+""")
+
+
+print("\n" + "="*70)
+print("VULNERABILITY 2: Multi-layer callbacks")
+print("="*70)
+print("""
+WHY: When a callback is passed through another function that returns
+a wrapper, the inner callback becomes a nonlocal of the wrapper.
+""")
+
+def _inner_callback():
+    return 42
+
+def middle_layer(callback):
+    def wrapper():
+        return callback() + 1
+    return wrapper
+
+wrapped = middle_layer(_inner_callback)
+
+print(f"type(wrapped): {type(wrapped)}")
+print(f"is_user_code(wrapped): {fingerprint.is_user_code(wrapped)}")
+
+cv = inspect.getclosurevars(wrapped)
+print(f"\nclosurevars of wrapped:")
+print(f"  globals: {cv.globals}")
+print(f"  nonlocals: {cv.nonlocals}")
+
+# The 'callback' nonlocal IS the _inner_callback function
+# Let's check if fingerprinting recurses into it
+fp = fingerprint.get_stage_fingerprint(wrapped)
+print(f"\nFingerprint of wrapped: {fp}")
+
+# Now change the inner callback and see if it's detected
+def _inner_callback_v2():
+    return 100
+
+wrapped_v2 = middle_layer(_inner_callback_v2)
+fp2 = fingerprint.get_stage_fingerprint(wrapped_v2)
+print(f"Fingerprint of wrapped_v2: {fp2}")
+
+if fp == fp2:
+    print("VULNERABILITY CONFIRMED: Different inner callbacks, same fingerprint!")
+else:
+    print("Actually detected - need to investigate stage usage pattern")
+
+print("""
+CONCLUSION: The wrapped function DOES capture and track its callback nonlocal.
+The issue is when a STAGE uses wrapped_callback - does the stage's fingerprint
+include the inner callback?
+""")
+
+def stage_multi_layer():
+    return wrapped()
+
+fp_stage = fingerprint.get_stage_fingerprint(stage_multi_layer)
+print(f"\nStage fingerprint: {fp_stage}")
+print(f"Has callback key: {'callback' in str(fp_stage)}")
+
+print("""
+The stage fingerprint DOES include 'func:callback' (the inner callback).
+The "vulnerability" was a false positive - checking if wrapped_callback is
+captured IS sufficient because fingerprinting recurses into its closure.
+""")
+
+
+print("\n" + "="*70)
+print("VULNERABILITY 3: Class attribute callbacks")
+print("="*70)
+
+class Config:
+    callback = None
+
+def _cb_v1():
+    return 1
+
+def _cb_v2():
+    return 2
+
+Config.callback = _cb_v1
+
+def stage_class_attr():
+    return Config.callback()
+
+# Check what fingerprinting sees
+cv = inspect.getclosurevars(stage_class_attr)
+print(f"closurevars of stage_class_attr:")
+print(f"  globals: {cv.globals}")
+print(f"  nonlocals: {cv.nonlocals}")
+
+# Config is in globals. Let's see what fingerprinting does with it
+fp1 = fingerprint.get_stage_fingerprint(stage_class_attr)
+print(f"\nFingerprint with _cb_v1: {fp1}")
+
+Config.callback = _cb_v2
+fp2 = fingerprint.get_stage_fingerprint(stage_class_attr)
+print(f"Fingerprint with _cb_v2: {fp2}")
+
+print(f"\nFP1 == FP2: {fp1 == fp2}")
+
+print("""
+ANALYSIS:
+- Config class is detected as a user-defined class instance? No, it's a type!
+- The fingerprint shows 'class:Config' - it hashes the CLASS definition
+- But Config.callback is a RUNTIME ATTRIBUTE, not part of the class definition
+- The class body at parse time has `callback = None`, so that's what gets hashed
+
+CONCLUSION: Class attributes that are modified at runtime are NOT tracked.
+Only the original class definition is hashed.
+
+IMPACT: HIGH - Any stage that relies on class attributes set at runtime
+will not detect changes to those attributes.
+""")
+
+
+print("\n" + "="*70)
+print("VULNERABILITY 4: functools.wraps")
+print("="*70)
+
+def original():
+    return 1
+
+@functools.wraps(original)
+def wrapped_different():
+    return 2  # Different code!
+
+print(f"original.__name__: {original.__name__}")
+print(f"wrapped_different.__name__: {wrapped_different.__name__}")
+print(f"wrapped_different.__wrapped__: {getattr(wrapped_different, '__wrapped__', 'N/A')}")
+
+fp_orig = fingerprint.get_stage_fingerprint(original)
+fp_wrapped = fingerprint.get_stage_fingerprint(wrapped_different)
+
+print(f"\noriginal fingerprint: {fp_orig}")
+print(f"wrapped_different fingerprint: {fp_wrapped}")
+
+# Let's check the hash_function_ast directly
+h_orig = fingerprint.hash_function_ast(original)
+h_wrapped = fingerprint.hash_function_ast(wrapped_different)
+print(f"\nhash original: {h_orig}")
+print(f"hash wrapped: {h_wrapped}")
+
+# What source does getsource return?
+print(f"\noriginal source:\n{inspect.getsource(original)}")
+print(f"\nwrapped_different source:\n{inspect.getsource(wrapped_different)}")
+
+print("""
+WAIT - the sources ARE different! Let me check why the hashes are the same...
+""")
+
+# Actually, looking at the original test, both used `return 1` vs `return 2`
+# But the test above shows DIFFERENT hashes!
+# Let me recreate the exact scenario from the original test
+
+print("\nRecreating original test scenario:")
+
+def original_func():
+    """Original function."""
+    return 1
+
+@functools.wraps(original_func)
+def wrapped_func():
+    """This is actually different."""
+    return 2
+
+fp1 = fingerprint.get_stage_fingerprint(original_func)
+fp2 = fingerprint.get_stage_fingerprint(wrapped_func)
+print(f"original_func FP: {fp1}")
+print(f"wrapped_func FP: {fp2}")
+
+# AHA! The key is 'self:original_func' in BOTH cases because
+# functools.wraps copies __name__ from the original to the wrapped function!
+
+print("""
+ROOT CAUSE FOUND:
+- functools.wraps copies __name__ from original to wrapped
+- Both fingerprints use 'self:original_func' as the key
+- The hash VALUES are different, but they're stored under the SAME KEY!
+- So when comparing fingerprints as dicts, they appear equal if keys match
+
+Actually wait, let's check the actual values...
+""")
+
+print(f"fp1['self:original_func']: {fp1['self:original_func']}")
+print(f"fp2['self:original_func']: {fp2['self:original_func']}")
+print(f"Values equal: {fp1['self:original_func'] == fp2['self:original_func']}")
+
+# The values are actually equal! That means the AST hashes are equal.
+# But the code is different... Let's check getsource
+
+src_orig = inspect.getsource(original_func)
+src_wrapped = inspect.getsource(wrapped_func)
+print(f"\noriginal_func source:\n{src_orig}")
+print(f"\nwrapped_func source:\n{src_wrapped}")
+
+print("""
+SMOKING GUN: inspect.getsource(wrapped_func) returns the SOURCE OF wrapped_func,
+NOT original_func. But the AST hashes are equal...
+
+Let me check what _normalize_ast does with docstrings...
+""")
+
+import ast
+
+tree_orig = ast.parse(src_orig)
+tree_wrapped = ast.parse(src_wrapped)
+
+# The docstrings should be stripped, and function names normalized
+# Let's see the dumps
+
+print("Original AST dump (before normalize):")
+print(ast.dump(tree_orig, indent=2)[:500])
+
+print("\nWrapped AST dump (before normalize):")
+print(ast.dump(tree_wrapped, indent=2)[:500])
+
+print("""
+AH HA! The issue is that _normalize_ast normalizes FUNCTION NAMES to 'func'.
+So both functions become:
+  def func():
+      return X
+
+But X is 1 vs 2, so they SHOULD be different...
+
+Actually, looking at the test output from before, both returned 1!
+Let me check the actual test functions used...
+""")
+
+# Look at what was ACTUALLY tested - in the original test file
+# Both docstrings are different, but the CODE (return 1) is the same!
+# @functools.wraps just changes metadata, but the test used the SAME return value
+
+print("""
+CORRECTION: In the original test:
+- original_func() returns 1
+- wrapped_func() returns 2 (different!)
+
+But the hashes were reported equal. Let me verify one more time with fresh functions...
+""")
+
+def fresh_v1():
+    return 111
+
+@functools.wraps(fresh_v1)
+def fresh_v2():
+    return 222
+
+h1 = fingerprint.hash_function_ast(fresh_v1)
+h2 = fingerprint.hash_function_ast(fresh_v2)
+print(f"fresh_v1 hash: {h1}")
+print(f"fresh_v2 hash: {h2}")
+print(f"Equal: {h1 == h2}")
+
+print("""
+They're DIFFERENT now! So the original test case must have been buggy.
+
+Let me look at the EXACT code from the original test file...
+""")
+
+
+print("\n" + "="*70)
+print("VULNERABILITY 5: Subscript callbacks (__getitem__)")
+print("="*70)
+
+class Container:
+    def __init__(self):
+        self._data = {}
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+container = Container()
+container["handler"] = _cb_v1
+
+def stage_subscript():
+    return container["handler"]()
+
+cv = inspect.getclosurevars(stage_subscript)
+print(f"closurevars of stage_subscript:")
+print(f"  globals: {cv.globals}")
+
+fp1 = fingerprint.get_stage_fingerprint(stage_subscript)
+print(f"\nFingerprint with _cb_v1: {fp1}")
+
+container["handler"] = _cb_v2
+fp2 = fingerprint.get_stage_fingerprint(stage_subscript)
+print(f"Fingerprint with _cb_v2: {fp2}")
+
+print(f"\nFP1 == FP2: {fp1 == fp2}")
+
+print("""
+ANALYSIS:
+- container is in globals as a user-defined class instance
+- _process_instance_dependency hashes the CLASS definition (Container)
+- It does NOT hash the INSTANCE STATE (container._data)
+- So changing container["handler"] doesn't change the fingerprint
+
+CONCLUSION: Instance state is not tracked, only class definitions.
+
+IMPACT: HIGH - Any mutable container holding callbacks will not track changes.
+""")
+
+
+print("\n" + "="*70)
+print("SUMMARY OF REAL VULNERABILITIES")
+print("="*70)
+print("""
+1. functools.partial - NOT tracked (stdlib, not user code)
+   - Severity: HIGH
+   - Trigger: Using partial(my_func, arg) where arg changes
+   - Impact: Stage won't re-run when partial arguments change
+
+2. Multi-layer callbacks - ACTUALLY WORKS
+   - The test was a false positive
+   - Fingerprinting DOES recurse into closure variables
+
+3. Class attribute callbacks - NOT tracked
+   - Severity: HIGH
+   - Trigger: Class.attr = different_callback at runtime
+   - Impact: Stage won't re-run when class attribute changes
+
+4. functools.wraps - NEED TO VERIFY
+   - May have been a test bug
+   - Needs more investigation
+
+5. Subscript/Instance state callbacks - NOT tracked
+   - Severity: HIGH
+   - Trigger: container["key"] = different_callback
+   - Impact: Stage won't re-run when instance state changes
+
+6. getattr with string literals - NOT tracked (by design)
+   - Severity: MEDIUM
+   - Trigger: getattr(obj, "method_name")() where method_name is a string
+   - Impact: Dynamic dispatch based on strings not tracked
+""")

--- a/experiments/callback_edge_cases/test_callback_edge_cases.py
+++ b/experiments/callback_edge_cases/test_callback_edge_cases.py
@@ -1,0 +1,682 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false, reportUnknownLambdaType=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
+"""
+Red team testing for callback/function argument change detection in fingerprinting.
+
+The goal is to find scenarios where:
+1. A function is passed as a callback/argument
+2. The callback code changes
+3. But the fingerprint stays the same (BUG!)
+"""
+
+import functools
+import sys
+import types
+
+# Add src to path for imports
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+
+# =============================================================================
+# Scenario 1: Callbacks retrieved from dictionaries at runtime
+# =============================================================================
+
+def _callback_v1():
+    """Original callback."""
+    return 1
+
+def _callback_v2():
+    """Changed callback."""
+    return 2
+
+CALLBACK_REGISTRY = {
+    "process": _callback_v1
+}
+
+def stage_uses_dict_callback():
+    """Stage that retrieves callback from dict at runtime."""
+    callback = CALLBACK_REGISTRY["process"]
+    return callback()
+
+
+def test_dict_callback_detection():
+    """Test if callbacks from dict are detected."""
+    print("\n=== Scenario 1: Dict-retrieved callbacks ===")
+
+    # Get fingerprint with v1
+    CALLBACK_REGISTRY["process"] = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(stage_uses_dict_callback)
+
+    # Change callback to v2
+    CALLBACK_REGISTRY["process"] = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage_uses_dict_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if CALLBACK_REGISTRY is in fingerprint
+    has_registry = any("CALLBACK_REGISTRY" in k for k in fp1.keys())
+    print(f"CALLBACK_REGISTRY captured: {has_registry}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Dict callback change NOT detected!")
+    else:
+        print("OK: Dict callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 2: Callbacks via getattr()
+# =============================================================================
+
+class Handlers:
+    @staticmethod
+    def process_v1():
+        return 1
+
+    @staticmethod
+    def process_v2():
+        return 2
+
+def stage_uses_getattr_callback():
+    """Stage that retrieves callback via getattr."""
+    handler_name = "process_v1"
+    callback = getattr(Handlers, handler_name)
+    return callback()
+
+
+def test_getattr_callback_detection():
+    """Test if callbacks from getattr are detected."""
+    print("\n=== Scenario 2: getattr-retrieved callbacks ===")
+
+    fp = fingerprint.get_stage_fingerprint(stage_uses_getattr_callback)
+    print(f"FP keys: {list(fp.keys())}")
+
+    # Check if Handlers class is captured
+    has_handlers = any("Handlers" in k for k in fp.keys())
+    print(f"Handlers captured: {has_handlers}")
+
+    # The issue: changing Handlers.process_v1 would change the class hash,
+    # but the string "process_v1" is just a string in the AST
+    print("INFO: getattr with string literal - dynamic dispatch not tracked")
+
+    return not has_handlers
+
+
+# =============================================================================
+# Scenario 3: functools.partial
+# =============================================================================
+
+def base_function(multiplier, x):
+    """Base function to be partialed."""
+    return x * multiplier
+
+partial_v1 = functools.partial(base_function, 2)
+partial_v2 = functools.partial(base_function, 3)
+
+def stage_uses_partial():
+    """Stage using a partial function."""
+    return partial_v1(10)
+
+
+def test_partial_detection():
+    """Test if partial function changes are detected."""
+    print("\n=== Scenario 3: functools.partial ===")
+
+    # Create the stage function dynamically to test different partials
+    def make_stage(p):
+        def stage():
+            return p(10)
+        return stage
+
+    stage1 = make_stage(partial_v1)
+    stage2 = make_stage(partial_v2)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage1)
+    fp2 = fingerprint.get_stage_fingerprint(stage2)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if partial is in fingerprint
+    has_partial = any("partial" in k.lower() or "p[" in k for k in fp1.keys())
+    print(f"Partial captured: {has_partial}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Partial change NOT detected!")
+    else:
+        print("OK: Partial change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 4: Callbacks selected via runtime conditions
+# =============================================================================
+
+MODE = "fast"
+
+def _slow_process():
+    return 1
+
+def _fast_process():
+    return 2
+
+def stage_conditional_callback():
+    """Stage that selects callback based on runtime condition."""
+    if MODE == "fast":
+        callback = _fast_process
+    else:
+        callback = _slow_process
+    return callback()
+
+
+def test_conditional_callback_detection():
+    """Test if conditional callback selection is detected."""
+    print("\n=== Scenario 4: Runtime conditional selection ===")
+
+    global MODE
+
+    MODE = "fast"
+    fp1 = fingerprint.get_stage_fingerprint(stage_conditional_callback)
+
+    MODE = "slow"
+    fp2 = fingerprint.get_stage_fingerprint(stage_conditional_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+
+    # Both _fast_process and _slow_process should be in closure vars
+    has_fast = any("_fast_process" in k for k in fp1.keys())
+    has_slow = any("_slow_process" in k for k in fp1.keys())
+    print(f"_fast_process captured: {has_fast}")
+    print(f"_slow_process captured: {has_slow}")
+
+    # The fingerprint SHOULD include both functions since both are referenced
+    # But does it?
+
+    if fp1 == fp2:
+        print("OK: Both callbacks captured, fingerprint stable (as expected)")
+    else:
+        print("ISSUE: Fingerprint changes with MODE despite code being same")
+
+    return not (has_fast and has_slow)
+
+
+# =============================================================================
+# Scenario 5: Bound methods
+# =============================================================================
+
+class Processor:
+    def __init__(self, multiplier):
+        self.multiplier = multiplier
+
+    def process(self, x):
+        return x * self.multiplier
+
+processor_v1 = Processor(2)
+processor_v2 = Processor(3)
+
+def stage_bound_method_v1():
+    """Stage using bound method from instance v1."""
+    return processor_v1.process(10)
+
+
+def stage_bound_method_v2():
+    """Stage using bound method from instance v2."""
+    return processor_v2.process(10)
+
+
+def test_bound_method_detection():
+    """Test if bound method instance changes are detected."""
+    print("\n=== Scenario 5: Bound methods ===")
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_bound_method_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_bound_method_v2)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if processor instances are captured
+    has_processor1 = any("processor_v1" in k for k in fp1.keys())
+    has_processor2 = any("processor_v2" in k for k in fp2.keys())
+    print(f"processor_v1 captured: {has_processor1}")
+    print(f"processor_v2 captured: {has_processor2}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Different bound method instances have same fingerprint!")
+    else:
+        print("OK: Bound method instance difference detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 6: Callbacks passed through multiple layers
+# =============================================================================
+
+def _inner_callback():
+    return 42
+
+def middle_layer(callback):
+    """Middle layer that receives callback."""
+    def wrapper():
+        return callback() + 1
+    return wrapper
+
+# The callback is bound at module load time
+wrapped_callback = middle_layer(_inner_callback)
+
+def stage_multi_layer():
+    """Stage using multi-layer wrapped callback."""
+    return wrapped_callback()
+
+
+def test_multi_layer_callback():
+    """Test if callbacks passed through layers are detected."""
+    print("\n=== Scenario 6: Multi-layer callbacks ===")
+
+    fp = fingerprint.get_stage_fingerprint(stage_multi_layer)
+    print(f"FP keys: {list(fp.keys())}")
+
+    # Check if wrapped_callback and _inner_callback are captured
+    has_wrapped = any("wrapped_callback" in k for k in fp.keys())
+    has_inner = any("_inner_callback" in k for k in fp.keys())
+    print(f"wrapped_callback captured: {has_wrapped}")
+    print(f"_inner_callback captured: {has_inner}")
+
+    # The issue: wrapped_callback is a closure that captured _inner_callback
+    # Does fingerprinting recurse into wrapped_callback's closure?
+
+    return not has_inner
+
+
+# =============================================================================
+# Scenario 7: Callbacks from factory functions
+# =============================================================================
+
+def callback_factory(version):
+    """Factory that creates callbacks."""
+    def callback():
+        return version
+    return callback
+
+factory_callback = callback_factory(1)
+
+def stage_factory_callback():
+    """Stage using factory-generated callback."""
+    return factory_callback()
+
+
+def test_factory_callback():
+    """Test if factory-generated callbacks are detected."""
+    print("\n=== Scenario 7: Factory callbacks ===")
+
+    global factory_callback
+
+    factory_callback = callback_factory(1)
+    fp1 = fingerprint.get_stage_fingerprint(stage_factory_callback)
+
+    factory_callback = callback_factory(2)
+    fp2 = fingerprint.get_stage_fingerprint(stage_factory_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if factory_callback is captured
+    has_callback = any("factory_callback" in k for k in fp1.keys())
+    print(f"factory_callback captured: {has_callback}")
+
+    # The issue: Both callbacks have the same code (return version)
+    # but different nonlocal 'version' values
+    # Does fingerprinting capture the nonlocal?
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Factory callback with different closures have same fingerprint!")
+    else:
+        print("OK: Factory callback closure difference detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 8: Class attributes
+# =============================================================================
+
+class Config:
+    callback = _callback_v1
+
+
+def stage_class_attr_callback():
+    """Stage using callback from class attribute."""
+    return Config.callback()
+
+
+def test_class_attr_callback():
+    """Test if class attribute callback changes are detected."""
+    print("\n=== Scenario 8: Class attribute callbacks ===")
+
+    Config.callback = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(stage_class_attr_callback)
+
+    Config.callback = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage_class_attr_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if Config class is captured
+    has_config = any("Config" in k for k in fp1.keys())
+    print(f"Config captured: {has_config}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Class attribute callback change NOT detected!")
+    else:
+        print("OK: Class attribute callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 9: functools.wraps decorated functions
+# =============================================================================
+
+def original_func():
+    """Original function."""
+    return 1
+
+@functools.wraps(original_func)
+def wrapped_func():
+    """This is actually different."""
+    return 2
+
+
+def test_wraps_detection():
+    """Test if functools.wraps doesn't hide code changes."""
+    print("\n=== Scenario 9: functools.wraps ===")
+
+    fp1 = fingerprint.get_stage_fingerprint(original_func)
+    fp2 = fingerprint.get_stage_fingerprint(wrapped_func)
+
+    print(f"FP1: {fp1}")
+    print(f"FP2: {fp2}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: @functools.wraps hides code change!")
+    else:
+        print("OK: @functools.wraps doesn't hide code change")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 10: Callbacks from __getitem__ / subscript access
+# =============================================================================
+
+class CallbackContainer:
+    def __init__(self):
+        self._callbacks = {"default": _callback_v1}
+
+    def __getitem__(self, key):
+        return self._callbacks[key]
+
+container = CallbackContainer()
+
+def stage_subscript_callback():
+    """Stage that gets callback via subscript."""
+    callback = container["default"]
+    return callback()
+
+
+def test_subscript_callback():
+    """Test if subscript-accessed callbacks are detected."""
+    print("\n=== Scenario 10: Subscript access callbacks ===")
+
+    container._callbacks["default"] = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(stage_subscript_callback)
+
+    container._callbacks["default"] = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage_subscript_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if container is captured
+    has_container = any("container" in k for k in fp1.keys())
+    print(f"container captured: {has_container}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Subscript callback change NOT detected!")
+    else:
+        print("OK: Subscript callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 11: Callbacks from module-level variables that change
+# =============================================================================
+
+current_callback = _callback_v1
+
+def stage_module_var_callback():
+    """Stage that uses module-level callback variable."""
+    return current_callback()
+
+
+def test_module_var_callback():
+    """Test if module-level callback variable changes are detected."""
+    print("\n=== Scenario 11: Module variable callbacks ===")
+
+    global current_callback
+
+    current_callback = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(stage_module_var_callback)
+
+    current_callback = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage_module_var_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if current_callback is in fingerprint
+    has_callback = any("current_callback" in k for k in fp1.keys())
+    print(f"current_callback captured: {has_callback}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Module variable callback change NOT detected!")
+    else:
+        print("OK: Module variable callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 12: Callbacks registered via decorator that modifies a global
+# =============================================================================
+
+registered_handlers = {}
+
+def register(name):
+    """Decorator that registers a handler."""
+    def decorator(func):
+        registered_handlers[name] = func
+        return func
+    return decorator
+
+@register("handler")
+def registered_handler_v1():
+    return 1
+
+
+def stage_registered_callback():
+    """Stage that uses registered callback."""
+    callback = registered_handlers["handler"]
+    return callback()
+
+
+def test_registered_callback():
+    """Test if decorator-registered callbacks are detected."""
+    print("\n=== Scenario 12: Decorator-registered callbacks ===")
+
+    # Register v1
+    registered_handlers["handler"] = registered_handler_v1
+    fp1 = fingerprint.get_stage_fingerprint(stage_registered_callback)
+
+    # Register v2 (different function)
+    registered_handlers["handler"] = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage_registered_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if registered_handlers is captured
+    has_handlers = any("registered_handlers" in k for k in fp1.keys())
+    print(f"registered_handlers captured: {has_handlers}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Registered callback change NOT detected!")
+    else:
+        print("OK: Registered callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 13: Lambdas with captured variables
+# =============================================================================
+
+multiplier = 2
+lambda_callback = lambda x: x * multiplier  # noqa: E731
+
+def stage_lambda_with_closure():
+    """Stage using lambda with captured variable."""
+    return lambda_callback(10)
+
+
+def test_lambda_closure_detection():
+    """Test if lambda closure variable changes are detected."""
+    print("\n=== Scenario 13: Lambda with closure ===")
+
+    global lambda_callback, multiplier
+
+    multiplier = 2
+    lambda_callback = lambda x: x * multiplier  # noqa: E731
+    fp1 = fingerprint.get_stage_fingerprint(stage_lambda_with_closure)
+
+    multiplier = 3
+    lambda_callback = lambda x: x * multiplier  # noqa: E731
+    fp2 = fingerprint.get_stage_fingerprint(stage_lambda_with_closure)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # The lambda code is the same, but the captured 'multiplier' is different
+    # Does fingerprinting detect this?
+
+    has_multiplier = any("multiplier" in k for k in fp1.keys())
+    print(f"multiplier captured: {has_multiplier}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Lambda closure change NOT detected!")
+    else:
+        print("OK: Lambda closure change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Scenario 14: Method resolution order / inheritance
+# =============================================================================
+
+class BaseProcessor:
+    def process(self):
+        return 1
+
+class DerivedProcessorV1(BaseProcessor):
+    def process(self):
+        return 2
+
+class DerivedProcessorV2(BaseProcessor):
+    def process(self):
+        return 3
+
+processor_instance = DerivedProcessorV1()
+
+def stage_polymorphic_callback():
+    """Stage using polymorphic method."""
+    return processor_instance.process()
+
+
+def test_polymorphic_callback():
+    """Test if polymorphic method changes are detected."""
+    print("\n=== Scenario 14: Polymorphic callbacks ===")
+
+    global processor_instance
+
+    processor_instance = DerivedProcessorV1()
+    fp1 = fingerprint.get_stage_fingerprint(stage_polymorphic_callback)
+
+    processor_instance = DerivedProcessorV2()
+    fp2 = fingerprint.get_stage_fingerprint(stage_polymorphic_callback)
+
+    print(f"FP1 keys: {list(fp1.keys())}")
+    print(f"FP2 keys: {list(fp2.keys())}")
+
+    # Check if processor_instance is captured
+    has_instance = any("processor_instance" in k for k in fp1.keys())
+    print(f"processor_instance captured: {has_instance}")
+
+    if fp1 == fp2:
+        print("VULNERABILITY: Polymorphic callback change NOT detected!")
+    else:
+        print("OK: Polymorphic callback change detected")
+
+    return fp1 == fp2
+
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+
+if __name__ == "__main__":
+    vulnerabilities = []
+
+    tests = [
+        ("Dict callbacks", test_dict_callback_detection),
+        ("getattr callbacks", test_getattr_callback_detection),
+        ("functools.partial", test_partial_detection),
+        ("Conditional selection", test_conditional_callback_detection),
+        ("Bound methods", test_bound_method_detection),
+        ("Multi-layer callbacks", test_multi_layer_callback),
+        ("Factory callbacks", test_factory_callback),
+        ("Class attribute callbacks", test_class_attr_callback),
+        ("functools.wraps", test_wraps_detection),
+        ("Subscript callbacks", test_subscript_callback),
+        ("Module variable callbacks", test_module_var_callback),
+        ("Registered callbacks", test_registered_callback),
+        ("Lambda closures", test_lambda_closure_detection),
+        ("Polymorphic callbacks", test_polymorphic_callback),
+    ]
+
+    for name, test in tests:
+        try:
+            has_vuln = test()
+            if has_vuln:
+                vulnerabilities.append(name)
+        except Exception as e:
+            print(f"\nERROR in {name}: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print("\n" + "="*60)
+    print("SUMMARY")
+    print("="*60)
+
+    if vulnerabilities:
+        print(f"\nVULNERABILITIES FOUND ({len(vulnerabilities)}):")
+        for v in vulnerabilities:
+            print(f"  - {v}")
+    else:
+        print("\nNo vulnerabilities found!")

--- a/experiments/callback_edge_cases/wraps_investigation.py
+++ b/experiments/callback_edge_cases/wraps_investigation.py
@@ -1,0 +1,190 @@
+# pyright: reportUnusedFunction=false
+"""
+Deep investigation of functools.wraps vulnerability.
+"""
+
+import functools
+import inspect
+import sys
+
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("="*70)
+print("functools.wraps VULNERABILITY - DEEP INVESTIGATION")
+print("="*70)
+
+# Test 1: Basic wraps scenario
+print("\n--- Test 1: Basic @functools.wraps ---")
+
+def original_v1():
+    """Original docstring."""
+    return 1
+
+@functools.wraps(original_v1)
+def different_implementation():
+    """Different docstring - ignored by wraps."""
+    return 999  # Completely different!
+
+print(f"original_v1.__name__: {original_v1.__name__}")
+print(f"different_implementation.__name__: {different_implementation.__name__}")
+print(f"different_implementation.__wrapped__: {different_implementation.__wrapped__}")
+
+# What does getsource return?
+src_orig = inspect.getsource(original_v1)
+src_diff = inspect.getsource(different_implementation)
+
+print(f"\noriginal_v1 source:\n{src_orig}")
+print(f"different_implementation source:\n{src_diff}")
+
+print("""
+KEY INSIGHT: inspect.getsource() returns the SOURCE OF THE WRAPPED FUNCTION
+when @functools.wraps is applied! It follows the __wrapped__ attribute.
+
+This means:
+1. hash_function_ast(different_implementation) hashes original_v1's AST
+2. The completely different implementation (return 999) is NEVER seen
+""")
+
+# Verify by checking the code object directly
+print("\n--- Verifying via code objects ---")
+print(f"original_v1.__code__.co_code: {original_v1.__code__.co_code.hex()}")
+print(f"different_implementation.__code__.co_code: {different_implementation.__code__.co_code.hex()}")
+
+# Code objects ARE different, but getsource is fooled
+
+# Test 2: Manual @wraps equivalent
+print("\n--- Test 2: Manual attributes vs @wraps ---")
+
+def base():
+    return "base"
+
+def manual_wrap():
+    return "manual"
+
+# Manually copy attributes (like wraps does)
+manual_wrap.__name__ = base.__name__
+manual_wrap.__doc__ = base.__doc__
+manual_wrap.__dict__.update(base.__dict__)
+# But NOT __wrapped__ !
+
+print(f"manual_wrap has __wrapped__: {hasattr(manual_wrap, '__wrapped__')}")
+src_manual = inspect.getsource(manual_wrap)
+print(f"manual_wrap source:\n{src_manual}")
+# This works correctly!
+
+# Test 3: Adding __wrapped__ manually
+print("\n--- Test 3: Adding __wrapped__ manually ---")
+
+def target():
+    return "target"
+
+def attacker():
+    return "EVIL CODE"
+
+attacker.__wrapped__ = target  # type: ignore
+
+src_attacker = inspect.getsource(attacker)
+print(f"attacker source:\n{src_attacker}")
+
+# Does this fool fingerprinting?
+fp_target = fingerprint.get_stage_fingerprint(target)
+fp_attacker = fingerprint.get_stage_fingerprint(attacker)
+print(f"target fingerprint: {fp_target}")
+print(f"attacker fingerprint: {fp_attacker}")
+
+print("""
+CONFIRMED: Setting __wrapped__ makes inspect.getsource() return the
+wrapped function's source, completely hiding the actual implementation!
+""")
+
+# Test 4: Decorator that modifies behavior but uses wraps
+print("\n--- Test 4: Real-world decorator pattern ---")
+
+def log_calls(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        print(f"Calling {func.__name__}")
+        result = func(*args, **kwargs)
+        print(f"Result: {result}")
+        return result
+    return wrapper
+
+@log_calls
+def add(a, b):
+    return a + b
+
+def add_v2(a, b):
+    return a + b
+
+print(f"add (decorated) source:\n{inspect.getsource(add)}")
+print(f"add_v2 (undecorated) source:\n{inspect.getsource(add_v2)}")
+
+fp_add = fingerprint.get_stage_fingerprint(add)
+fp_add_v2 = fingerprint.get_stage_fingerprint(add_v2)
+print(f"add fingerprint: {fp_add}")
+print(f"add_v2 fingerprint: {fp_add_v2}")
+
+print("""
+IMPACT ANALYSIS:
+
+The @functools.wraps decorator (or anything setting __wrapped__) causes
+hash_function_ast() to hash the WRAPPED function, not the WRAPPER.
+
+This means:
+1. Any decorator using @functools.wraps will have the DECORATOR CODE IGNORED
+2. Only the original wrapped function is fingerprinted
+3. Changing the decorator's behavior (e.g., adding caching, logging, validation)
+   will NOT trigger a re-run
+
+SEVERITY: CRITICAL
+- Very common pattern in Python
+- Affects: @lru_cache, @cache, custom decorators, middleware patterns
+- Completely invisible - decorator code is never fingerprinted
+""")
+
+# Test 5: @functools.lru_cache
+print("\n--- Test 5: @functools.lru_cache ---")
+
+@functools.lru_cache(maxsize=100)
+def cached_v1(x):
+    return x * 2
+
+@functools.lru_cache(maxsize=1000)  # Different cache size!
+def cached_v2(x):
+    return x * 2
+
+fp_cached_v1 = fingerprint.get_stage_fingerprint(cached_v1)
+fp_cached_v2 = fingerprint.get_stage_fingerprint(cached_v2)
+
+print(f"cached_v1 fingerprint: {fp_cached_v1}")
+print(f"cached_v2 fingerprint: {fp_cached_v2}")
+print(f"Equal: {fp_cached_v1 == fp_cached_v2}")
+
+print("""
+@functools.lru_cache ALSO uses __wrapped__, so:
+- Different maxsize values produce SAME fingerprint
+- Adding/removing @lru_cache is NOT detected
+""")
+
+# Test 6: The nuclear option - can we detect __wrapped__?
+print("\n--- Test 6: Detecting __wrapped__ ---")
+
+def has_wrapped(func):
+    return hasattr(func, '__wrapped__')
+
+print(f"original_v1 has __wrapped__: {has_wrapped(original_v1)}")
+print(f"different_implementation has __wrapped__: {has_wrapped(different_implementation)}")
+print(f"cached_v1 has __wrapped__: {has_wrapped(cached_v1)}")
+
+print("""
+MITIGATION STRATEGY:
+In hash_function_ast(), check for __wrapped__ and:
+1. Hash BOTH the wrapper and the wrapped function
+2. Or: Follow __wrapped__ chain and hash ALL functions in it
+3. Or: Explicitly ignore __wrapped__ and get source differently
+
+The current implementation is vulnerable because it trusts inspect.getsource()
+which follows __wrapped__ automatically.
+""")

--- a/experiments/edge_case_container_instances.py
+++ b/experiments/edge_case_container_instances.py
@@ -1,0 +1,111 @@
+"""
+Detailed test for instances inside containers.
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("=" * 80)
+print("BUG PROOF: Instances inside containers are NOT tracked")
+print("=" * 80)
+
+class WorkerV1:
+    def work(self, x):
+        return x + 1  # V1: adds 1
+
+class WorkerV2:
+    def work(self, x):
+        return x + 999  # V2: adds 999
+
+# Test 1: Instance in dict
+print("\n--- Test 1: Instance in dict ---")
+workers_dict = {"main": WorkerV1()}
+
+def stage_dict():
+    return workers_dict["main"].work(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_dict)
+print(f"Fingerprint with WorkerV1 in dict: {fp1}")
+print(f"Result: {stage_dict()}")
+
+# Replace with different implementation
+workers_dict["main"] = WorkerV2()
+
+fp2 = fingerprint.get_stage_fingerprint(stage_dict)
+print(f"Fingerprint with WorkerV2 in dict: {fp2}")
+print(f"Result: {stage_dict()}")
+print(f"Fingerprints SAME (BUG!): {fp1 == fp2}")
+
+# Test 2: Instance in list
+print("\n--- Test 2: Instance in list ---")
+workers_list = [WorkerV1()]
+
+def stage_list():
+    return workers_list[0].work(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_list)
+print(f"Fingerprint with WorkerV1 in list: {fp1}")
+print(f"Result: {stage_list()}")
+
+workers_list[0] = WorkerV2()
+
+fp2 = fingerprint.get_stage_fingerprint(stage_list)
+print(f"Fingerprint with WorkerV2 in list: {fp2}")
+print(f"Result: {stage_list()}")
+print(f"Fingerprints SAME (BUG!): {fp1 == fp2}")
+
+# Test 3: Instance in tuple (immutable, so different tuples)
+print("\n--- Test 3: Instance in tuple ---")
+workers_tuple_v1 = (WorkerV1(),)
+workers_tuple_v2 = (WorkerV2(),)
+
+def stage_tuple_v1():
+    return workers_tuple_v1[0].work(10)
+
+def stage_tuple_v2():
+    return workers_tuple_v2[0].work(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_tuple_v1)
+fp2 = fingerprint.get_stage_fingerprint(stage_tuple_v2)
+print(f"Fingerprint V1 tuple: {fp1}")
+print(f"Fingerprint V2 tuple: {fp2}")
+print(f"Fingerprints SAME (BUG!): {fp1 == fp2}")
+
+# Test 4: Nested dict with instance
+print("\n--- Test 4: Nested dict with instance ---")
+config_v1 = {"processing": {"worker": WorkerV1()}}
+config_v2 = {"processing": {"worker": WorkerV2()}}
+
+def stage_nested_v1():
+    return config_v1["processing"]["worker"].work(10)
+
+def stage_nested_v2():
+    return config_v2["processing"]["worker"].work(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_nested_v1)
+fp2 = fingerprint.get_stage_fingerprint(stage_nested_v2)
+print(f"Fingerprint V1 nested: {fp1}")
+print(f"Fingerprint V2 nested: {fp2}")
+print(f"Results differ: {stage_nested_v1()} vs {stage_nested_v2()}")
+print(f"Fingerprints SAME (BUG!): {fp1 == fp2}")
+
+print("\n" + "=" * 80)
+print("ANALYSIS")
+print("=" * 80)
+print("""
+The _process_collection_dependency function only processes CALLABLE items:
+
+    for i, value in enumerate(items):
+        if callable(value) and is_user_code(value):
+            _add_callable_to_manifest(...)
+
+Instance objects are NOT callable (unless they have __call__), so they are
+completely ignored. This means any instance stored in a dict/list/tuple
+will not have its class tracked in the fingerprint.
+
+IMPACT:
+- Pipeline configurations that store worker instances in dicts/lists
+- Strategy pattern implementations where strategies are in a registry
+- Plugin systems where plugins are stored in collections
+""")

--- a/experiments/edge_case_fingerprint.py
+++ b/experiments/edge_case_fingerprint.py
@@ -1,0 +1,325 @@
+"""
+Red team testing: Finding edge cases where instance method changes are NOT detected.
+
+The current fingerprinting mechanism tracks instances via `type(instance)` -> class AST hash.
+We need to find scenarios where:
+1. An instance exists in closure vars
+2. A stage calls a method on it
+3. The method code changes
+4. But the fingerprint stays the same
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("=" * 80)
+print("EDGE CASE 1: Method defined on instance, not class")
+print("=" * 80)
+
+class BaseProcessor:
+    def process(self, x):
+        return x * 2
+
+# Create instance and monkey-patch a method directly on the instance
+processor1 = BaseProcessor()
+processor1.process = lambda self, x: x * 100  # Instance-level override
+
+def stage_uses_processor():
+    return processor1.process(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_uses_processor)
+print(f"Fingerprint keys: {list(fp1.keys())}")
+print(f"Class key present: {'class:processor1.__class__' in fp1}")
+
+# Now change the monkey-patched method
+processor1.process = lambda self, x: x * 999  # Different logic
+
+fp2 = fingerprint.get_stage_fingerprint(stage_uses_processor)
+print(f"Fingerprint changed after monkey-patch: {fp1 != fp2}")
+print(f"Fingerprint SAME (BUG!): {fp1 == fp2}")
+print()
+
+print("=" * 80)
+print("EDGE CASE 2: __getattr__ delegation / Proxy objects")
+print("=" * 80)
+
+class RealWorker:
+    def compute(self, x):
+        return x + 1
+
+class Proxy:
+    """Proxy that delegates to another object."""
+    def __init__(self, target):
+        self._target = target
+
+    def __getattr__(self, name):
+        return getattr(self._target, name)
+
+real_worker_v1 = RealWorker()
+proxy = Proxy(real_worker_v1)
+
+def stage_uses_proxy():
+    return proxy.compute(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_uses_proxy)
+print(f"Fingerprint keys: {list(fp1.keys())}")
+
+# The fingerprint tracks Proxy class, but the real work is in RealWorker
+# If RealWorker.compute changes, will fingerprint detect it?
+print(f"Note: Only Proxy class is tracked, not RealWorker!")
+print()
+
+print("=" * 80)
+print("EDGE CASE 3: Mixin classes where method is inherited")
+print("=" * 80)
+
+class LogMixin:
+    def log_and_process(self, x):
+        return x * 2
+
+class ConcreteProcessor(LogMixin):
+    pass
+
+processor = ConcreteProcessor()
+
+def stage_with_mixin():
+    return processor.log_and_process(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_with_mixin)
+print(f"Fingerprint keys: {list(fp.keys())}")
+print(f"Class tracked: {'class:processor.__class__' in fp}")
+
+# The method is defined in LogMixin, not ConcreteProcessor
+# Does the fingerprint include LogMixin's hash?
+print(f"Note: log_and_process is from LogMixin, but only ConcreteProcessor is hashed!")
+print()
+
+print("=" * 80)
+print("EDGE CASE 4: Factory-created instance with closure state")
+print("=" * 80)
+
+def create_processor(multiplier):
+    class DynamicProcessor:
+        def process(self, x):
+            return x * multiplier
+    return DynamicProcessor()
+
+processor_2x = create_processor(2)
+processor_10x = create_processor(10)
+
+def stage_with_2x():
+    return processor_2x.process(5)
+
+def stage_with_10x():
+    return processor_10x.process(5)
+
+fp_2x = fingerprint.get_stage_fingerprint(stage_with_2x)
+fp_10x = fingerprint.get_stage_fingerprint(stage_with_10x)
+
+print(f"2x fingerprint: {fp_2x}")
+print(f"10x fingerprint: {fp_10x}")
+print(f"Different fingerprints: {fp_2x != fp_10x}")
+print(f"SAME fingerprints (BUG!): {fp_2x == fp_10x}")
+print()
+
+print("=" * 80)
+print("EDGE CASE 5: Instance stored in container (dict/list)")
+print("=" * 80)
+
+class Worker:
+    def work(self, x):
+        return x * 2
+
+workers = {"main": Worker()}
+
+def stage_uses_dict_worker():
+    return workers["main"].work(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_uses_dict_worker)
+print(f"Fingerprint keys: {list(fp.keys())}")
+print(f"Note: workers dict is in closure, but the Worker instance inside is NOT tracked")
+print()
+
+print("=" * 80)
+print("EDGE CASE 6: Instance imported from another module")
+print("=" * 80)
+
+# Simulating: from some_module import shared_instance
+# The instance is in globals, but is_user_code might fail if module path is weird
+
+import types
+fake_module = types.ModuleType("fake_external")
+fake_module.__file__ = "/home/pivot/agent1/src/fake_external.py"
+
+class ExternalService:
+    def fetch(self, x):
+        return x + 100
+
+fake_module.service = ExternalService()
+fake_module.ExternalService = ExternalService
+sys.modules["fake_external"] = fake_module
+
+# Now import it
+import fake_external
+
+def stage_uses_imported_instance():
+    return fake_external.service.fetch(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_uses_imported_instance)
+print(f"Fingerprint keys: {list(fp.keys())}")
+print(f"service attribute tracked: {'mod:fake_external.service' in fp}")
+print()
+
+print("=" * 80)
+print("EDGE CASE 7: __class__ changed at runtime")
+print("=" * 80)
+
+class OriginalClass:
+    def do_work(self):
+        return "original"
+
+class ModifiedClass:
+    def do_work(self):
+        return "modified"
+
+obj = OriginalClass()
+
+def stage_with_mutable_class():
+    return obj.do_work()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_with_mutable_class)
+print(f"Before class change: {list(fp1.keys())}")
+
+# Now mutate the object's class!
+obj.__class__ = ModifiedClass
+
+fp2 = fingerprint.get_stage_fingerprint(stage_with_mutable_class)
+print(f"After class change: {list(fp2.keys())}")
+print(f"Fingerprint changed: {fp1 != fp2}")
+print("Note: This DOES work because type(obj) changes")
+print()
+
+print("=" * 80)
+print("EDGE CASE 8: Method overridden by descriptor")
+print("=" * 80)
+
+class CachedMethod:
+    """A descriptor that caches method results but can be replaced."""
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return self.func.__get__(obj, objtype)
+
+class ServiceWithDescriptor:
+    @CachedMethod
+    def compute(self, x):
+        return x * 2
+
+svc = ServiceWithDescriptor()
+
+def stage_with_descriptor():
+    return svc.compute(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_with_descriptor)
+print(f"Fingerprint keys: {list(fp.keys())}")
+print(f"Note: The compute method is wrapped in a descriptor")
+print()
+
+print("=" * 80)
+print("EDGE CASE 9: Method from dynamically created class via type()")
+print("=" * 80)
+
+def make_processor_class(multiplier):
+    def process(self, x):
+        return x * multiplier
+    return type("DynamicProcessor", (), {"process": process})
+
+DynClass1 = make_processor_class(2)
+DynClass2 = make_processor_class(10)
+
+obj1 = DynClass1()
+obj2 = DynClass2()
+
+def stage_dyn1():
+    return obj1.process(5)
+
+def stage_dyn2():
+    return obj2.process(5)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_dyn1)
+fp2 = fingerprint.get_stage_fingerprint(stage_dyn2)
+print(f"Dynamic class 1 fingerprint keys: {list(fp1.keys())}")
+print(f"Dynamic class 2 fingerprint keys: {list(fp2.keys())}")
+print(f"Different fingerprints: {fp1 != fp2}")
+print(f"SAME fingerprints (potential BUG): {fp1 == fp2}")
+print()
+
+print("=" * 80)
+print("EDGE CASE 10: Instance method bound at runtime")
+print("=" * 80)
+
+class Calculator:
+    def add(self, x, y):
+        return x + y
+
+    def multiply(self, x, y):
+        return x * y
+
+calc = Calculator()
+operation = calc.add  # Bound method stored in variable
+
+def stage_with_bound_method():
+    return operation(1, 2)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_with_bound_method)
+print(f"Fingerprint keys: {list(fp1.keys())}")
+
+# Now swap to multiply
+operation = calc.multiply
+
+# Re-fingerprint
+fp2 = fingerprint.get_stage_fingerprint(stage_with_bound_method)
+print(f"After swapping bound method: {fp1 == fp2}")
+print(f"Note: 'operation' is a bound method, closure capture might not update")
+print()
+
+print("=" * 80)
+print("EDGE CASE 11: Subclass overrides method but instance is typed as parent")
+print("=" * 80)
+
+class BaseService:
+    def process(self, x):
+        return x + 1
+
+class EnhancedService(BaseService):
+    def process(self, x):
+        return x * 100
+
+# Instance is EnhancedService but often typed/documented as BaseService
+service: BaseService = EnhancedService()
+
+def stage_with_subclass():
+    return service.process(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_with_subclass)
+print(f"Fingerprint keys: {list(fp.keys())}")
+print(f"Note: type(service) is EnhancedService, so this should work correctly")
+print(f"Class hash would include EnhancedService.process")
+print()
+
+print("=" * 80)
+print("SUMMARY OF POTENTIAL BUGS")
+print("=" * 80)
+print("""
+1. Instance-level monkey-patched methods NOT detected (methods attached directly to instance)
+2. Proxy/delegation patterns - only proxy class tracked, not delegated target
+3. Mixin methods - only concrete class hashed, not mixin base classes
+4. Factory-created classes with closure state - multiplier not captured
+5. Instances inside containers (dict/list) - not recursively tracked
+6. Bound methods in closure - swapping doesn't update fingerprint (closure captures early)
+7. Dynamic type() classes - may have same name but different implementations
+""")

--- a/experiments/edge_case_fingerprint_additional.py
+++ b/experiments/edge_case_fingerprint_additional.py
@@ -1,0 +1,277 @@
+"""
+Additional edge cases to complete the red team analysis.
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("=" * 80)
+print("EDGE CASE: functools.wraps decorator")
+print("=" * 80)
+
+import functools
+
+def original_process(x):
+    return x + 1
+
+def wrapper_factory(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs) * 2
+    return wrapper
+
+wrapped = wrapper_factory(original_process)
+
+def stage_wrapped():
+    return wrapped(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_wrapped)
+print(f"Fingerprint: {fp1}")
+print(f"wrapped.__name__: {wrapped.__name__}")
+print(f"wrapped.__wrapped__: {getattr(wrapped, '__wrapped__', 'NOT SET')}")
+
+# Now change the original function
+def original_process_v2(x):
+    return x + 999
+
+wrapped_v2 = wrapper_factory(original_process_v2)
+
+def stage_wrapped_v2():
+    return wrapped_v2(10)
+
+fp2 = fingerprint.get_stage_fingerprint(stage_wrapped_v2)
+print(f"Fingerprint V2: {fp2}")
+print(f"Fingerprints same: {fp1 == fp2}")
+print()
+
+print("=" * 80)
+print("EDGE CASE: Lambda in closure")
+print("=" * 80)
+
+multiplier_v1 = lambda x: x * 2  # noqa: E731
+multiplier_v2 = lambda x: x * 999  # noqa: E731
+
+def stage_lambda_v1():
+    return multiplier_v1(10)
+
+def stage_lambda_v2():
+    return multiplier_v2(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_lambda_v1)
+fp2 = fingerprint.get_stage_fingerprint(stage_lambda_v2)
+print(f"Lambda V1 fingerprint: {fp1}")
+print(f"Lambda V2 fingerprint: {fp2}")
+print(f"Different: {fp1 != fp2}")
+print()
+
+print("=" * 80)
+print("EDGE CASE: Class method vs instance method")
+print("=" * 80)
+
+class ProcessorWithClassMethod:
+    @classmethod
+    def class_process(cls, x):
+        return x + 1
+
+    @staticmethod
+    def static_process(x):
+        return x + 2
+
+    def instance_process(self, x):
+        return x + 3
+
+proc = ProcessorWithClassMethod()
+
+def stage_classmethod():
+    return ProcessorWithClassMethod.class_process(10)
+
+def stage_staticmethod():
+    return ProcessorWithClassMethod.static_process(10)
+
+def stage_instancemethod():
+    return proc.instance_process(10)
+
+fp_class = fingerprint.get_stage_fingerprint(stage_classmethod)
+fp_static = fingerprint.get_stage_fingerprint(stage_staticmethod)
+fp_instance = fingerprint.get_stage_fingerprint(stage_instancemethod)
+
+print(f"Classmethod fingerprint: {fp_class}")
+print(f"Staticmethod fingerprint: {fp_static}")
+print(f"Instancemethod fingerprint: {fp_instance}")
+print()
+
+print("=" * 80)
+print("EDGE CASE: __slots__ class")
+print("=" * 80)
+
+class SlottedClass:
+    __slots__ = ['value']
+
+    def __init__(self, value):
+        self.value = value
+
+    def process(self, x):
+        return x + self.value
+
+slotted = SlottedClass(10)
+
+def stage_slotted():
+    return slotted.process(5)
+
+fp = fingerprint.get_stage_fingerprint(stage_slotted)
+print(f"Slotted class fingerprint: {fp}")
+print()
+
+print("=" * 80)
+print("EDGE CASE: dataclass")
+print("=" * 80)
+
+import dataclasses
+
+@dataclasses.dataclass
+class DataProcessor:
+    multiplier: int = 2
+
+    def process(self, x):
+        return x * self.multiplier
+
+data_proc = DataProcessor(multiplier=3)
+
+def stage_dataclass():
+    return data_proc.process(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_dataclass)
+print(f"Dataclass fingerprint: {fp}")
+print(f"Note: multiplier value (3) is stored in instance, not in class definition")
+print()
+
+# Check if multiplier value change is detected
+data_proc_v2 = DataProcessor(multiplier=999)
+
+def stage_dataclass_v2():
+    return data_proc_v2.process(10)
+
+fp_v2 = fingerprint.get_stage_fingerprint(stage_dataclass_v2)
+print(f"Dataclass V2 fingerprint: {fp_v2}")
+print(f"Different fingerprints: {fp != fp_v2}")
+print(f"BUG: Instance state (multiplier value) is NOT tracked!")
+print()
+
+print("=" * 80)
+print("EDGE CASE: Property getter/setter")
+print("=" * 80)
+
+class ConfigWithProperty:
+    def __init__(self):
+        self._threshold = 0.5
+
+    @property
+    def threshold(self):
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value):
+        self._threshold = value
+
+    def is_above_threshold(self, x):
+        return x > self._threshold
+
+config = ConfigWithProperty()
+
+def stage_property():
+    return config.is_above_threshold(0.6)
+
+fp = fingerprint.get_stage_fingerprint(stage_property)
+print(f"Property fingerprint: {fp}")
+print()
+
+print("=" * 80)
+print("EDGE CASE: Instance attribute (config value)")
+print("=" * 80)
+
+class ModelConfig:
+    def __init__(self, learning_rate):
+        self.learning_rate = learning_rate
+
+    def get_lr(self):
+        return self.learning_rate
+
+config_v1 = ModelConfig(learning_rate=0.001)
+config_v2 = ModelConfig(learning_rate=0.1)  # Different value!
+
+def stage_config_v1():
+    return config_v1.get_lr()
+
+def stage_config_v2():
+    return config_v2.get_lr()
+
+fp1 = fingerprint.get_stage_fingerprint(stage_config_v1)
+fp2 = fingerprint.get_stage_fingerprint(stage_config_v2)
+
+print(f"Config V1 fingerprint: {fp1}")
+print(f"Config V2 fingerprint: {fp2}")
+print(f"Class hashes same: {fp1.get('class:config_v1.__class__') == fp2.get('class:config_v2.__class__')}")
+print(f"BUG: Instance attribute values (learning_rate) are NOT tracked!")
+print()
+
+print("=" * 80)
+print("EDGE CASE: Enum class")
+print("=" * 80)
+
+import enum
+
+class Mode(enum.Enum):
+    FAST = "fast"
+    ACCURATE = "accurate"
+
+def stage_enum():
+    return Mode.FAST.value
+
+fp = fingerprint.get_stage_fingerprint(stage_enum)
+print(f"Enum fingerprint: {fp}")
+print()
+
+print("=" * 80)
+print("SUMMARY OF ALL CONFIRMED BUGS")
+print("=" * 80)
+print("""
+CRITICAL SEVERITY:
+1. Base class / mixin method changes NOT detected
+   - Only concrete class is hashed
+   - Methods inherited from user-defined base classes are invisible
+   - MRO is completely ignored
+
+2. Instance attribute values NOT tracked
+   - Class is hashed, but instance state is not
+   - Different ModelConfig(lr=0.001) vs ModelConfig(lr=0.1) have same fingerprint
+   - Dataclass field values are not tracked
+
+HIGH SEVERITY:
+3. Instance-level monkey-patched methods NOT detected
+   - Methods attached directly to instance via types.MethodType
+   - type(instance) still returns the original class
+
+4. Instances inside collections NOT tracked
+   - Dict/list values that are instances are silently ignored
+   - _process_collection_dependency only handles callables
+
+5. Proxy/delegation objects (__getattr__)
+   - Only proxy class tracked, not the delegated target
+
+6. Module.instance.method pattern
+   - mod:module.instance tracked as repr, not the method code
+
+MEDIUM SEVERITY:
+7. Nested attribute access (obj.attr.method)
+   - Only top-level obj tracked
+   - Nested objects invisible
+
+8. functools.partial wrapping methods
+   - May or may not be tracked depending on how captured
+
+DESIGN LIMITATIONS (lower priority):
+9. Instance state in general is not tracked
+   - self.x values are only tracked if they're in class definition
+   - Runtime state changes are invisible
+""")

--- a/experiments/edge_case_fingerprint_final.py
+++ b/experiments/edge_case_fingerprint_final.py
@@ -1,0 +1,130 @@
+"""
+FINAL PROOF: Demonstrating that base class method changes are NOT detected
+when the concrete class AST doesn't change.
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+import tempfile
+import importlib.util
+import os
+from pivot import fingerprint
+
+print("=" * 80)
+print("PROOF: Base class method change not detected")
+print("=" * 80)
+
+# Create temporary module files to simulate real file editing
+with tempfile.TemporaryDirectory() as tmpdir:
+    # Write base_v1.py
+    base_path = os.path.join(tmpdir, "base.py")
+    with open(base_path, "w") as f:
+        f.write("""
+class BaseMixin:
+    def process(self, x):
+        return x + 1  # V1 implementation
+""")
+
+    # Write concrete.py that imports from base
+    concrete_path = os.path.join(tmpdir, "concrete.py")
+    with open(concrete_path, "w") as f:
+        f.write("""
+from base import BaseMixin
+
+class MyProcessor(BaseMixin):
+    '''Concrete processor using BaseMixin.'''
+    pass
+""")
+
+    # Add tmpdir to sys.path
+    sys.path.insert(0, tmpdir)
+
+    # Import the modules
+    spec_base = importlib.util.spec_from_file_location("base", base_path)
+    base_module = importlib.util.module_from_spec(spec_base)
+    sys.modules["base"] = base_module
+    spec_base.loader.exec_module(base_module)
+
+    spec_concrete = importlib.util.spec_from_file_location("concrete", concrete_path)
+    concrete_module = importlib.util.module_from_spec(spec_concrete)
+    sys.modules["concrete"] = concrete_module
+    spec_concrete.loader.exec_module(concrete_module)
+
+    # Create instance and stage
+    proc_v1 = concrete_module.MyProcessor()
+
+    def stage_v1():
+        return proc_v1.process(10)
+
+    fp_v1 = fingerprint.get_stage_fingerprint(stage_v1)
+    print(f"V1 fingerprint: {fp_v1}")
+    print(f"V1 result: {stage_v1()}")
+
+    # Now modify ONLY the base class method
+    with open(base_path, "w") as f:
+        f.write("""
+class BaseMixin:
+    def process(self, x):
+        return x + 999  # V2 implementation - CHANGED!
+""")
+
+    # Reload the base module
+    importlib.reload(base_module)
+
+    # Reload concrete to pick up new base class
+    importlib.reload(concrete_module)
+
+    # Create new instance
+    proc_v2 = concrete_module.MyProcessor()
+
+    def stage_v2():
+        return proc_v2.process(10)
+
+    fp_v2 = fingerprint.get_stage_fingerprint(stage_v2)
+    print(f"V2 fingerprint: {fp_v2}")
+    print(f"V2 result: {stage_v2()}")
+
+    # Compare
+    class_hash_v1 = fp_v1.get('class:proc_v1.__class__')
+    class_hash_v2 = fp_v2.get('class:proc_v2.__class__')
+
+    print(f"\nClass hash V1: {class_hash_v1}")
+    print(f"Class hash V2: {class_hash_v2}")
+    print(f"Class hashes SAME: {class_hash_v1 == class_hash_v2}")
+    print()
+
+    print("=" * 80)
+    print("ANALYSIS")
+    print("=" * 80)
+
+    import inspect
+    print("MyProcessor source (hashed by Pivot):")
+    print(inspect.getsource(concrete_module.MyProcessor))
+    print()
+
+    print("BaseMixin source (NOT hashed by Pivot):")
+    print(inspect.getsource(base_module.BaseMixin))
+    print()
+
+    # Check MRO
+    print("MyProcessor.__mro__:")
+    for cls in concrete_module.MyProcessor.__mro__:
+        print(f"  {cls.__name__}")
+        if fingerprint.is_user_code(cls) and cls != object:
+            print(f"    is_user_code: True")
+            print(f"    hash: {fingerprint.hash_function_ast(cls)}")
+    print()
+
+    print("=" * 80)
+    print("BUG CONFIRMED")
+    print("=" * 80)
+    if class_hash_v1 == class_hash_v2:
+        print("*** BUG: Class hashes are SAME despite base class method change! ***")
+        print("*** Stage would NOT be re-run even though behavior changed! ***")
+    else:
+        print("Note: Hashes differ, but check if it's just due to stage name difference")
+
+    # Cleanup
+    sys.path.remove(tmpdir)
+    del sys.modules["base"]
+    del sys.modules["concrete"]

--- a/experiments/edge_case_fingerprint_v2.py
+++ b/experiments/edge_case_fingerprint_v2.py
@@ -1,0 +1,336 @@
+"""
+Deeper investigation of confirmed bugs and additional edge cases.
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+
+print("=" * 80)
+print("BUG 1 DEEP DIVE: Instance-level monkey-patch")
+print("=" * 80)
+
+class Processor:
+    def process(self, x):
+        return x * 2
+
+processor = Processor()
+
+def original_method(self, x):
+    return x * 100
+
+def modified_method(self, x):
+    return x * 999
+
+# Attach method to instance
+import types
+processor.process = types.MethodType(original_method, processor)
+
+def stage_monkey():
+    return processor.process(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_monkey)
+print(f"FP with original monkey-patch: {fp1}")
+
+# Change the monkey-patched method
+processor.process = types.MethodType(modified_method, processor)
+
+fp2 = fingerprint.get_stage_fingerprint(stage_monkey)
+print(f"FP with modified monkey-patch: {fp2}")
+print(f"BUG CONFIRMED: Fingerprints are SAME: {fp1 == fp2}")
+print()
+
+print("=" * 80)
+print("BUG 3 DEEP DIVE: Mixin method changes NOT detected")
+print("=" * 80)
+
+# Simulate code change by creating two different mixin versions
+class LogMixinV1:
+    def log_and_process(self, x):
+        return x * 2  # Version 1
+
+class LogMixinV2:
+    def log_and_process(self, x):
+        return x * 3  # Version 2 - CHANGED!
+
+# Create concrete classes from each mixin
+class ConcreteV1(LogMixinV1):
+    pass
+
+class ConcreteV2(LogMixinV2):
+    pass
+
+proc_v1 = ConcreteV1()
+proc_v2 = ConcreteV2()
+
+def stage_v1():
+    return proc_v1.log_and_process(10)
+
+def stage_v2():
+    return proc_v2.log_and_process(10)
+
+fp_v1 = fingerprint.get_stage_fingerprint(stage_v1)
+fp_v2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+print(f"V1 fingerprint: {fp_v1}")
+print(f"V2 fingerprint: {fp_v2}")
+
+# Check if class hashes differ
+print(f"Class hashes differ: {fp_v1.get('class:proc_v1.__class__') != fp_v2.get('class:proc_v2.__class__')}")
+
+# But what if we just hash the concrete class (which has no body)?
+print(f"Note: ConcreteV1 and ConcreteV2 both have empty bodies (just 'pass')")
+print()
+
+print("=" * 80)
+print("BUG 5 DEEP DIVE: Instances in containers")
+print("=" * 80)
+
+class WorkerV1:
+    def work(self, x):
+        return x + 1
+
+class WorkerV2:
+    def work(self, x):
+        return x + 999  # Different logic
+
+workers_v1 = {"main": WorkerV1()}
+workers_v2 = {"main": WorkerV2()}
+
+def stage_dict_v1():
+    return workers_v1["main"].work(10)
+
+def stage_dict_v2():
+    return workers_v2["main"].work(10)
+
+fp_v1 = fingerprint.get_stage_fingerprint(stage_dict_v1)
+fp_v2 = fingerprint.get_stage_fingerprint(stage_dict_v2)
+
+print(f"V1 dict worker fingerprint: {fp_v1}")
+print(f"V2 dict worker fingerprint: {fp_v2}")
+print(f"BUG: Instance inside dict is NOT tracked at all")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Instance in list")
+print("=" * 80)
+
+workers_list_v1 = [WorkerV1()]
+workers_list_v2 = [WorkerV2()]
+
+def stage_list_v1():
+    return workers_list_v1[0].work(10)
+
+def stage_list_v2():
+    return workers_list_v2[0].work(10)
+
+fp_v1 = fingerprint.get_stage_fingerprint(stage_list_v1)
+fp_v2 = fingerprint.get_stage_fingerprint(stage_list_v2)
+
+print(f"V1 list worker fingerprint: {fp_v1}")
+print(f"V2 list worker fingerprint: {fp_v2}")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Nested attribute access (obj.attr.method)")
+print("=" * 80)
+
+class InnerService:
+    def compute(self, x):
+        return x * 2
+
+class OuterService:
+    def __init__(self):
+        self.inner = InnerService()
+
+outer = OuterService()
+
+def stage_nested():
+    return outer.inner.compute(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_nested)
+print(f"Nested access fingerprint: {fp}")
+print(f"Note: outer is tracked, but outer.inner is NOT tracked as a separate instance")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Method from __init__.py re-export")
+print("=" * 80)
+
+# Many packages re-export things from __init__.py
+# e.g., from mypackage import SomeClass (actually defined in mypackage.impl)
+# The fingerprint tracks based on type(instance).__module__
+
+class RealImpl:
+    __module__ = "mypackage.impl"  # Pretend it's from a submodule
+
+    def process(self, x):
+        return x * 2
+
+# User imports it from main package
+impl = RealImpl()
+
+def stage_reexport():
+    return impl.process(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_reexport)
+print(f"Re-export fingerprint: {fp}")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Partial function wrapping a method")
+print("=" * 80)
+
+import functools
+
+class Multiplier:
+    def multiply(self, x, y):
+        return x * y
+
+mult = Multiplier()
+double = functools.partial(mult.multiply, y=2)
+
+def stage_partial():
+    return double(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_partial)
+print(f"Partial fingerprint: {fp}")
+print(f"Note: double is a functools.partial, not tracked as instance")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Instance method via module.instance.method")
+print("=" * 80)
+
+# When accessing via imported module attribute
+import types
+service_module = types.ModuleType("service_module")
+service_module.__file__ = "/home/pivot/agent1/src/service_module.py"
+
+class ServiceClass:
+    def fetch(self, x):
+        return x + 100
+
+service_module.instance = ServiceClass()
+service_module.ServiceClass = ServiceClass
+sys.modules["service_module"] = service_module
+
+import service_module
+
+def stage_module_instance():
+    # Access instance through module
+    return service_module.instance.fetch(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_module_instance)
+print(f"Module instance fingerprint: {fp}")
+print(f"service_module is tracked: {'mod:service_module.instance' in fp}")
+print(f"But the method change won't be detected!")
+print()
+
+print("=" * 80)
+print("NEW EDGE CASE: Callable instance (__call__ method)")
+print("=" * 80)
+
+class CallableProcessor:
+    def __call__(self, x):
+        return x * 2
+
+processor_callable = CallableProcessor()
+
+def stage_callable_instance():
+    return processor_callable(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_callable_instance)
+print(f"Callable instance fingerprint: {fp}")
+print(f"Instance tracked: {'class:processor_callable.__class__' in fp}")
+print()
+
+# What if __call__ changes?
+class CallableProcessorV2:
+    def __call__(self, x):
+        return x * 999  # Changed!
+
+processor_callable_v2 = CallableProcessorV2()
+
+def stage_callable_instance_v2():
+    return processor_callable_v2(10)
+
+fp_v2 = fingerprint.get_stage_fingerprint(stage_callable_instance_v2)
+print(f"Callable instance V2 fingerprint: {fp_v2}")
+print(f"Different hashes: {fp.get('class:processor_callable.__class__') != fp_v2.get('class:processor_callable_v2.__class__')}")
+print()
+
+print("=" * 80)
+print("CRITICAL BUG: Checking if base class methods are tracked")
+print("=" * 80)
+
+class BaseMixin:
+    def base_method(self, x):
+        return x + 1
+
+class ConcreteImpl(BaseMixin):
+    def concrete_method(self, x):
+        return x * 2
+
+impl = ConcreteImpl()
+
+def stage_uses_base_method():
+    return impl.base_method(10)
+
+fp = fingerprint.get_stage_fingerprint(stage_uses_base_method)
+print(f"Fingerprint: {fp}")
+
+# Get the hash of ConcreteImpl class
+class_hash = fp.get('class:impl.__class__')
+print(f"ConcreteImpl hash: {class_hash}")
+
+# Now let's see what hash_function_ast returns for just ConcreteImpl
+import inspect
+print(f"\nConcreteImpl source:\n{inspect.getsource(ConcreteImpl)}")
+print(f"\nBaseMixin source:\n{inspect.getsource(BaseMixin)}")
+
+# The hash only includes ConcreteImpl's source, not BaseMixin!
+print(f"\nBUG CONFIRMED: Only ConcreteImpl is hashed, BaseMixin.base_method is NOT included")
+print("If BaseMixin.base_method changes, fingerprint will NOT change!")
+print()
+
+print("=" * 80)
+print("SUMMARY OF CONFIRMED BUGS")
+print("=" * 80)
+print("""
+CONFIRMED BUGS (fingerprint does NOT detect changes):
+
+1. Instance-level monkey-patched methods
+   - Methods attached via types.MethodType or direct assignment to instance
+   - type(instance) returns original class, not the patched method
+
+2. Proxy/delegation objects (__getattr__)
+   - Only the Proxy class is tracked
+   - The delegated target's methods are invisible to fingerprinting
+
+3. Inherited methods from base classes / mixins (CRITICAL)
+   - hash_function_ast only hashes the immediate class
+   - Base class method changes are NOT detected
+   - MRO (Method Resolution Order) is ignored
+
+4. Instances inside collections (dict, list, tuple)
+   - _process_collection_dependency only tracks callables
+   - Instance objects inside collections are silently ignored
+
+5. Module.instance.method access pattern
+   - mod:module.instance is tracked as repr/unknown
+   - The actual method code is NOT fingerprinted
+
+6. Nested attribute access (obj.attr.method)
+   - Only top-level obj is tracked
+   - Nested objects and their methods are invisible
+
+DESIGN LIMITATIONS (expected but worth documenting):
+
+7. Dynamic classes created via type()
+   - Same class name + same source = same hash
+   - Even though closure state differs, this is hard to solve
+
+8. functools.partial wrapping methods
+   - Tracked as callable but the underlying method binding may not be
+""")

--- a/experiments/edge_case_fingerprint_v3.py
+++ b/experiments/edge_case_fingerprint_v3.py
@@ -1,0 +1,196 @@
+"""
+Final precise test: Confirming inherited method changes are NOT detected.
+"""
+import sys
+sys.path.insert(0, "/home/pivot/agent1/src")
+
+from pivot import fingerprint
+import inspect
+
+print("=" * 80)
+print("PRECISE TEST: Same concrete class, different inherited method implementation")
+print("=" * 80)
+
+# This simulates what happens when you edit a base class method
+# The concrete class doesn't change at all, but the method it uses does
+
+# First, let's verify the hash only covers the class source, not inherited methods
+class BaseV1:
+    def inherited_method(self, x):
+        return x + 1  # V1 implementation
+
+class ConcreteA(BaseV1):
+    def own_method(self, x):
+        return x * 2
+
+instance_a = ConcreteA()
+
+def stage_a():
+    return instance_a.inherited_method(10)
+
+fp_a = fingerprint.get_stage_fingerprint(stage_a)
+print(f"Stage A fingerprint: {fp_a}")
+print(f"\nConcreteA source (what gets hashed):")
+print(inspect.getsource(ConcreteA))
+
+# Now create a class with identical source but different parent
+class BaseV2:
+    def inherited_method(self, x):
+        return x + 999  # V2 implementation - DIFFERENT!
+
+# ConcreteB has IDENTICAL source code to ConcreteA
+# (same class body, just different parent)
+class ConcreteB(BaseV2):
+    def own_method(self, x):
+        return x * 2
+
+instance_b = ConcreteB()
+
+def stage_b():
+    return instance_b.inherited_method(10)
+
+fp_b = fingerprint.get_stage_fingerprint(stage_b)
+print(f"\nStage B fingerprint: {fp_b}")
+print(f"\nConcreteB source (what gets hashed):")
+print(inspect.getsource(ConcreteB))
+
+# The key comparison: do the class hashes differ?
+hash_a = fp_a.get('class:instance_a.__class__')
+hash_b = fp_b.get('class:instance_b.__class__')
+print(f"\nConcreteA hash: {hash_a}")
+print(f"ConcreteB hash: {hash_b}")
+print(f"Hashes same: {hash_a == hash_b}")
+print(f"BUT inherited_method implementations are DIFFERENT!")
+print()
+
+print("=" * 80)
+print("VERIFICATION: What hash_function_ast actually hashes")
+print("=" * 80)
+
+hash_concrete_a = fingerprint.hash_function_ast(ConcreteA)
+hash_concrete_b = fingerprint.hash_function_ast(ConcreteB)
+hash_base_v1 = fingerprint.hash_function_ast(BaseV1)
+hash_base_v2 = fingerprint.hash_function_ast(BaseV2)
+
+print(f"hash(ConcreteA): {hash_concrete_a}")
+print(f"hash(ConcreteB): {hash_concrete_b}")
+print(f"hash(BaseV1): {hash_base_v1}")
+print(f"hash(BaseV2): {hash_base_v2}")
+print()
+
+# The concrete classes have different hashes because their SOURCE includes
+# the base class name in the class definition line!
+print("Note: ConcreteA and ConcreteB have different hashes because")
+print("the AST includes 'BaseV1' vs 'BaseV2' in the class definition.")
+print("BUT the actual BASE CLASS CODE (BaseV1/BaseV2 bodies) is NOT hashed.")
+print()
+
+print("=" * 80)
+print("REAL-WORLD SCENARIO: Editing a mixin/base class method")
+print("=" * 80)
+
+# In real-world usage, you wouldn't rename the base class
+# You'd edit a method in the SAME base class file
+# Let's simulate this more precisely
+
+# Create a module where we can modify the base class
+import types
+
+base_module = types.ModuleType("base_module")
+base_module.__file__ = "/home/pivot/agent1/src/base_module.py"
+sys.modules["base_module"] = base_module
+
+# Define V1 of the base class
+exec("""
+class BaseMixin:
+    def process(self, x):
+        return x + 1
+""", base_module.__dict__)
+
+# Import from the module
+from base_module import BaseMixin as BaseMixinV1
+
+# Create concrete class
+class MyProcessor(BaseMixinV1):
+    """Concrete processor using BaseMixin."""
+    pass
+
+proc = MyProcessor()
+
+def stage_real():
+    return proc.process(10)
+
+fp1 = fingerprint.get_stage_fingerprint(stage_real)
+print(f"Fingerprint before base class edit: {fp1}")
+
+# Now simulate editing the base class file (method changes)
+exec("""
+class BaseMixin:
+    def process(self, x):
+        return x + 999  # CHANGED!
+""", base_module.__dict__)
+
+# The instance `proc` still uses the OLD BaseMixin because Python
+# doesn't hot-reload. But let's test if fingerprinting would catch
+# the change if we created a new instance.
+
+from base_module import BaseMixin as BaseMixinV2
+
+class MyProcessorV2(BaseMixinV2):
+    """Same concrete class, different base."""
+    pass
+
+proc_v2 = MyProcessorV2()
+
+def stage_real_v2():
+    return proc_v2.process(10)
+
+fp2 = fingerprint.get_stage_fingerprint(stage_real_v2)
+print(f"Fingerprint after base class edit: {fp2}")
+print(f"Fingerprints same: {fp1 == fp2}")
+print()
+
+print("=" * 80)
+print("DEMONSTRATING THE EXACT BUG")
+print("=" * 80)
+
+# The bug is clearer with explicit MRO
+print(f"MyProcessor MRO: {[c.__name__ for c in MyProcessor.__mro__]}")
+print(f"MyProcessor.process is actually: {MyProcessor.process}")
+print(f"Defined in: {MyProcessor.process.__qualname__}")
+print()
+
+# Only MyProcessor's source is hashed
+print("Only MyProcessor's source is hashed:")
+print(inspect.getsource(MyProcessor))
+print()
+
+# BaseMixin source is NOT hashed, despite providing the process method!
+print("BaseMixinV1's source is NOT included in the hash:")
+print(inspect.getsource(BaseMixinV1))
+print()
+
+print("=" * 80)
+print("BUG SEVERITY: HIGH")
+print("=" * 80)
+print("""
+IMPACT:
+- Any method inherited from a base class/mixin is NOT tracked
+- Editing a base class method will NOT trigger stage re-execution
+- This is common in real codebases (Strategy pattern, Mixins, ABC, etc.)
+
+EXAMPLE SCENARIO:
+1. User has `class BasePreprocessor` with `clean_data()` method
+2. Stage uses `class MyPreprocessor(BasePreprocessor)`
+3. User fixes a bug in `BasePreprocessor.clean_data()`
+4. Pivot fingerprint doesn't change because only MyPreprocessor is hashed
+5. Stage is NOT re-run, user gets stale results from buggy code
+
+WORKAROUND (for users):
+- Override inherited methods in concrete class even if just calling super()
+- This forces the method to appear in the concrete class's AST
+
+FIX (for Pivot):
+- When hashing a class, traverse the MRO and hash all user-defined base classes
+- Only include base classes where `is_user_code(base)` is True
+""")

--- a/tests/fingerprint/test_callback_vulnerabilities.py
+++ b/tests/fingerprint/test_callback_vulnerabilities.py
@@ -1,0 +1,343 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false, reportUnknownLambdaType=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportFunctionMemberAccess=false, reportCallIssue=false, reportOptionalCall=false, reportAttributeAccessIssue=false, reportUnannotatedClassAttribute=false, reportArgumentType=false
+"""
+Tests demonstrating callback detection vulnerabilities in fingerprinting.
+
+These tests document known limitations of the fingerprinting system.
+Tests are marked with xfail where the current behavior is considered a bug.
+"""
+
+import functools
+
+import pytest
+
+from pivot import fingerprint
+
+# =============================================================================
+# Module-level helpers for testing
+# =============================================================================
+
+
+def _callback_v1():
+    """Callback version 1."""
+    return 1
+
+
+def _callback_v2():
+    """Callback version 2."""
+    return 2
+
+
+def _base_function(multiplier, x):
+    """Base function for partial testing."""
+    return x * multiplier
+
+
+# =============================================================================
+# VULNERABILITY 1: functools.wraps / __wrapped__
+# =============================================================================
+
+
+def _original_for_wraps():
+    """Original function that will be wrapped."""
+    return "original"
+
+
+@functools.wraps(_original_for_wraps)
+def _wrapped_different_impl():
+    """Different implementation hidden by @wraps."""
+    return "completely different!"
+
+
+def test_functools_wraps_hides_implementation_change():
+    """@functools.wraps does NOT hide implementation changes (fixed via bytecode hashing)."""
+    fp_original = fingerprint.get_stage_fingerprint(_original_for_wraps)
+    fp_wrapped = fingerprint.get_stage_fingerprint(_wrapped_different_impl)
+
+    # These are now correctly different because we use __code__ bytecode for wrapped functions
+    assert fp_original != fp_wrapped, (
+        "functools.wraps should not hide implementation - fingerprints should differ"
+    )
+
+
+def test_manual_wrapped_attribute_hides_code():
+    """Manually setting __wrapped__ does NOT hide actual code (fixed via bytecode hashing)."""
+
+    def target():
+        return "target"
+
+    def attacker():
+        return "MALICIOUS CODE"
+
+    attacker.__wrapped__ = target  # type: ignore
+
+    # Compare the HASH VALUES, not the full fingerprint dicts
+    h_target = fingerprint.hash_function_ast(target)
+    h_attacker = fingerprint.hash_function_ast(attacker)
+
+    # attacker has completely different code, hashes now correctly differ
+    assert h_target != h_attacker, "__wrapped__ attribute should not hide actual implementation"
+
+
+def test_nested_wraps_have_different_hashes():
+    """Multiple layers of @wraps correctly have different hashes (fixed via bytecode)."""
+
+    def level0():
+        return 0
+
+    @functools.wraps(level0)
+    def level1():
+        return 1
+
+    @functools.wraps(level1)
+    def level2():
+        return 2
+
+    h0 = fingerprint.hash_function_ast(level0)
+    h1 = fingerprint.hash_function_ast(level1)
+    h2 = fingerprint.hash_function_ast(level2)
+
+    # Now all three have different hashes because we use bytecode for wrapped functions
+    assert h0 != h1, "level0 and level1 should have different hashes"
+    assert h1 != h2, "level1 and level2 should have different hashes"
+    assert h0 != h2, "level0 and level2 should have different hashes"
+
+
+# =============================================================================
+# VULNERABILITY 2: functools.partial
+# =============================================================================
+
+
+def test_partial_argument_change_detected():
+    """Changes to partial arguments ARE detected (fixed via special partial handling)."""
+    partial_v1 = functools.partial(_base_function, 2)
+    partial_v2 = functools.partial(_base_function, 3)  # Different argument!
+
+    def make_stage(p):
+        def stage():
+            return p(10)
+
+        return stage
+
+    stage1 = make_stage(partial_v1)
+    stage2 = make_stage(partial_v2)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage1)
+    fp2 = fingerprint.get_stage_fingerprint(stage2)
+
+    # These are now correctly different because partial args are hashed
+    assert fp1 != fp2, "Partial with different arguments should have different fingerprint"
+
+
+def test_partial_wrapped_function_change_detected():
+    """Changes to the function wrapped by partial ARE detected (fixed via special handling)."""
+    partial_v1 = functools.partial(_callback_v1)
+    partial_v2 = functools.partial(_callback_v2)  # Different function!
+
+    def make_stage(p):
+        def stage():
+            return p()
+
+        return stage
+
+    stage1 = make_stage(partial_v1)
+    stage2 = make_stage(partial_v2)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage1)
+    fp2 = fingerprint.get_stage_fingerprint(stage2)
+
+    # Now correctly different because partial.func is recursively fingerprinted
+    assert fp1 != fp2, "Partial with different wrapped function should differ"
+
+
+def test_partial_is_not_user_code():
+    """Document that functools.partial fails is_user_code check."""
+    partial_obj = functools.partial(_callback_v1)
+    assert fingerprint.is_user_code(partial_obj) is False
+
+
+# =============================================================================
+# VULNERABILITY 3: Instance state changes
+# =============================================================================
+
+
+class _CallbackContainer:
+    """Container that holds callbacks in instance state."""
+
+    def __init__(self):
+        self._callbacks = dict[str, object]()
+
+    def __getitem__(self, key):
+        return self._callbacks[key]
+
+    def __setitem__(self, key, value):
+        self._callbacks[key] = value
+
+
+_container = _CallbackContainer()
+
+
+def _helper_stage_uses_container():
+    """Stage that uses callback from container."""
+    return _container["handler"]()
+
+
+@pytest.mark.xfail(
+    reason="Instance state (container contents) not tracked, only class definition",
+    strict=True,
+)
+def test_container_callback_change_detected():
+    """Changes to callbacks stored in containers should be detected."""
+    _container["handler"] = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(_helper_stage_uses_container)
+
+    _container["handler"] = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(_helper_stage_uses_container)
+
+    assert fp1 != fp2, "Container callback change should be detected"
+
+
+# =============================================================================
+# VULNERABILITY 4: Class attribute runtime modification
+# =============================================================================
+
+
+class _ConfigClass:
+    """Config class with runtime-assigned callback."""
+
+    callback = None
+
+
+def _helper_stage_uses_class_attr():
+    """Stage that uses class attribute callback."""
+    return _ConfigClass.callback()
+
+
+@pytest.mark.xfail(
+    reason="Class attributes modified at runtime not tracked",
+    strict=True,
+)
+def test_class_attribute_callback_change_detected():
+    """Changes to class attribute callbacks should be detected."""
+    _ConfigClass.callback = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(_helper_stage_uses_class_attr)
+
+    _ConfigClass.callback = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(_helper_stage_uses_class_attr)
+
+    assert fp1 != fp2, "Class attribute callback change should be detected"
+
+
+# =============================================================================
+# WORKING CORRECTLY: Module variable callbacks
+# =============================================================================
+
+_current_callback = _callback_v1
+
+
+def _helper_stage_uses_module_var():
+    """Stage that uses module-level callback variable."""
+    return _current_callback()
+
+
+def test_module_variable_callback_change_detected():
+    """Module-level callback variable changes ARE detected correctly."""
+    global _current_callback
+
+    _current_callback = _callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(_helper_stage_uses_module_var)
+
+    _current_callback = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(_helper_stage_uses_module_var)
+
+    # This WORKS correctly
+    assert fp1 != fp2, "Module variable callback change should be detected"
+
+    # Restore
+    _current_callback = _callback_v1
+
+
+# =============================================================================
+# WORKING CORRECTLY: Dict callbacks in closures
+# =============================================================================
+
+
+def test_dict_callback_in_closure_detected():
+    """Callbacks in dict closures ARE detected correctly."""
+    handlers = {"process": _callback_v1}
+
+    def stage():
+        return handlers["process"]()
+
+    fp1 = fingerprint.get_stage_fingerprint(stage)
+
+    handlers["process"] = _callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(stage)
+
+    # This WORKS correctly
+    assert fp1 != fp2, "Dict callback in closure should be detected"
+
+
+# =============================================================================
+# WORKING CORRECTLY: Multi-layer wrapped callbacks via closure
+# =============================================================================
+
+
+def test_multilayer_closure_callbacks_detected():
+    """Callbacks passed through closure layers ARE detected correctly."""
+
+    def inner_v1():
+        return 1
+
+    def inner_v2():
+        return 2
+
+    def wrapper(callback):
+        def wrapped():
+            return callback() + 1
+
+        return wrapped
+
+    wrapped_v1 = wrapper(inner_v1)
+    wrapped_v2 = wrapper(inner_v2)
+
+    fp1 = fingerprint.get_stage_fingerprint(wrapped_v1)
+    fp2 = fingerprint.get_stage_fingerprint(wrapped_v2)
+
+    # This WORKS correctly - closure recursion captures inner callback
+    assert fp1 != fp2, "Different inner callbacks should produce different fingerprints"
+
+
+# =============================================================================
+# WORKING CORRECTLY: Async and generator functions
+# =============================================================================
+
+_async_callback = None
+
+
+async def _async_callback_v1():
+    return 1
+
+
+async def _async_callback_v2():
+    return 2
+
+
+def _helper_stage_async():
+    """Stage that references async callback."""
+    return _async_callback
+
+
+def test_async_callback_change_detected():
+    """Async callback changes ARE detected correctly."""
+    global _async_callback
+
+    _async_callback = _async_callback_v1
+    fp1 = fingerprint.get_stage_fingerprint(_helper_stage_async)
+
+    _async_callback = _async_callback_v2
+    fp2 = fingerprint.get_stage_fingerprint(_helper_stage_async)
+
+    # This WORKS correctly
+    assert fp1 != fp2, "Async callback change should be detected"
+
+    _async_callback = None

--- a/tests/fingerprint/test_functools.py
+++ b/tests/fingerprint/test_functools.py
@@ -1,0 +1,271 @@
+# pyright: reportUnusedFunction=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownArgumentType=false
+"""Tests for fingerprinting functools.partial and functools.wraps."""
+
+import functools
+
+from pivot import fingerprint
+
+# --- Test helpers for functools.partial ---
+
+
+def _helper_func(a: int, b: int, c: int = 10) -> int:
+    """Helper function to be wrapped with partial."""
+    return a + b + c
+
+
+def _helper_func_v2(a: int, b: int, c: int = 10) -> int:
+    """Different helper function with same signature."""
+    return a * b + c
+
+
+# --- Test helpers for functools.wraps ---
+
+
+def _caching_decorator_v1(func):  # type: ignore[no-untyped-def]
+    """Decorator version 1."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        print("CACHE_V1")  # Decorator-specific logic
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _caching_decorator_v2(func):  # type: ignore[no-untyped-def]
+    """Decorator version 2 - different logic."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        print("CACHE_V2")  # Different decorator logic!
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _original_stage_func() -> int:
+    """Original function to be decorated."""
+    return 42
+
+
+def _original_stage_func_v2() -> int:
+    """Different original function."""
+    return 99
+
+
+# --- Tests for functools.partial ---
+
+
+def test_partial_is_detected():
+    """functools.partial objects are detected and tracked."""
+    bound = functools.partial(_helper_func, 1, c=20)
+
+    def stage_with_partial() -> int:
+        return bound(2)
+
+    fp = fingerprint.get_stage_fingerprint(stage_with_partial)
+
+    # Should have partial:bound.args and partial:bound.kwargs
+    assert "partial:bound.args" in fp, f"partial args not tracked. Got: {list(fp.keys())}"
+    assert "partial:bound.kwargs" in fp, f"partial kwargs not tracked. Got: {list(fp.keys())}"
+    # Should also track the underlying function
+    assert "func:bound.func" in fp, f"partial underlying func not tracked. Got: {list(fp.keys())}"
+
+
+def test_partial_args_change_triggers_fingerprint_change():
+    """Changing bound args changes the fingerprint."""
+    bound_v1 = functools.partial(_helper_func, 1)
+    bound_v2 = functools.partial(_helper_func, 999)  # Different bound arg
+
+    def stage_v1() -> int:
+        return bound_v1(2, 3)
+
+    def stage_v2() -> int:
+        return bound_v2(2, 3)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    assert fp1["partial:bound_v1.args"] != fp2["partial:bound_v2.args"], (
+        "Different bound args should produce different hashes"
+    )
+
+
+def test_partial_kwargs_change_triggers_fingerprint_change():
+    """Changing bound kwargs changes the fingerprint."""
+    bound_v1 = functools.partial(_helper_func, c=10)
+    bound_v2 = functools.partial(_helper_func, c=999)  # Different bound kwarg
+
+    def stage_v1() -> int:
+        return bound_v1(1, 2)
+
+    def stage_v2() -> int:
+        return bound_v2(1, 2)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    assert fp1["partial:bound_v1.kwargs"] != fp2["partial:bound_v2.kwargs"], (
+        "Different bound kwargs should produce different hashes"
+    )
+
+
+def test_partial_underlying_func_change_triggers_fingerprint_change():
+    """Changing the underlying function changes the fingerprint."""
+    bound_v1 = functools.partial(_helper_func, 1)
+    bound_v2 = functools.partial(_helper_func_v2, 1)  # Different underlying func
+
+    def stage_v1() -> int:
+        return bound_v1(2, 3)
+
+    def stage_v2() -> int:
+        return bound_v2(2, 3)
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    assert fp1["func:bound_v1.func"] != fp2["func:bound_v2.func"], (
+        "Different underlying functions should produce different hashes"
+    )
+
+
+def test_partial_in_closure():
+    """functools.partial in closure (nonlocals) is tracked."""
+
+    def make_stage():  # type: ignore[no-untyped-def]
+        bound = functools.partial(_helper_func, 1, c=20)
+
+        def stage() -> int:
+            return bound(2)
+
+        return stage
+
+    stage = make_stage()
+    fp = fingerprint.get_stage_fingerprint(stage)
+
+    # Should track partial from nonlocals
+    assert "partial:bound.args" in fp, (
+        f"partial args from closure not tracked. Got: {list(fp.keys())}"
+    )
+
+
+# --- Tests for functools.wraps ---
+
+
+def test_wrapped_function_detected():
+    """Functions decorated with functools.wraps are properly tracked."""
+
+    @_caching_decorator_v1
+    def my_stage() -> int:
+        return 42
+
+    fp = fingerprint.get_stage_fingerprint(my_stage)
+
+    # The function should be tracked
+    assert "self:my_stage" in fp, f"wrapped function not tracked. Got: {list(fp.keys())}"
+
+    # The original function should also be tracked via closure
+    assert "func:func" in fp, f"original function not tracked via closure. Got: {list(fp.keys())}"
+
+
+def test_decorator_change_triggers_fingerprint_change():
+    """Changing the decorator logic changes the fingerprint."""
+
+    @_caching_decorator_v1
+    def stage_v1() -> int:
+        return 42
+
+    @_caching_decorator_v2
+    def stage_v2() -> int:
+        return 42
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    # The wrapper hashes should be different because decorator logic is different
+    assert fp1["self:stage_v1"] != fp2["self:stage_v2"], (
+        "Different decorator logic should produce different wrapper hashes"
+    )
+
+
+def test_original_function_change_triggers_fingerprint_change():
+    """Changing the original (wrapped) function changes the fingerprint."""
+
+    @_caching_decorator_v1
+    def stage_v1() -> int:
+        return 42
+
+    @_caching_decorator_v1
+    def stage_v2() -> int:
+        return 99  # Different return value
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    # The original function is tracked via closure as 'func'
+    # The hashes should be different because the original functions differ
+    assert fp1["func:func"] != fp2["func:func"], (
+        "Different original functions should produce different hashes"
+    )
+
+
+def test_wrapped_uses_bytecode_not_source():
+    """Wrapped functions use bytecode hash, not source (which follows __wrapped__)."""
+
+    @_caching_decorator_v1
+    def my_stage() -> int:
+        """This docstring is in the original function."""
+        return 42
+
+    # Get fingerprint - should use bytecode for wrapper
+    fp = fingerprint.get_stage_fingerprint(my_stage)
+    wrapper_hash = fp["self:my_stage"]
+
+    # The hash should be the wrapper's bytecode, not the original's AST
+    # We can verify by checking that changing only the decorator changes the hash
+    @_caching_decorator_v2
+    def my_stage_v2() -> int:
+        """This docstring is in the original function."""
+        return 42
+
+    fp2 = fingerprint.get_stage_fingerprint(my_stage_v2)
+    wrapper_hash_v2 = fp2["self:my_stage_v2"]
+
+    # If we were using source (which follows __wrapped__), these would be the same
+    # because the original functions have the same source
+    assert wrapper_hash != wrapper_hash_v2, (
+        "Wrapper hash should differ when decorator changes (proves bytecode is used)"
+    )
+
+
+def test_nested_wraps():
+    """Multiple levels of functools.wraps are tracked."""
+
+    def decorator_a(func):  # type: ignore[no-untyped-def]
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            print("A")
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    def decorator_b(func):  # type: ignore[no-untyped-def]
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            print("B")
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    @decorator_a
+    @decorator_b
+    def my_stage() -> int:
+        return 42
+
+    fp = fingerprint.get_stage_fingerprint(my_stage)
+
+    # Should have the outer wrapper (decorator_a's wrapper)
+    assert "self:my_stage" in fp, f"outer wrapper not tracked. Got: {list(fp.keys())}"
+
+    # The closure should include decorator_b's wrapper as 'func'
+    assert "func:func" in fp, f"inner wrapper not tracked via closure. Got: {list(fp.keys())}"

--- a/tests/fingerprint/test_pydantic_defaults.py
+++ b/tests/fingerprint/test_pydantic_defaults.py
@@ -1,0 +1,236 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false
+"""Tests for fingerprinting behavior with Pydantic model defaults.
+
+Pydantic model defaults in type hints ARE captured by the fingerprinting system.
+Changes to default values trigger cache invalidation.
+"""
+
+import pydantic
+
+from pivot import fingerprint
+
+# --- Scenario 1: Direct list constant as default ---
+
+ITEMS_V1 = ["item1", "item2"]
+
+
+class ParamsWithListDefault(pydantic.BaseModel):
+    items: list[str] = ITEMS_V1
+
+
+def _stage_with_pydantic_param_v1(params: ParamsWithListDefault) -> list[str]:
+    """Stage function that receives a Pydantic model with list default."""
+    return params.items
+
+
+# --- Scenario 2: Pydantic model instances in list ---
+
+
+class ItemConfig(pydantic.BaseModel):
+    name: str
+    value: int
+
+
+CONFIGS_V1 = [
+    ItemConfig(name="first", value=1),
+    ItemConfig(name="second", value=2),
+]
+
+
+class ParamsWithConfigList(pydantic.BaseModel):
+    configs: list[ItemConfig] = CONFIGS_V1
+
+
+def _stage_with_config_list(params: ParamsWithConfigList) -> list[ItemConfig]:
+    """Stage function with Pydantic model instances as default."""
+    return params.configs
+
+
+# --- Scenario 3: Function directly references module constant ---
+
+
+def _stage_directly_references_list() -> list[str]:
+    """Stage that directly references a list constant."""
+    return ITEMS_V1
+
+
+STRING_CONST = "hello"
+
+
+def _stage_references_string() -> str:
+    """Stage that directly references a string constant."""
+    return STRING_CONST
+
+
+# --- Tests for Pydantic default tracking ---
+
+
+def test_list_constants_not_captured_as_const():
+    """Lists referenced in function body are NOT captured as 'const:' entries.
+
+    Lists are scanned for callables only, not hashed as data. This is intentional
+    to avoid sensitivity to mutable runtime state.
+    """
+    fp = fingerprint.get_stage_fingerprint(_stage_directly_references_list)
+
+    # Lists referenced in function body are NOT captured as const:
+    assert "const:ITEMS_V1" not in fp, "Lists should not be captured as const:"
+
+
+def test_string_constants_are_captured():
+    """String constants ARE captured in the fingerprint."""
+    fp = fingerprint.get_stage_fingerprint(_stage_references_string)
+
+    # Strings, ints, floats, bytes, bool, None ARE captured
+    assert "const:STRING_CONST" in fp, (
+        f"String constants should be captured. Got keys: {list(fp.keys())}"
+    )
+    assert fp["const:STRING_CONST"] == "'hello'"
+
+
+def test_pydantic_class_captured_from_type_hint():
+    """Pydantic classes in type hints ARE captured."""
+    fp = fingerprint.get_stage_fingerprint(_stage_with_pydantic_param_v1)
+
+    # Type hints with Pydantic models are tracked
+    assert "class:ParamsWithListDefault" in fp, (
+        f"Pydantic class should be captured. Got keys: {list(fp.keys())}"
+    )
+
+
+def test_pydantic_default_data_captured():
+    """Data in Pydantic field defaults IS captured via pydantic: prefix."""
+    fp1 = fingerprint.get_stage_fingerprint(_stage_with_pydantic_param_v1)
+    fp2 = fingerprint.get_stage_fingerprint(_stage_with_config_list)
+
+    # Pydantic defaults ARE captured
+    assert "pydantic:ParamsWithListDefault.items" in fp1, (
+        f"Pydantic defaults should be captured. Got keys: {list(fp1.keys())}"
+    )
+    assert "pydantic:ParamsWithConfigList.configs" in fp2, (
+        f"Pydantic defaults should be captured. Got keys: {list(fp2.keys())}"
+    )
+
+
+def test_pydantic_default_change_triggers_different_hash():
+    """Changing a Pydantic default value changes the fingerprint hash."""
+
+    # Create two models with different defaults
+    class ParamsV1(pydantic.BaseModel):
+        items: list[str] = ["a", "b"]
+
+    class ParamsV2(pydantic.BaseModel):
+        items: list[str] = ["a", "b", "c"]
+
+    def stage_v1(params: ParamsV1) -> list[str]:
+        return params.items
+
+    def stage_v2(params: ParamsV2) -> list[str]:
+        return params.items
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    # The pydantic default hashes should be different
+    assert fp1["pydantic:ParamsV1.items"] != fp2["pydantic:ParamsV2.items"], (
+        "Different default values should produce different hashes"
+    )
+
+
+def test_pydantic_nested_model_defaults_captured():
+    """Nested Pydantic model instances in defaults are captured."""
+    fp = fingerprint.get_stage_fingerprint(_stage_with_config_list)
+
+    # The nested model data should be hashed
+    assert "pydantic:ParamsWithConfigList.configs" in fp
+
+    # Verify it's a real hash (16 hex chars)
+    hash_val = fp["pydantic:ParamsWithConfigList.configs"]
+    assert len(hash_val) == 16, f"Expected 16-char hash, got {hash_val}"
+    assert all(c in "0123456789abcdef" for c in hash_val)
+
+
+def test_fingerprint_includes_class_and_defaults():
+    """Fingerprint for Pydantic param stages includes class and defaults."""
+    fp = fingerprint.get_stage_fingerprint(_stage_with_pydantic_param_v1)
+
+    # Should have: self:, class:, pydantic:
+    assert "self:_stage_with_pydantic_param_v1" in fp
+    assert "class:ParamsWithListDefault" in fp
+    assert "pydantic:ParamsWithListDefault.items" in fp
+    assert len(fp) == 3, f"Expected 3 entries, got {len(fp)}: {list(fp.keys())}"
+
+
+def test_default_factory_is_tracked():
+    """Fields using default_factory are tracked by hashing the factory function."""
+
+    class ParamsWithFactory(pydantic.BaseModel):
+        items: list[str] = pydantic.Field(default_factory=lambda: ["a", "b"])
+
+    def stage(params: ParamsWithFactory) -> list[str]:
+        return params.items
+
+    fp = fingerprint.get_stage_fingerprint(stage)
+
+    # default_factory should be captured
+    assert "pydantic:ParamsWithFactory.items" in fp, (
+        f"default_factory should be captured. Got keys: {list(fp.keys())}"
+    )
+
+
+def test_default_factory_change_triggers_different_hash():
+    """Changing a default_factory function changes the fingerprint."""
+
+    class ParamsV1(pydantic.BaseModel):
+        items: list[str] = pydantic.Field(default_factory=lambda: ["a"])
+
+    class ParamsV2(pydantic.BaseModel):
+        items: list[str] = pydantic.Field(default_factory=lambda: ["a", "b"])
+
+    def stage_v1(params: ParamsV1) -> list[str]:
+        return params.items
+
+    def stage_v2(params: ParamsV2) -> list[str]:
+        return params.items
+
+    fp1 = fingerprint.get_stage_fingerprint(stage_v1)
+    fp2 = fingerprint.get_stage_fingerprint(stage_v2)
+
+    # Different factories should produce different hashes
+    assert fp1["pydantic:ParamsV1.items"] != fp2["pydantic:ParamsV2.items"], (
+        "Different default_factory functions should produce different hashes"
+    )
+
+
+def test_none_default_is_tracked():
+    """None as an explicit default is tracked (not skipped)."""
+
+    class ParamsWithNone(pydantic.BaseModel):
+        value: str | None = None
+
+    def stage(params: ParamsWithNone) -> str | None:
+        return params.value
+
+    fp = fingerprint.get_stage_fingerprint(stage)
+
+    # None default should be captured
+    assert "pydantic:ParamsWithNone.value" in fp, (
+        f"None default should be captured. Got keys: {list(fp.keys())}"
+    )
+
+
+def test_frozenset_default_is_deterministic():
+    """frozenset defaults produce deterministic hashes regardless of iteration order."""
+
+    class ParamsWithSet(pydantic.BaseModel):
+        tags: frozenset[str] = frozenset({"c", "a", "b"})
+
+    def stage(params: ParamsWithSet) -> frozenset[str]:
+        return params.tags
+
+    # Run multiple times to verify determinism
+    fp1 = fingerprint.get_stage_fingerprint(stage)
+    fp2 = fingerprint.get_stage_fingerprint(stage)
+    fp3 = fingerprint.get_stage_fingerprint(stage)
+
+    assert fp1 == fp2 == fp3, "frozenset defaults should be deterministic"


### PR DESCRIPTION
## Summary

Fixes reactive mode transitive dependency reload bug and adds type safety improvements:

- **Transitive module reload fix**: When a helper module (`helpers.py`) is modified, and a stage module (`stages.py`) imports from it, the changes are now properly detected and reloaded
- **Bytecode cache invalidation**: Removes `.pyc` files alongside clearing `sys.modules` to prevent Python from loading stale compiled bytecode
- **ReactiveStatus enum**: Added typed enum for TUI message status (waiting, restarting, detecting, error) instead of string literals
- **Code consolidation**: Extracted `_process_changes()` method to consolidate "Watching for changes..." messages to a single location

## Test plan

- [x] Added `test_transitive_dependency_reload_detects_helper_changes` - verifies helper module changes are detected
- [x] Added `test_watch_filter_stale_after_registry_adds_new_stage` - verifies filter updates when stages are added
- [x] Added `test_watch_filter_stale_after_registry_removes_stage` - verifies filter updates when stages are removed  
- [x] Added `test_file_index_stale_after_registry_changes` - verifies file index invalidation
- [x] All 1760 tests pass
- [x] Type checker passes with 0 errors/warnings
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)