### PR TITLE
feat: add JSON output support for CLI commands

### DIFF
--- a/src/pivot/cli/__init__.py
+++ b/src/pivot/cli/__init__.py
@@ -12,7 +12,7 @@ COMMAND_CATEGORIES = {
     "Inspection": ["list", "metrics", "params", "plots", "data", "history", "show"],
     "Versioning": ["track", "checkout"],
     "Remote": ["remote", "push", "pull"],
-    "Other": ["init", "export", "config", "completion"],
+    "Other": ["init", "export", "config", "completion", "schema"],
 }
 
 # Lazy command registry: command_name -> (module_path, attr_name, help_text)
@@ -40,6 +40,7 @@ _LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
     "config": ("pivot.cli.config", "config_cmd", "View and modify Pivot configuration."),
     "history": ("pivot.cli.history", "history", "List recent pipeline runs."),
     "show": ("pivot.cli.history", "show_cmd", "Show details of a specific run."),
+    "schema": ("pivot.cli.schema", "schema", "Output JSON Schema for pivot.yaml configuration."),
 }
 
 

--- a/src/pivot/cli/list.py
+++ b/src/pivot/cli/list.py
@@ -1,22 +1,72 @@
 from __future__ import annotations
 
+import json
+from typing import TypedDict
+
 import click
 
 from pivot import registry
 from pivot.cli import decorators as cli_decorators
 
 
+class StageJsonOutput(TypedDict):
+    """JSON output for a single stage."""
+
+    name: str
+    deps: list[str]
+    outs: list[str]
+    mutex: list[str]
+    variant: str | None
+
+
+class ListJsonOutput(TypedDict):
+    """JSON output for pivot list --json."""
+
+    stages: list[StageJsonOutput]
+
+
+def _get_output_sources(stage_list: list[str]) -> dict[str, str]:
+    """Build a map from output path to the stage that produces it."""
+    return {
+        out_path: name
+        for name in stage_list
+        for out_path in registry.REGISTRY.get(name)["outs_paths"]
+    }
+
+
 @cli_decorators.pivot_command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@click.option("--deps", "show_deps", is_flag=True, help="Show stage dependencies")
 @click.pass_context
-def list_cmd(ctx: click.Context) -> None:
+def list_cmd(ctx: click.Context, as_json: bool, show_deps: bool) -> None:
     """List registered stages."""
-    verbose = ctx.obj.get("verbose", False)
+    verbose = ctx.obj.get("verbose", False) if ctx.obj else False
     stage_list = registry.REGISTRY.list_stages()
 
     if not stage_list:
-        click.echo("No stages registered.")
-        click.echo("Create a pipeline.py with @stage decorators, or a pivot.yaml file.")
+        if as_json:
+            click.echo(json.dumps(ListJsonOutput(stages=[])))
+        else:
+            click.echo("No stages registered.")
+            click.echo("Create a pipeline.py with @stage decorators, or a pivot.yaml file.")
         return
+
+    if as_json:
+        stages = [
+            StageJsonOutput(
+                name=name,
+                deps=(info := registry.REGISTRY.get(name))["deps"],
+                outs=info["outs_paths"],
+                mutex=info["mutex"],
+                variant=info["variant"],
+            )
+            for name in stage_list
+        ]
+        click.echo(json.dumps(ListJsonOutput(stages=stages), indent=2))
+        return
+
+    # Build output->stage map for showing dep sources
+    output_sources = _get_output_sources(stage_list) if show_deps else {}
 
     click.echo(f"Registered stages ({len(stage_list)}):")
     for name in stage_list:
@@ -24,6 +74,17 @@ def list_cmd(ctx: click.Context) -> None:
         deps = info["deps"]
         outs = info["outs_paths"]
         click.echo(f"  {name}")
-        if verbose:
-            click.echo(f"    deps: {deps}")
-            click.echo(f"    outs: {outs}")
+
+        if show_deps or verbose:
+            if deps:
+                click.echo("    deps:")
+                for dep in deps:
+                    source = output_sources.get(dep)
+                    if source and source != name:
+                        click.echo(f"      {dep} (from: {source})")
+                    else:
+                        click.echo(f"      {dep}")
+            if outs:
+                click.echo("    outs:")
+                for out in outs:
+                    click.echo(f"      {out}")

