### PR TITLE
fix: notify TUI when file watcher fails

### DIFF
--- a/src/pivot/reactive/engine.py
+++ b/src/pivot/reactive/engine.py
@@ -223,6 +223,7 @@ class ReactiveEngine:
                     pass  # Keep accumulating, will send next iteration
         except Exception as e:
             logger.critical(f"Watcher thread failed: {e}")
+            self._send_message(f"File watcher failed: {e}", is_error=True)
             self.shutdown()  # Signal coordinator to exit
 
     def _coordinator_loop(self) -> None:


### PR DESCRIPTION
## Summary
- Add TUI notification when the file watcher thread fails unexpectedly
- Without this fix, watcher failures were logged but not shown in the TUI

## Issue
Related to #79 (Phase 2: Watch TUI Integration)

## Approach
Added a `_send_message()` call to notify the TUI before shutting down when the watcher thread catches an unexpected exception. This ensures users see the error message in the TUI instead of just having it logged to the debug output.

## Testing
- All existing tests pass (1937 passed)
- Manual testing: watcher errors now appear in TUI status

## Checklist
- [x] Tests pass locally
- [x] Code follows project style guidelines
- [x] No new linting/type errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)