### PR TITLE
fix: address code review issues from #143, #144, #145, #146

### DIFF
--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -481,10 +481,10 @@ def _execute_greedy(
                         if "metrics" in result:
                             metrics.add_entries(result["metrics"])
 
-                        if result["status"] == "failed":
+                        if result["status"] == StageStatus.FAILED:
                             state.status = StageStatus.FAILED
                             _handle_stage_failure(stage_name, stage_states, error_mode)
-                        elif result["status"] == "skipped":
+                        elif result["status"] == StageStatus.SKIPPED:
                             state.status = StageStatus.SKIPPED
                         else:
                             state.status = StageStatus.COMPLETED

--- a/src/pivot/storage/lock.py
+++ b/src/pivot/storage/lock.py
@@ -122,11 +122,8 @@ def _convert_from_storage_format(data: StorageLockData) -> LockData:
         params=data["params"] if "params" in data else {},
         dep_hashes=dep_hashes,
         output_hashes=output_hashes,
+        dep_generations=data["dep_generations"] if "dep_generations" in data else {},
     )
-
-    # Preserve dep_generations for --no-commit mode
-    if "dep_generations" in data:
-        result["dep_generations"] = data["dep_generations"]
 
     return result
 

--- a/src/pivot/storage/project_lock.py
+++ b/src/pivot/storage/project_lock.py
@@ -23,7 +23,11 @@ def _get_lock_path() -> pathlib.Path:
 
 
 def _create_lock(timeout: float = -1) -> filelock.BaseFileLock:
-    """Create a FileLock with standard setup (creates parent dir if needed)."""
+    """Create a FileLock with standard setup (creates parent dir if needed).
+
+    Args:
+        timeout: Seconds to wait for lock. -1 means wait forever (default), 0 means non-blocking.
+    """
     lock_path = _get_lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     return filelock.FileLock(lock_path, timeout=timeout)
@@ -33,7 +37,14 @@ def _create_lock(timeout: float = -1) -> filelock.BaseFileLock:
 def pending_state_lock(timeout: float = -1) -> Generator[filelock.BaseFileLock]:
     """Context manager for coordinating --no-commit execution and commit operations.
 
-    Yields the lock object for callers that need it (e.g., to check lock state).
+    Args:
+        timeout: Seconds to wait for lock. -1 means wait forever (default), 0 means non-blocking.
+
+    Yields:
+        BaseFileLock for callers that need it (e.g., to check lock state).
+
+    Raises:
+        filelock.Timeout: If timeout >= 0 and lock not acquired in time.
     """
     lock = _create_lock(timeout=timeout)
     logger.debug(f"Acquiring pending state lock: {lock.lock_file}")

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -640,6 +640,11 @@ class WatchTuiApp(_BaseTuiApp[None]):
         self._commit_in_progress: bool = False
         self._cancel_commit: bool = False
 
+    @property
+    def _has_running_stages(self) -> bool:
+        """Check if any stages are currently in progress."""
+        return any(s.status == StageStatus.IN_PROGRESS for s in self._stages.values())
+
     async def on_mount(self) -> None:  # pragma: no cover
         self.title = "[●] Watching for changes..."
         self._start_queue_reader()
@@ -741,7 +746,7 @@ class WatchTuiApp(_BaseTuiApp[None]):
         if self._commit_in_progress:
             return
 
-        if any(s.status == StageStatus.IN_PROGRESS for s in self._stages.values()):
+        if self._has_running_stages:
             self.notify("Cannot commit while stages are running", severity="warning")
             return
 
@@ -822,7 +827,7 @@ class WatchTuiApp(_BaseTuiApp[None]):
             return
 
         # Don't offer commit if stages are running (could cause data inconsistency)
-        if any(s.status == StageStatus.IN_PROGRESS for s in self._stages.values()):
+        if self._has_running_stages:
             self._engine.shutdown()
             await super().action_quit()
             return

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -120,7 +120,7 @@ class LockData(TypedDict):
     dep_hashes: dict[str, HashInfo]
     output_hashes: dict[str, OutputHash]
     # Stored at execution time for --no-commit mode (used by commit to record correct generations)
-    dep_generations: NotRequired[dict[str, int]]
+    dep_generations: dict[str, int]
 
 
 # Type alias for output queue messages: (stage_name, line, is_stderr) or None for shutdown

--- a/tests/cli/test_cli_plots.py
+++ b/tests/cli/test_cli_plots.py
@@ -205,6 +205,7 @@ def test_plots_diff_json_format(
                 params={},
                 dep_hashes={},
                 output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+                dep_generations={},
             )
         )
 
@@ -254,6 +255,7 @@ def test_plots_diff_md_format(
                 params={},
                 dep_hashes={},
                 output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+                dep_generations={},
             )
         )
 
