### PR TITLE
feat: add production-ready metrics instrumentation for benchmarking

### DIFF
--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -23,6 +23,7 @@ from pivot import (
     dag,
     exceptions,
     explain,
+    metrics,
     outputs,
     parameters,
     project,
@@ -278,33 +279,34 @@ def _verify_tracked_files(project_root: pathlib.Path) -> None:
     if not tracked_files:
         return
 
-    missing = list[str]()
-    state_db_path = project_root / ".pivot" / "state.db"
+    with metrics.timed("core.verify_tracked_files"):
+        missing = list[str]()
+        state_db_path = project_root / ".pivot" / "state.db"
 
-    with state_mod.StateDB(state_db_path) as state_db:
-        for data_path, track_data in tracked_files.items():
-            path = pathlib.Path(data_path)
-            if not path.exists():
-                missing.append(data_path)
-                continue
+        with state_mod.StateDB(state_db_path) as state_db:
+            for data_path, track_data in tracked_files.items():
+                path = pathlib.Path(data_path)
+                if not path.exists():
+                    missing.append(data_path)
+                    continue
 
-            # Check hash mismatch (file exists but content changed)
-            if path.is_file():
-                current_hash = cache.hash_file(path, state_db)
-            else:
-                current_hash, _ = cache.hash_directory(path, state_db)
-            if current_hash != track_data["hash"]:
-                logger.warning(
-                    f"Tracked file '{data_path}' has changed since tracking. "
-                    + f"Run 'pivot track --force {track_data['path']}' to update."
-                )
+                # Check hash mismatch (file exists but content changed)
+                if path.is_file():
+                    current_hash = cache.hash_file(path, state_db)
+                else:
+                    current_hash, _ = cache.hash_directory(path, state_db)
+                if current_hash != track_data["hash"]:
+                    logger.warning(
+                        f"Tracked file '{data_path}' has changed since tracking. "
+                        + f"Run 'pivot track --force {track_data['path']}' to update."
+                    )
 
-    if missing:
-        missing_list = "\n".join(f"  - {p}" for p in missing)
-        raise exceptions.TrackedFileMissingError(
-            f"The following tracked files are missing:\n{missing_list}\n\n"
-            + "Run 'pivot checkout' to restore them from cache."
-        )
+        if missing:
+            missing_list = "\n".join(f"  - {p}" for p in missing)
+            raise exceptions.TrackedFileMissingError(
+                f"The following tracked files are missing:\n{missing_list}\n\n"
+                + "Run 'pivot checkout' to restore them from cache."
+            )
 
 
 def _warn_single_stage_mutex_groups(stage_states: dict[str, StageState]) -> None:
@@ -451,6 +453,10 @@ def _execute_greedy(
                         result = future.result()
                         state.result = result
                         state.end_time = time.perf_counter()
+
+                        # Aggregate metrics from worker process
+                        if "metrics" in result:
+                            metrics.add_entries(result["metrics"])
 
                         if result["status"] == "failed":
                             state.status = StageStatus.FAILED

--- a/src/pivot/fingerprint.py
+++ b/src/pivot/fingerprint.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import xxhash
 
-from pivot import ast_utils
+from pivot import ast_utils, metrics
 
 if TYPE_CHECKING:
     from pivot import loaders
@@ -39,6 +39,12 @@ def get_stage_fingerprint(
         # to protect visited set from race conditions. Current single-threaded
         # usage is safe.
 
+    with metrics.timed("fingerprint.get_stage_fingerprint"):
+        return _get_stage_fingerprint_impl(func, visited)
+
+
+def _get_stage_fingerprint_impl(func: Callable[..., Any], visited: set[int]) -> dict[str, str]:
+    """Internal implementation of get_stage_fingerprint."""
     manifest = dict[str, str]()
 
     func_id = id(func)

--- a/src/pivot/metrics.py
+++ b/src/pivot/metrics.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# Maximum entries to prevent unbounded memory growth
+MAX_ENTRIES = 100_000
+
+_enabled = os.environ.get("PIVOT_METRICS", "").lower() in ("1", "true", "yes")
+
+# Store durations directly by name for simplicity
+_durations: dict[str, list[float]] = {}
+
+
+def enable() -> None:
+    """Enable metrics collection."""
+    global _enabled
+    _enabled = True
+
+
+def clear() -> None:
+    """Clear all collected metrics."""
+    _durations.clear()
+
+
+def get_entries() -> list[tuple[str, float]]:
+    """Get raw entries for cross-process transfer.
+
+    Returns list of (name, duration_ms) tuples that can be serialized
+    and returned from worker processes.
+    """
+    return [(name, d) for name, ds in _durations.items() for d in ds]
+
+
+def add_entries(entries: list[tuple[str, float]]) -> None:
+    """Add entries from another process (used by main process to aggregate)."""
+    for name, duration_ms in entries:
+        _add(name, duration_ms)
+
+
+def _add(name: str, duration_ms: float) -> None:
+    """Internal: add a single metric entry."""
+    if name not in _durations:
+        _durations[name] = []
+    _durations[name].append(duration_ms)
+
+    # Prevent unbounded growth - trim oldest entries if over limit
+    total = sum(len(ds) for ds in _durations.values())
+    if total > MAX_ENTRIES:
+        # Remove oldest half of entries from each metric
+        for metric_name in _durations:
+            ds = _durations[metric_name]
+            if len(ds) > 1:
+                _durations[metric_name] = ds[len(ds) // 2 :]
+
+
+def summary() -> dict[str, dict[str, float]]:
+    """Summarize metrics by name: count, total_ms, avg_ms, min_ms, max_ms."""
+    result = dict[str, dict[str, float]]()
+    for name, durations in sorted(_durations.items()):
+        if not durations:
+            continue
+        result[name] = {
+            "count": float(len(durations)),
+            "total_ms": sum(durations),
+            "avg_ms": sum(durations) / len(durations),
+            "min_ms": min(durations),
+            "max_ms": max(durations),
+        }
+    return result
+
+
+@contextlib.contextmanager
+def timed(name: str) -> Generator[None]:
+    """Context manager to time a block of code.
+
+    Usage:
+        with metrics.timed("cache.hash_file"):
+            ...
+
+    Metrics are only collected when enabled via PIVOT_METRICS=1 or enable().
+    """
+    if not _enabled:
+        yield
+        return
+
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000
+        _add(name, duration_ms)

--- a/src/pivot/storage/cache.py
+++ b/src/pivot/storage/cache.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import xxhash
 
-from pivot import exceptions
+from pivot import exceptions, metrics
 from pivot.config import CheckoutMode as CheckoutMode
 from pivot.types import DirHash, DirManifestEntry, FileHash, OutputHash
 
@@ -71,20 +71,21 @@ def hash_file(path: pathlib.Path, state_db: state_mod.StateDB | None = None) -> 
         if cached is not None:
             return cached
 
-    hasher = xxhash.xxh64()
-    with open(path, "rb") as f:
-        if file_stat.st_size >= MMAP_THRESHOLD:
-            try:
-                with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
-                    hasher.update(mm)
-            except (ValueError, OSError):
-                # Fall back to buffered read if mmap fails (empty file, network FS, etc.)
+    with metrics.timed("cache.hash_file"):
+        hasher = xxhash.xxh64()
+        with open(path, "rb") as f:
+            if file_stat.st_size >= MMAP_THRESHOLD:
+                try:
+                    with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                        hasher.update(mm)
+                except (ValueError, OSError):
+                    # Fall back to buffered read if mmap fails (empty file, network FS, etc.)
+                    while chunk := f.read(CHUNK_SIZE):
+                        hasher.update(chunk)
+            else:
                 while chunk := f.read(CHUNK_SIZE):
                     hasher.update(chunk)
-        else:
-            while chunk := f.read(CHUNK_SIZE):
-                hasher.update(chunk)
-    file_hash = hasher.hexdigest()
+        file_hash = hasher.hexdigest()
 
     if state_db is not None:
         state_db.save(path, file_stat, file_hash)
@@ -124,32 +125,33 @@ def hash_directory(
     Note: For portability, paths are stored as normalized (symlinks preserved)
     in lock files, but resolved here for consistent hashing.
     """
-    manifest = list[DirManifestEntry]()
-    resolved_base = path.resolve()
+    with metrics.timed("cache.hash_directory"):
+        manifest = list[DirManifestEntry]()
+        resolved_base = path.resolve()
 
-    for entry in sorted(_scandir_recursive(path), key=lambda e: e.path):
-        file_path = pathlib.Path(entry.path)
-        # Verify file is still within the directory (paranoid check)
-        if not file_path.resolve().is_relative_to(resolved_base):
-            continue
-        try:
-            rel = file_path.relative_to(path)
-            file_stat = entry.stat(follow_symlinks=True)
-            manifest_entry: DirManifestEntry = {
-                "relpath": str(rel),
-                "hash": hash_file(file_path, state_db),
-                "size": file_stat.st_size,
-            }
-            if file_stat.st_mode & stat.S_IXUSR:
-                manifest_entry["isexec"] = True
-            manifest.append(manifest_entry)
-        except FileNotFoundError:
-            continue  # File deleted between scan and hash
+        for entry in sorted(_scandir_recursive(path), key=lambda e: e.path):
+            file_path = pathlib.Path(entry.path)
+            # Verify file is still within the directory (paranoid check)
+            if not file_path.resolve().is_relative_to(resolved_base):
+                continue
+            try:
+                rel = file_path.relative_to(path)
+                file_stat = entry.stat(follow_symlinks=True)
+                manifest_entry: DirManifestEntry = {
+                    "relpath": str(rel),
+                    "hash": hash_file(file_path, state_db),
+                    "size": file_stat.st_size,
+                }
+                if file_stat.st_mode & stat.S_IXUSR:
+                    manifest_entry["isexec"] = True
+                manifest.append(manifest_entry)
+            except FileNotFoundError:
+                continue  # File deleted between scan and hash
 
-    manifest_json = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
-    tree_hash = xxhash.xxh64(manifest_json.encode()).hexdigest()
+        manifest_json = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+        tree_hash = xxhash.xxh64(manifest_json.encode()).hexdigest()
 
-    return tree_hash, manifest
+        return tree_hash, manifest
 
 
 def get_cache_path(cache_dir: pathlib.Path, file_hash: str) -> pathlib.Path:

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -38,6 +38,7 @@ class StageResult(TypedDict):
     status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED]
     reason: str
     output_lines: list[tuple[str, bool]]
+    metrics: NotRequired[list[tuple[str, float]]]  # (name, duration_ms) for cross-process
 
 
 class FileHash(TypedDict):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import metrics
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    """Reset metrics state before each test."""
+    metrics.clear()
+    # Save original enabled state
+    original_enabled = metrics._enabled
+    yield
+    # Restore original state after test
+    metrics.clear()
+    metrics._enabled = original_enabled
+
+
+# =============================================================================
+# enable() tests
+# =============================================================================
+
+
+def test_enable_sets_flag():
+    metrics._enabled = False
+    metrics.enable()
+    assert metrics._enabled is True
+
+
+def test_enable_idempotent():
+    metrics._enabled = True
+    metrics.enable()
+    assert metrics._enabled is True
+
+
+# =============================================================================
+# clear() tests
+# =============================================================================
+
+
+def test_clear_removes_all_entries():
+    metrics._enabled = True
+    with metrics.timed("test"):
+        pass
+    assert len(metrics._durations) > 0
+    metrics.clear()
+    assert len(metrics._durations) == 0
+
+
+def test_clear_on_empty():
+    metrics.clear()
+    assert len(metrics._durations) == 0
+
+
+# =============================================================================
+# get_entries() tests
+# =============================================================================
+
+
+def test_get_entries_empty():
+    assert metrics.get_entries() == []
+
+
+def test_get_entries_single_metric():
+    metrics.add_entries([("test", 1.0), ("test", 2.0)])
+    entries = metrics.get_entries()
+    assert len(entries) == 2
+    assert ("test", 1.0) in entries
+    assert ("test", 2.0) in entries
+
+
+def test_get_entries_multiple_metrics():
+    metrics.add_entries([("a", 1.0), ("b", 2.0), ("a", 3.0)])
+    entries = metrics.get_entries()
+    assert len(entries) == 3
+    names = [e[0] for e in entries]
+    assert names.count("a") == 2
+    assert names.count("b") == 1
+
+
+# =============================================================================
+# add_entries() tests
+# =============================================================================
+
+
+def test_add_entries_creates_metric():
+    metrics.add_entries([("new_metric", 5.0)])
+    assert "new_metric" in metrics._durations
+    assert metrics._durations["new_metric"] == [5.0]
+
+
+def test_add_entries_appends_to_existing():
+    metrics.add_entries([("metric", 1.0)])
+    metrics.add_entries([("metric", 2.0)])
+    assert metrics._durations["metric"] == [1.0, 2.0]
+
+
+def test_add_entries_empty_list():
+    metrics.add_entries([])
+    assert len(metrics._durations) == 0
+
+
+# =============================================================================
+# summary() tests
+# =============================================================================
+
+
+def test_summary_empty():
+    assert metrics.summary() == {}
+
+
+def test_summary_single_entry():
+    metrics.add_entries([("test", 10.0)])
+    result = metrics.summary()
+    assert "test" in result
+    assert result["test"]["count"] == 1.0
+    assert result["test"]["total_ms"] == 10.0
+    assert result["test"]["avg_ms"] == 10.0
+    assert result["test"]["min_ms"] == 10.0
+    assert result["test"]["max_ms"] == 10.0
+
+
+def test_summary_multiple_entries():
+    metrics.add_entries([("test", 10.0), ("test", 20.0), ("test", 30.0)])
+    result = metrics.summary()
+    assert result["test"]["count"] == 3.0
+    assert result["test"]["total_ms"] == 60.0
+    assert result["test"]["avg_ms"] == 20.0
+    assert result["test"]["min_ms"] == 10.0
+    assert result["test"]["max_ms"] == 30.0
+
+
+def test_summary_multiple_metrics_sorted():
+    metrics.add_entries([("z_metric", 1.0), ("a_metric", 2.0)])
+    result = metrics.summary()
+    keys = list(result.keys())
+    assert keys == ["a_metric", "z_metric"]
+
+
+# =============================================================================
+# timed() tests
+# =============================================================================
+
+
+def test_timed_disabled_does_not_record():
+    metrics._enabled = False
+    with metrics.timed("test"):
+        pass
+    assert len(metrics._durations) == 0
+
+
+def test_timed_enabled_records_duration():
+    metrics._enabled = True
+    with metrics.timed("test"):
+        time.sleep(0.01)  # 10ms
+    assert "test" in metrics._durations
+    assert len(metrics._durations["test"]) == 1
+    # Duration should be at least 10ms
+    assert metrics._durations["test"][0] >= 10.0
+
+
+def test_timed_records_on_exception():
+    metrics._enabled = True
+    with pytest.raises(ValueError), metrics.timed("test"):
+        raise ValueError("test error")
+    # Metrics should still be recorded even when exception occurs
+    assert "test" in metrics._durations
+    assert len(metrics._durations["test"]) == 1
+
+
+def test_timed_nested():
+    metrics._enabled = True
+    with metrics.timed("outer"), metrics.timed("inner"):
+        pass
+    assert "outer" in metrics._durations
+    assert "inner" in metrics._durations
+
+
+def test_timed_same_name_accumulates():
+    metrics._enabled = True
+    with metrics.timed("test"):
+        pass
+    with metrics.timed("test"):
+        pass
+    assert len(metrics._durations["test"]) == 2
+
+
+# =============================================================================
+# MAX_ENTRIES trimming tests
+# =============================================================================
+
+
+def test_trimming_triggers_at_max_entries(monkeypatch: MonkeyPatch):
+    # Use a smaller limit for testing
+    monkeypatch.setattr(metrics, "MAX_ENTRIES", 10)
+
+    # Add exactly MAX_ENTRIES
+    for i in range(10):
+        metrics.add_entries([("test", float(i))])
+
+    total = sum(len(ds) for ds in metrics._durations.values())
+    assert total == 10
+
+    # Add one more to trigger trimming
+    metrics.add_entries([("test", 10.0)])
+
+    total = sum(len(ds) for ds in metrics._durations.values())
+    # After trimming, should have ~half the entries (5 or 6 depending on implementation)
+    assert total < 10
+
+
+def test_trimming_preserves_recent_entries(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr(metrics, "MAX_ENTRIES", 10)
+
+    # Add 11 entries to trigger trim
+    for i in range(11):
+        metrics.add_entries([("test", float(i))])
+
+    # After trimming, should have newer entries (higher values)
+    # Trimming removes oldest half, so values 0-4 should be removed
+    remaining = metrics._durations["test"]
+    assert all(v >= 5.0 for v in remaining)
+
+
+def test_trimming_multiple_metrics(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr(metrics, "MAX_ENTRIES", 10)
+
+    # Add entries across multiple metrics
+    for i in range(6):
+        metrics.add_entries([("a", float(i))])
+    for i in range(6):
+        metrics.add_entries([("b", float(i))])
+
+    # Should have triggered trimming, both metrics reduced
+    total = sum(len(ds) for ds in metrics._durations.values())
+    assert total < 12
+
+
+# =============================================================================
+# Cross-process integration tests
+# =============================================================================
+
+
+def test_roundtrip_serialization():
+    """Test that get_entries/add_entries can transfer metrics across processes."""
+    metrics._enabled = True
+
+    # Simulate worker: collect metrics
+    with metrics.timed("worker.task"):
+        pass
+    entries = metrics.get_entries()
+
+    # Clear to simulate new process
+    metrics.clear()
+    assert metrics.get_entries() == []
+
+    # Simulate main process: aggregate
+    metrics.add_entries(entries)
+
+    # Verify metrics transferred
+    assert "worker.task" in metrics._durations
+    result = metrics.summary()
+    assert result["worker.task"]["count"] == 1.0


### PR DESCRIPTION
## Summary

Add a metrics module for collecting timing data during pipeline execution. This enables benchmarking of hashing operations to determine if parallelization is worthwhile (issue #115).

## Changes

- **New `src/pivot/metrics.py`** - Simple metrics collection module with:
  - `enable()` / `clear()` functions for controlling collection
  - `timed(name)` context manager for timing code blocks
  - `get_entries()` / `add_entries()` for cross-process transfer
  - `summary()` for aggregated stats (count, total_ms, avg_ms, min_ms, max_ms)
  - Memory bounds to prevent unbounded growth (MAX_ENTRIES = 100,000)
  - Disabled by default, enabled via `PIVOT_METRICS=1` env var

- **Cross-process metrics collection** - Workers collect metrics and return them via `StageResult`, main process aggregates

- **Timing instrumentation** at key points:
  - `fingerprint.get_stage_fingerprint`
  - `cache.hash_file` and `cache.hash_directory`
  - `worker.hash_dependencies` and `worker.save_outputs_to_cache`
  - `core.verify_tracked_files`

## Test plan

- [x] 23 new tests in `tests/test_metrics.py` covering all public API functions
- [x] All existing tests pass (2016 passed)
- [x] Quality checks pass (ruff format, ruff check, basedpyright)

## Related

- Part of benchmarking work for #115
- Future improvements tracked in #146

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)