--- a/src/pivot/cli/schema.py
+++ b/src/pivot/cli/schema.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from pivot.cli import decorators as cli_decorators
+from pivot.pipeline import yaml as pipeline_yaml
+
+
+@cli_decorators.pivot_command("schema")
+@click.option(
+    "--indent",
+    type=int,
+    default=2,
+    help="JSON indentation (0 for compact)",
+)
+def schema(indent: int) -> None:
+    """Output JSON Schema for pivot.yaml configuration."""
+    json_schema = pipeline_yaml.PipelineConfig.model_json_schema()
+    indent_val = indent if indent > 0 else None
+    click.echo(json.dumps(json_schema, indent=indent_val))

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -5,7 +5,7 @@ import dataclasses
 import logging
 import queue
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, override
+from typing import TYPE_CHECKING, Any, ClassVar, final, override
 
 import textual.app
 import textual.binding
@@ -28,6 +28,7 @@ from pivot.types import (
 if TYPE_CHECKING:
     import multiprocessing as mp
     from collections.abc import Callable
+    from typing import Protocol
 
     from pivot import executor
 
@@ -501,6 +502,7 @@ def should_use_tui(display_mode: DisplayMode | None) -> bool:
     return sys.stdout.isatty()
 
 
+@final
 class WatchTuiApp(_BaseTuiApp):
     """TUI for watch mode pipeline execution."""
 
@@ -514,7 +516,7 @@ class WatchTuiApp(_BaseTuiApp):
         self._engine_thread: threading.Thread | None = None
 
     async def on_mount(self) -> None:  # pragma: no cover
-        self.title = "[●] Watching for changes..."  # pyright: ignore[reportUnannotatedClassAttribute]
+        self.title = "[●] Watching for changes..."
         self._start_queue_reader()
         self._engine_thread = threading.Thread(target=self._run_engine, daemon=True)
         self._engine_thread.start()

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -373,3 +373,63 @@ class TuiReloadMessage(TypedDict):
 
 
 TuiMessage = TuiLogMessage | TuiStatusMessage | TuiReactiveMessage | TuiReloadMessage | None
+
+
+# =============================================================================
+# Reactive JSONL Event Types (for --json output)
+# =============================================================================
+
+
+class ReactiveEventType(enum.StrEnum):
+    """Type of reactive JSONL event."""
+
+    STATUS = "status"
+    FILES_CHANGED = "files_changed"
+    AFFECTED_STAGES = "affected_stages"
+    EXECUTION_RESULT = "execution_result"
+
+
+class ReactiveStatusEvent(TypedDict):
+    """Status message event."""
+
+    type: Literal[ReactiveEventType.STATUS]
+    message: str
+    is_error: bool
+
+
+class ReactiveFilesChangedEvent(TypedDict):
+    """File change detection event."""
+
+    type: Literal[ReactiveEventType.FILES_CHANGED]
+    paths: list[str]
+    code_changed: bool
+
+
+class ReactiveAffectedStagesEvent(TypedDict):
+    """Affected stages event."""
+
+    type: Literal[ReactiveEventType.AFFECTED_STAGES]
+    stages: list[str]
+    count: int
+
+
+class ReactiveStageResult(TypedDict):
+    """Result for a single stage in reactive execution."""
+
+    status: str
+    reason: str
+
+
+class ReactiveExecutionResultEvent(TypedDict):
+    """Execution result event."""
+
+    type: Literal[ReactiveEventType.EXECUTION_RESULT]
+    stages: dict[str, ReactiveStageResult]
+
+
+ReactiveJsonEvent = (
+    ReactiveStatusEvent
+    | ReactiveFilesChangedEvent
+    | ReactiveAffectedStagesEvent
+    | ReactiveExecutionResultEvent
+)


### PR DESCRIPTION
## Summary

- Add `pivot schema` command to export JSON Schema for pivot.yaml configuration
- Add `--json` and `--deps` flags to `pivot list` for machine-readable output
- Add `--json` flag to `pivot run` for JSON output of execution results
- Add JSONL streaming output for `pivot run --watch --json` with typed event messages
- Improve type safety with `Literal` types for status fields in TypedDicts

## Test plan

- [x] `pivot schema | jq .` outputs valid JSON Schema
- [x] `pivot list --json | jq .` shows stage metadata
- [x] `pivot list --deps` shows dependency relationships  
- [x] `pivot run --json | jq .` shows execution results
- [x] `pivot run --watch --json` streams JSONL events
- [x] All 1937 tests pass
- [x] Type checking passes with 0 errors/warnings

## Changes from previous PR #127

Rebased on main after #125 merged. Resolved one trivial conflict in watch mode error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)