@@ -298,6 +300,7 @@ def test_plots_diff_no_path_flag(
                 params={},
                 dep_hashes={},
                 output_hashes={str(plot_file): {"hash": "old_hash_value"}},
+                dep_generations={},
             )
         )
 

--- a/tests/core/test_explain.py
+++ b/tests/core/test_explain.py
@@ -282,6 +282,7 @@ def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -310,6 +311,7 @@ def test_get_stage_explanation_code_changed(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -342,6 +344,7 @@ def test_get_stage_explanation_params_changed(tmp_path: Path) -> None:
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -378,6 +381,7 @@ def test_get_stage_explanation_deps_changed(tmp_path: Path) -> None:
             params={},
             dep_hashes={normalized_path: {"hash": "old_data_hash"}},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -415,6 +419,7 @@ def test_get_stage_explanation_multiple_changes(tmp_path: Path) -> None:
             params={"epochs": 5},
             dep_hashes={normalized_path: {"hash": "old_hash"}},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -442,6 +447,7 @@ def test_get_stage_explanation_missing_deps(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -480,6 +486,7 @@ def test_get_stage_explanation_invalid_params(
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -522,6 +529,7 @@ def test_get_stage_explanation_force_without_changes(
                 params={},
                 dep_hashes={},
                 output_hashes={},
+                dep_generations={},
             )
         )
 
@@ -555,6 +563,7 @@ def test_get_stage_explanation_force_with_code_changes(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -584,6 +593,7 @@ def test_get_stage_explanation_force_with_missing_deps(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 

--- a/tests/reactive/test_engine.py
+++ b/tests/reactive/test_engine.py
@@ -1060,14 +1060,14 @@ def test_send_message_to_tui_queue(pipeline_dir: pathlib.Path) -> None:
 
 
 def test_send_message_error_to_tui_queue(pipeline_dir: pathlib.Path) -> None:
-    """_send_message with is_error=True should set error status."""
+    """_send_message with status=ERROR should set error status."""
     manager = multiprocessing.Manager()
     tui_queue = manager.Queue()
 
     eng = engine.ReactiveEngine()
     eng._tui_queue = tui_queue  # pyright: ignore[reportAttributeAccessIssue]
 
-    eng._send_message("Error occurred", is_error=True)
+    eng._send_message("Error occurred", status=types.ReactiveStatus.ERROR)
 
     msg = tui_queue.get_nowait()
     assert msg["status"] == types.ReactiveStatus.ERROR

--- a/tests/show/test_plots.py
+++ b/tests/show/test_plots.py
@@ -123,6 +123,7 @@ def test_get_plot_hashes_from_lock_with_hash(set_project_root: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "abc123def456"}},
+            dep_generations={},
         )
     )
 
@@ -155,6 +156,7 @@ def test_get_plot_hashes_from_lock_with_none_hash(set_project_root: Path) -> Non
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): None},
+            dep_generations={},
         )
     )
 
@@ -234,6 +236,7 @@ def test_get_plot_hashes_from_head_returns_committed_hash(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "committed_hash_123"}},
+            dep_generations={},
         )
     )
 
@@ -277,6 +280,7 @@ def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "original_hash"}},
+            dep_generations={},
         )
     )
 
@@ -295,6 +299,7 @@ def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "modified_hash"}},
+            dep_generations={},
         )
     )
 

--- a/tests/storage/test_incremental_out.py
+++ b/tests/storage/test_incremental_out.py
@@ -73,6 +73,7 @@ def test_prepare_outputs_incremental_restores_from_cache(tmp_path: pathlib.Path)
         params={},
         dep_hashes={},
         output_hashes={str(output_file): output_hash},
+        dep_generations={},
     )
 
     # Prepare for execution
@@ -99,6 +100,7 @@ def test_prepare_outputs_incremental_restored_file_is_writable(tmp_path: pathlib
         params={},
         dep_hashes={},
         output_hashes={str(output_file): output_hash},
+        dep_generations={},
     )
 
     # Prepare for execution
@@ -230,6 +232,7 @@ def test_incremental_out_restores_directory(tmp_path: pathlib.Path) -> None:
         params={},
         dep_hashes={},
         output_hashes={str(output_dir): output_hash},
+        dep_generations={},
     )
 
     # Delete the output
@@ -264,6 +267,7 @@ def test_incremental_out_directory_is_writable(tmp_path: pathlib.Path) -> None:
         params={},
         dep_hashes={},
         output_hashes={str(output_dir): output_hash},
+        dep_generations={},
     )
 
     # Delete and restore
@@ -301,6 +305,7 @@ def test_incremental_out_directory_subdirs_writable(tmp_path: pathlib.Path) -> N
         params={},
         dep_hashes={},
         output_hashes={str(output_dir): output_hash},
+        dep_generations={},
     )
 
     # Delete and restore

--- a/tests/storage/test_lock.py
+++ b/tests/storage/test_lock.py
@@ -23,6 +23,7 @@ def test_lock_file_creation(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -42,6 +43,7 @@ def test_lock_file_read(set_project_root: Path) -> None:
         params={"learning_rate": 0.01},
         dep_hashes=dep_hashes,
         output_hashes={},
+        dep_generations={},
     )
 
     stage_lock.write(data)
@@ -75,6 +77,7 @@ def test_manifest_preservation(tmp_path: Path) -> None:
         params={},
         dep_hashes={},
         output_hashes={},
+        dep_generations={},
     )
     stage_lock.write(data)
     result = stage_lock.read()
@@ -97,6 +100,7 @@ def test_parallel_lock_writes(tmp_path: Path) -> None:
                     params={},
                     dep_hashes={},
                     output_hashes={},
+                    dep_generations={},
                 )
             )
         except Exception as e:
@@ -118,6 +122,7 @@ def test_parallel_lock_writes(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
 
 
@@ -150,6 +155,7 @@ def test_stage_unchanged_when_identical(tmp_path: Path) -> None:
             params=params,
             dep_hashes=dep_hashes,
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -168,6 +174,7 @@ def test_stage_changed_code_modified(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -190,6 +197,7 @@ def test_stage_changed_new_dependency(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -212,6 +220,7 @@ def test_stage_changed_params_modified(tmp_path: Path) -> None:
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -235,6 +244,7 @@ def test_stage_changed_dep_hash_modified(tmp_path: Path) -> None:
             params={},
             dep_hashes=old_dep_hashes,
             output_hashes={},
+            dep_generations={},
         )
     )
 
@@ -259,6 +269,7 @@ def test_stage_changed_dep_added(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": old_dep_hashes,
             "output_hashes": {},
+            "dep_generations": {},
         }
     )
 
@@ -288,6 +299,7 @@ def test_stage_changed_dep_removed(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": old_dep_hashes,
             "output_hashes": {},
+            "dep_generations": {},
         }
     )
 
@@ -311,6 +323,7 @@ def test_atomic_write_no_partial_file(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": {},
             "output_hashes": {},
+            "dep_generations": {},
         }
     )
 
@@ -330,6 +343,7 @@ def test_lock_directory_created(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": {},
             "output_hashes": {},
+            "dep_generations": {},
         }
     )
 
@@ -388,6 +402,7 @@ def test_write_failure_no_orphaned_tmp(tmp_path: Path) -> None:
                 "params": {},
                 "dep_hashes": {},
                 "output_hashes": {},
+                "dep_generations": {},
             }
         )
 
@@ -409,6 +424,7 @@ def test_concurrent_same_stage_writes(tmp_path: Path) -> None:
                     "params": {"thread_id": value},
                     "dep_hashes": {},
                     "output_hashes": {},
+                    "dep_generations": {},
                 }
             )
             results.append(value)


### PR DESCRIPTION
## Summary

Addresses technical debt identified in code review issues #143, #144, #145, and #146. Changes organized into logical batches:

### Metrics Module (#146)
- Add `MetricSummary` TypedDict for type-safe summary return
- Fix trimming bug (unbounded growth with single-entry metrics)
- Add NaN/Inf validation in `_add()`
- Add empty list guard in `summary()` to prevent division by zero
- Add comment explaining O(n) counting is intentional

### Executor Module (#144, #145)
- **commit.py**: Document that callers must hold `pending_state_lock`
- **worker.py**: Document `--no-cache` + `--force` behavior, fix uncached output skip bug
- **core.py**: Use `StageStatus` enum instead of string comparisons

### Fingerprint Module (#146)
- Extract `_process_closure_values()` helper to reduce ~50 lines of duplication

### TUI & Reactive Engine (#143, #144)
- **tui/run.py**: Add `_has_running_stages` property to consolidate repeated checks
- **engine.py**: Remove deprecated `is_error` parameter, use `status=ReactiveStatus.ERROR`

### Documentation (#144)
- **project_lock.py**: Document that `timeout=-1` means infinite wait

### Tests (#145)
- Rename `test_no_commit.py` → `test_execution_modes.py`
- Parametrize four duplicate ReactiveEngine flag tests into one
- Update string comparisons to use `StageStatus` enum

## Test plan
- [x] `uv run ruff format . && uv run ruff check .` - All checks pass
- [x] `uv run basedpyright .` - 0 errors, 0 warnings
- [x] `uv run pytest tests/ -n auto` - 2065 passed, 19 skipped, 5 xfailed

Closes #143, closes #144, closes #145, closes #146

🤖 Generated with [Claude Code](https://claude.ai/code)