### PR TITLE
feat(tui): add tabbed interface with Input/Output diff tabs (#151, #152)

### DIFF
--- a/src/pivot/tui/__init__.py
+++ b/src/pivot/tui/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pivot.tui import console as console
 from pivot.tui import diff as diff
+from pivot.tui import diff_panels as diff_panels
 
 # Note: run module is NOT imported here to avoid circular import with executor
 # Import it directly: from pivot.tui import run

--- a/src/pivot/tui/diff_panels.py
+++ b/src/pivot/tui/diff_panels.py
@@ -1,0 +1,355 @@
+"""Input and Output diff panels for the TUI.
+
+Displays stage change information in the Input and Output tabs:
+- Input tab: code changes, dependency changes, parameter changes
+- Output tab: output file changes grouped by type (Out, Metric, Plot)
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Literal
+
+import textual.widgets
+
+from pivot import explain, outputs, parameters, project
+from pivot.registry import REGISTRY
+from pivot.storage import cache, lock
+from pivot.types import ChangeType, OutputChange
+
+if TYPE_CHECKING:
+    from pivot.registry import RegistryStageInfo
+    from pivot.types import LockData, OutputHash
+
+# Type alias for output types matching OutputChange["output_type"]
+OutputType = Literal["out", "metric", "plot"]
+
+# Change indicators with brackets and colors (per plan spec)
+_INDICATOR_MODIFIED = "[yellow]\\[~][/]"
+_INDICATOR_ADDED = "[green]\\[+][/]"
+_INDICATOR_REMOVED = "[red]\\[-][/]"
+_INDICATOR_UNCHANGED = "[dim]\\[ ][/]"
+
+
+def _get_indicator(change_type: ChangeType | None) -> str:
+    """Get the appropriate indicator for a change type."""
+    if change_type is None:
+        return _INDICATOR_UNCHANGED
+    match change_type:
+        case ChangeType.MODIFIED:
+            return _INDICATOR_MODIFIED
+        case ChangeType.ADDED:
+            return _INDICATOR_ADDED
+        case ChangeType.REMOVED:
+            return _INDICATOR_REMOVED
+
+
+def _truncate_hash(hash_str: str | None, length: int = 8) -> str:
+    """Truncate hash to specified length, or return placeholder."""
+    if hash_str is None:
+        return "(none)"
+    return hash_str[:length]
+
+
+def _format_hash_change(
+    old_hash: str | None,
+    new_hash: str | None,
+    change_type: ChangeType | None,
+) -> str:
+    """Format the hash change display."""
+    if change_type is None:
+        # Unchanged
+        return "(unchanged)"
+    match change_type:
+        case ChangeType.ADDED:
+            return f"(none)   -> {_truncate_hash(new_hash)}"
+        case ChangeType.REMOVED:
+            return f"{_truncate_hash(old_hash)} -> (deleted)"
+        case ChangeType.MODIFIED:
+            return f"{_truncate_hash(old_hash)} -> {_truncate_hash(new_hash)}"
+
+
+def _get_registry_info(stage_name: str) -> RegistryStageInfo | None:
+    """Safely get registry info for a stage."""
+    try:
+        return REGISTRY.get(stage_name)
+    except KeyError:
+        return None
+
+
+def _get_cache_dir() -> pathlib.Path:
+    """Get the cache directory path."""
+    return project.get_project_root() / ".pivot" / "cache"
+
+
+def _get_relative_path(abs_path: str) -> str:
+    """Convert absolute path to relative path from project root."""
+    try:
+        proj_root = project.get_project_root()
+        path = pathlib.Path(abs_path)
+        if path.is_absolute():
+            return str(path.relative_to(proj_root))
+    except ValueError:
+        pass
+    return abs_path
+
+
+def _compute_output_changes(
+    lock_data: LockData | None,
+    registry_info: RegistryStageInfo,
+) -> list[OutputChange]:
+    """Compute output changes by comparing lock file with current state."""
+    changes = list[OutputChange]()
+
+    # Build maps for easier lookup
+    outs = registry_info["outs"]
+    outs_paths = registry_info["outs_paths"]
+
+    # Map path -> output type (properly typed as Literal)
+    path_to_type: dict[str, OutputType] = {}
+    for out, path in zip(outs, outs_paths, strict=True):
+        if isinstance(out, outputs.Metric):
+            path_to_type[path] = "metric"
+        elif isinstance(out, outputs.Plot):
+            path_to_type[path] = "plot"
+        else:
+            path_to_type[path] = "out"
+
+    # Get old hashes from lock
+    old_hashes: dict[str, OutputHash] = {}
+    if lock_data and "output_hashes" in lock_data:
+        old_hashes = lock_data["output_hashes"]
+
+    # Compare each output
+    for path in outs_paths:
+        old_hash_info = old_hashes.get(path)
+        old_hash: str | None = None
+        if old_hash_info is not None:
+            old_hash = old_hash_info.get("hash")
+
+        # Compute current hash
+        new_hash: str | None = None
+        path_obj = pathlib.Path(path)
+        try:
+            if path_obj.exists():
+                if path_obj.is_dir():
+                    new_hash, _ = cache.hash_directory(path_obj)
+                else:
+                    new_hash = cache.hash_file(path_obj)
+        except OSError:
+            # File unreadable
+            new_hash = None
+
+        # Determine change type
+        change_type: ChangeType | None = None
+        if old_hash is None and new_hash is not None:
+            change_type = ChangeType.ADDED
+        elif old_hash is not None and new_hash is None:
+            change_type = ChangeType.REMOVED
+        elif old_hash != new_hash and old_hash is not None and new_hash is not None:
+            change_type = ChangeType.MODIFIED
+        # else: both None or equal -> unchanged (None)
+
+        # Since path_to_type is dict[str, OutputType] and we provide "out" as default,
+        # this is already typed as OutputType (Literal["out", "metric", "plot"])
+        output_type: OutputType = path_to_type.get(path, "out")
+
+        changes.append(
+            OutputChange(
+                path=path,
+                old_hash=old_hash,
+                new_hash=new_hash,
+                change_type=change_type,
+                output_type=output_type,
+            )
+        )
+
+    return changes
+
+
+class InputDiffPanel(textual.widgets.Static):
+    """Panel showing input changes for a stage (code, deps, params)."""
+
+    _stage_name: str | None
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+        self._stage_name = None
+
+    def set_stage(self, stage_name: str | None) -> None:  # pragma: no cover
+        """Update the displayed stage."""
+        self._stage_name = stage_name
+        self._update_display()
+
+    def _update_display(self) -> None:  # pragma: no cover
+        """Render the input changes."""
+        if self._stage_name is None:
+            self.update("[dim]No stage selected[/]")
+            return
+
+        registry_info = _get_registry_info(self._stage_name)
+        if registry_info is None:
+            self.update("[dim]Stage not in registry[/]")
+            return
+
+        # Get stage explanation
+        cache_dir = _get_cache_dir()
+        try:
+            explanation = explain.get_stage_explanation(
+                stage_name=self._stage_name,
+                fingerprint=registry_info["fingerprint"],
+                deps=registry_info["deps"],
+                params_instance=registry_info["params"],
+                overrides=parameters.load_params_yaml(),
+                cache_dir=cache_dir,
+            )
+        except Exception:
+            self.update("[dim]Error loading stage explanation[/]")
+            return
+
+        lines = list[str]()
+
+        # Code section
+        code_changes = explanation["code_changes"]
+        if code_changes:
+            lines.append("[bold]Code: Changed[/]")
+            for change in code_changes:
+                indicator = _get_indicator(change["change_type"])
+                hash_display = _format_hash_change(
+                    change["old_hash"], change["new_hash"], change["change_type"]
+                )
+                lines.append(f"  {indicator} {change['key']:<25} {hash_display}")
+        else:
+            lines.append("[bold]Code:[/] [dim](unchanged)[/]")
+
+        lines.append("")
+
+        # Dependencies section
+        dep_changes = explanation["dep_changes"]
+        lines.append("[bold]Dependencies:[/]")
+        if dep_changes:
+            for change in dep_changes:
+                indicator = _get_indicator(change["change_type"])
+                rel_path = _get_relative_path(change["path"])
+                hash_display = _format_hash_change(
+                    change["old_hash"], change["new_hash"], change["change_type"]
+                )
+                lines.append(f"  {indicator} {rel_path:<25} {hash_display}")
+        else:
+            # Show deps from registry as unchanged
+            deps = registry_info["deps"]
+            if deps:
+                for dep_path in deps:
+                    rel_path = _get_relative_path(dep_path)
+                    lines.append(f"  {_INDICATOR_UNCHANGED} {rel_path:<25} (unchanged)")
+            else:
+                lines.append("  [dim]No dependencies[/]")
+
+        lines.append("")
+
+        # Parameters section
+        param_changes = explanation["param_changes"]
+        if param_changes:
+            lines.append("[bold]Parameters: Changed[/]")
+            for change in param_changes:
+                indicator = _get_indicator(change["change_type"])
+                old_val = repr(change["old_value"]) if change["old_value"] is not None else "(none)"
+                new_val = repr(change["new_value"]) if change["new_value"] is not None else "(none)"
+                match change["change_type"]:
+                    case ChangeType.ADDED:
+                        val_display = f"(none) -> {new_val}"
+                    case ChangeType.REMOVED:
+                        val_display = f"{old_val} -> (deleted)"
+                    case ChangeType.MODIFIED:
+                        val_display = f"{old_val} -> {new_val}"
+                lines.append(f"  {indicator} {change['key']:<25} {val_display}")
+        else:
+            lines.append("[bold]Parameters:[/] [dim](unchanged)[/]")
+
+        self.update("\n".join(lines))
+
+
+class OutputDiffPanel(textual.widgets.Static):
+    """Panel showing output changes for a stage (outs, metrics, plots)."""
+
+    _stage_name: str | None
+
+    def __init__(self, *, id: str | None = None, classes: str | None = None) -> None:
+        super().__init__(id=id, classes=classes)
+        self._stage_name = None
+
+    def set_stage(self, stage_name: str | None) -> None:  # pragma: no cover
+        """Update the displayed stage."""
+        self._stage_name = stage_name
+        self._update_display()
+
+    def _update_display(self) -> None:  # pragma: no cover
+        """Render the output changes."""
+        if self._stage_name is None:
+            self.update("[dim]No stage selected[/]")
+            return
+
+        registry_info = _get_registry_info(self._stage_name)
+        if registry_info is None:
+            self.update("[dim]Stage not in registry[/]")
+            return
+
+        # Read lock file
+        cache_dir = _get_cache_dir()
+        stage_lock = lock.StageLock(self._stage_name, cache_dir)
+        lock_data = stage_lock.read()
+
+        # Compute output changes
+        output_changes = _compute_output_changes(lock_data, registry_info)
+
+        # Group by type
+        outs_list = [c for c in output_changes if c["output_type"] == "out"]
+        metrics_list = [c for c in output_changes if c["output_type"] == "metric"]
+        plots_list = [c for c in output_changes if c["output_type"] == "plot"]
+
+        lines = list[str]()
+
+        # Outputs section
+        lines.append("[bold]Outputs:[/]")
+        if outs_list:
+            for change in outs_list:
+                indicator = _get_indicator(change["change_type"])
+                rel_path = _get_relative_path(change["path"])
+                hash_display = _format_hash_change(
+                    change["old_hash"], change["new_hash"], change["change_type"]
+                )
+                lines.append(f"  {indicator} {rel_path:<25} {hash_display}")
+        else:
+            lines.append("  [dim]No outputs[/]")
+
+        lines.append("")
+
+        # Metrics section
+        lines.append("[bold]Metrics:[/]")
+        if metrics_list:
+            for change in metrics_list:
+                indicator = _get_indicator(change["change_type"])
+                rel_path = _get_relative_path(change["path"])
+                hash_display = _format_hash_change(
+                    change["old_hash"], change["new_hash"], change["change_type"]
+                )
+                lines.append(f"  {indicator} {rel_path:<25} {hash_display}")
+        else:
+            lines.append("  [dim]No metrics[/]")
+
+        lines.append("")
+
+        # Plots section
+        lines.append("[bold]Plots:[/]")
+        if plots_list:
+            for change in plots_list:
+                indicator = _get_indicator(change["change_type"])
+                rel_path = _get_relative_path(change["path"])
+                hash_display = _format_hash_change(
+                    change["old_hash"], change["new_hash"], change["change_type"]
+                )
+                lines.append(f"  {indicator} {rel_path:<25} {hash_display}")
+        else:
+            lines.append("  [dim]No plots[/]")
+
+        self.update("\n".join(lines))

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -25,6 +25,7 @@ from pivot import project
 from pivot.executor import ExecutionSummary
 from pivot.executor import commit as commit_mod
 from pivot.storage import lock, project_lock
+from pivot.tui.diff_panels import InputDiffPanel, OutputDiffPanel
 from pivot.types import (
     DisplayMode,
     ReactiveStatus,
@@ -283,18 +284,29 @@ class TabbedDetailPanel(textual.containers.Vertical):
             with textual.widgets.TabPane("Logs", id="tab-logs"):
                 yield StageLogPanel(id="stage-logs")
             with textual.widgets.TabPane("Input", id="tab-input"):
-                yield textual.widgets.Static("[dim]Coming soon...[/]", id="input-placeholder")
+                yield InputDiffPanel(id="input-panel")
             with textual.widgets.TabPane("Output", id="tab-output"):
-                yield textual.widgets.Static("[dim]Coming soon...[/]", id="output-placeholder")
+                yield OutputDiffPanel(id="output-panel")
 
     def set_stage(self, stage: StageInfo | None) -> None:  # pragma: no cover
         """Update the displayed stage."""
         self._stage = stage
+        stage_name = stage.name if stage else None
         try:
             log_panel = self.query_one("#stage-logs", StageLogPanel)
             log_panel.set_stage(stage)
         except textual.css.query.NoMatches:
             _logger.debug("stage-logs panel not found during set_stage")
+        try:
+            input_panel = self.query_one("#input-panel", InputDiffPanel)
+            input_panel.set_stage(stage_name)
+        except textual.css.query.NoMatches:
+            _logger.debug("input-panel not found during set_stage")
+        try:
+            output_panel = self.query_one("#output-panel", OutputDiffPanel)
+            output_panel.set_stage(stage_name)
+        except textual.css.query.NoMatches:
+            _logger.debug("output-panel not found during set_stage")
 
 
 _TUI_CSS: str = """
@@ -331,6 +343,18 @@ _TUI_CSS: str = """
 
 #stage-logs {
     height: 100%;
+}
+
+#input-panel {
+    height: 100%;
+    padding: 1;
+    overflow-y: auto;
+}
+
+#output-panel {
+    height: 100%;
+    padding: 1;
+    overflow-y: auto;
 }
 
 #log-panel {

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -162,6 +162,16 @@ class DepChange(TypedDict):
     change_type: ChangeType
 
 
+class OutputChange(TypedDict):
+    """Change info for an output file."""
+
+    path: str
+    old_hash: str | None
+    new_hash: str | None
+    change_type: ChangeType | None  # None means unchanged
+    output_type: Literal["out", "metric", "plot"]
+
+
 class StageExplanation(TypedDict):
     """Detailed explanation of why a stage would run."""
 

--- a/tests/tui/test_diff_panels.py
+++ b/tests/tui/test_diff_panels.py
@@ -1,0 +1,367 @@
+"""Tests for TUI diff panels."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pivot import outputs, project
+from pivot.storage import cache
+from pivot.tui import diff_panels
+from pivot.types import ChangeType, LockData, OutputChange
+
+if TYPE_CHECKING:
+    import pathlib
+
+    import pytest
+
+    from pivot.registry import RegistryStageInfo
+
+
+# =============================================================================
+# _get_indicator Tests
+# =============================================================================
+
+
+def test_get_indicator_modified() -> None:
+    """_get_indicator returns yellow indicator for modified."""
+    result = diff_panels._get_indicator(ChangeType.MODIFIED)
+    assert "[yellow]" in result
+    assert "~" in result
+
+
+def test_get_indicator_added() -> None:
+    """_get_indicator returns green indicator for added."""
+    result = diff_panels._get_indicator(ChangeType.ADDED)
+    assert "[green]" in result
+    assert "+" in result
+
+
+def test_get_indicator_removed() -> None:
+    """_get_indicator returns red indicator for removed."""
+    result = diff_panels._get_indicator(ChangeType.REMOVED)
+    assert "[red]" in result
+    assert "-" in result
+
+
+def test_get_indicator_unchanged() -> None:
+    """_get_indicator returns dim indicator for unchanged (None)."""
+    result = diff_panels._get_indicator(None)
+    assert "[dim]" in result
+
+
+# =============================================================================
+# _truncate_hash Tests
+# =============================================================================
+
+
+def test_truncate_hash_long() -> None:
+    """_truncate_hash truncates long hash to 8 chars."""
+    result = diff_panels._truncate_hash("a1b2c3d4e5f6g7h8")
+    assert result == "a1b2c3d4"
+
+
+def test_truncate_hash_short() -> None:
+    """_truncate_hash preserves short hash."""
+    result = diff_panels._truncate_hash("abc")
+    assert result == "abc"
+
+
+def test_truncate_hash_none() -> None:
+    """_truncate_hash returns placeholder for None."""
+    result = diff_panels._truncate_hash(None)
+    assert result == "(none)"
+
+
+def test_truncate_hash_custom_length() -> None:
+    """_truncate_hash respects custom length."""
+    result = diff_panels._truncate_hash("a1b2c3d4e5f6g7h8", length=4)
+    assert result == "a1b2"
+
+
+# =============================================================================
+# _format_hash_change Tests
+# =============================================================================
+
+
+def test_format_hash_change_unchanged() -> None:
+    """_format_hash_change shows unchanged for None change_type."""
+    result = diff_panels._format_hash_change("abc123", "abc123", None)
+    assert result == "(unchanged)"
+
+
+def test_format_hash_change_added() -> None:
+    """_format_hash_change shows none -> hash for added."""
+    result = diff_panels._format_hash_change(None, "abc12345", ChangeType.ADDED)
+    assert "(none)" in result
+    assert "abc12345" in result
+    assert "->" in result
+
+
+def test_format_hash_change_removed() -> None:
+    """_format_hash_change shows hash -> deleted for removed."""
+    result = diff_panels._format_hash_change("abc12345", None, ChangeType.REMOVED)
+    assert "abc12345" in result
+    assert "(deleted)" in result
+    assert "->" in result
+
+
+def test_format_hash_change_modified() -> None:
+    """_format_hash_change shows old -> new for modified."""
+    result = diff_panels._format_hash_change("oldhashabc", "newhashxyz", ChangeType.MODIFIED)
+    assert "oldhasha" in result, "Should truncate to 8 chars"
+    assert "newhashx" in result, "Should truncate to 8 chars"
+    assert "->" in result
+
+
+# =============================================================================
+# _get_relative_path Tests
+# =============================================================================
+
+
+def test_get_relative_path_absolute(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_get_relative_path converts absolute path inside project."""
+    (tmp_path / ".pivot").mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(project, "_project_root_cache", None)
+
+    abs_path = str(tmp_path / "data" / "file.csv")
+    result = diff_panels._get_relative_path(abs_path)
+    assert result == "data/file.csv"
+
+
+def test_get_relative_path_relative(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_get_relative_path preserves relative paths."""
+    (tmp_path / ".pivot").mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(project, "_project_root_cache", None)
+
+    result = diff_panels._get_relative_path("some/relative/path.txt")
+    assert result == "some/relative/path.txt"
+
+
+# =============================================================================
+# _get_registry_info Tests
+# =============================================================================
+
+
+def test_get_registry_info_missing_stage() -> None:
+    """_get_registry_info returns None for missing stage."""
+    result = diff_panels._get_registry_info("nonexistent_stage_xyz")
+    assert result is None
+
+
+# =============================================================================
+# _compute_output_changes Tests
+# =============================================================================
+
+
+def test_compute_output_changes_no_lock_shows_added(tmp_path: pathlib.Path) -> None:
+    """_compute_output_changes shows new outputs as ADDED when no lock exists."""
+    output_file = tmp_path / "output.csv"
+    output_file.write_text("data")
+
+    registry_info: RegistryStageInfo = {
+        "func": lambda: None,
+        "name": "test_stage",
+        "deps": [],
+        "outs": [outputs.Out(path=str(output_file))],
+        "outs_paths": [str(output_file)],
+        "params": None,
+        "mutex": [],
+        "variant": None,
+        "signature": None,
+        "fingerprint": {},
+        "cwd": None,
+    }
+
+    result = diff_panels._compute_output_changes(None, registry_info)
+
+    assert len(result) == 1
+    assert result[0]["path"] == str(output_file)
+    assert result[0]["old_hash"] is None
+    assert result[0]["new_hash"] is not None
+    assert result[0]["change_type"] == ChangeType.ADDED
+    assert result[0]["output_type"] == "out"
+
+
+def test_compute_output_changes_missing_file_shows_removed(tmp_path: pathlib.Path) -> None:
+    """_compute_output_changes shows missing files as REMOVED."""
+    output_file = tmp_path / "missing.csv"
+
+    registry_info: RegistryStageInfo = {
+        "func": lambda: None,
+        "name": "test_stage",
+        "deps": [],
+        "outs": [outputs.Out(path=str(output_file))],
+        "outs_paths": [str(output_file)],
+        "params": None,
+        "mutex": [],
+        "variant": None,
+        "signature": None,
+        "fingerprint": {},
+        "cwd": None,
+    }
+
+    lock_data: LockData = {
+        "code_manifest": {},
+        "params": {},
+        "dep_hashes": {},
+        "output_hashes": {str(output_file): {"hash": "oldhash123"}},
+        "dep_generations": {},
+    }
+
+    result = diff_panels._compute_output_changes(lock_data, registry_info)
+
+    assert len(result) == 1
+    assert result[0]["old_hash"] == "oldhash123"
+    assert result[0]["new_hash"] is None
+    assert result[0]["change_type"] == ChangeType.REMOVED
+
+
+def test_compute_output_changes_unchanged(tmp_path: pathlib.Path) -> None:
+    """_compute_output_changes returns None change_type for unchanged files."""
+    output_file = tmp_path / "output.csv"
+    output_file.write_text("data")
+
+    actual_hash = cache.hash_file(output_file)
+
+    registry_info: RegistryStageInfo = {
+        "func": lambda: None,
+        "name": "test_stage",
+        "deps": [],
+        "outs": [outputs.Out(path=str(output_file))],
+        "outs_paths": [str(output_file)],
+        "params": None,
+        "mutex": [],
+        "variant": None,
+        "signature": None,
+        "fingerprint": {},
+        "cwd": None,
+    }
+
+    lock_data: LockData = {
+        "code_manifest": {},
+        "params": {},
+        "dep_hashes": {},
+        "output_hashes": {str(output_file): {"hash": actual_hash}},
+        "dep_generations": {},
+    }
+
+    result = diff_panels._compute_output_changes(lock_data, registry_info)
+
+    assert len(result) == 1
+    assert result[0]["change_type"] is None, "Unchanged files should have None change_type"
+
+
+def test_compute_output_changes_detects_output_types(tmp_path: pathlib.Path) -> None:
+    """_compute_output_changes correctly identifies Out, Metric, Plot types."""
+    out_file = tmp_path / "output.csv"
+    metric_file = tmp_path / "metrics.json"
+    plot_file = tmp_path / "plot.png"
+
+    for f in [out_file, metric_file, plot_file]:
+        f.write_text("data")
+
+    registry_info: RegistryStageInfo = {
+        "func": lambda: None,
+        "name": "test_stage",
+        "deps": [],
+        "outs": [
+            outputs.Out(path=str(out_file)),
+            outputs.Metric(path=str(metric_file)),
+            outputs.Plot(path=str(plot_file)),
+        ],
+        "outs_paths": [str(out_file), str(metric_file), str(plot_file)],
+        "params": None,
+        "mutex": [],
+        "variant": None,
+        "signature": None,
+        "fingerprint": {},
+        "cwd": None,
+    }
+
+    result = diff_panels._compute_output_changes(None, registry_info)
+
+    assert len(result) == 3
+    types = {r["output_type"] for r in result}
+    assert types == {"out", "metric", "plot"}
+
+
+# =============================================================================
+# Panel Initialization Tests
+# =============================================================================
+
+
+def test_input_diff_panel_init() -> None:
+    """InputDiffPanel initializes with None stage_name."""
+    panel = diff_panels.InputDiffPanel(id="test-panel")
+    assert panel._stage_name is None
+
+
+def test_input_diff_panel_set_stage_none() -> None:
+    """InputDiffPanel.set_stage(None) sets stage_name to None."""
+    panel = diff_panels.InputDiffPanel()
+    panel.set_stage(None)
+    assert panel._stage_name is None
+
+
+def test_output_diff_panel_init() -> None:
+    """OutputDiffPanel initializes with None stage_name."""
+    panel = diff_panels.OutputDiffPanel(id="test-panel")
+    assert panel._stage_name is None
+
+
+def test_output_diff_panel_set_stage_none() -> None:
+    """OutputDiffPanel.set_stage(None) sets stage_name to None."""
+    panel = diff_panels.OutputDiffPanel()
+    panel.set_stage(None)
+    assert panel._stage_name is None
+
+
+# =============================================================================
+# OutputChange TypedDict Tests
+# =============================================================================
+
+
+def test_output_change_creation() -> None:
+    """OutputChange TypedDict can be created with all fields."""
+    change = OutputChange(
+        path="/path/to/file.csv",
+        old_hash="abc123",
+        new_hash="def456",
+        change_type=ChangeType.MODIFIED,
+        output_type="out",
+    )
+    assert change["path"] == "/path/to/file.csv"
+    assert change["old_hash"] == "abc123"
+    assert change["new_hash"] == "def456"
+    assert change["change_type"] == ChangeType.MODIFIED
+    assert change["output_type"] == "out"
+
+
+def test_output_change_with_metric_type() -> None:
+    """OutputChange can have metric output_type."""
+    change = OutputChange(
+        path="/metrics.json",
+        old_hash=None,
+        new_hash="xyz789",
+        change_type=ChangeType.ADDED,
+        output_type="metric",
+    )
+    assert change["output_type"] == "metric"
+
+
+def test_output_change_with_plot_type() -> None:
+    """OutputChange can have plot output_type."""
+    change = OutputChange(
+        path="/plot.png",
+        old_hash="old123",
+        new_hash=None,
+        change_type=ChangeType.REMOVED,
+        output_type="plot",
+    )
+    assert change["output_type"] == "plot"


### PR DESCRIPTION
## Summary

Implements the TUI tabbed interface and diff panels from Issues #151 and #152.

- **Tabbed Interface (#151)**: Add `TabbedDetailPanel` with Logs, Input, and Output tabs
- **Input Tab (#152)**: Shows code status, dependencies, and parameter changes with indicators
- **Output Tab (#152)**: Shows outputs, metrics, and plots grouped by type with hash values

### Visual Format

```
Input Tab:
─────────────────────────────────────────────────────────────
Code: Changed
  [~] self:process            a1b2c3d4 -> e5f6g7h8

Dependencies:
  [~] data/input.csv          q7r8s9t0 -> u1v2w3x4
  [ ] config/settings.yaml    (unchanged)

Parameters: Unchanged
─────────────────────────────────────────────────────────────

Output Tab:
─────────────────────────────────────────────────────────────
Outputs:
  [~] output/results.csv      a1b2c3d4 -> e5f6g7h8
  [ ] output/model.pkl        (unchanged)

Metrics:
  [+] metrics/scores.json     (none)   -> m3n4o5p6

Plots:
  [ ] plots/accuracy.png      (unchanged)
─────────────────────────────────────────────────────────────
```

### Changes

- Add `TabbedDetailPanel` with Logs, Input, and Output tabs
- Remove old `run_tui.py` module, consolidate into `tui/run.py`
- Add `InputDiffPanel` showing code, dependencies, and parameter changes
- Add `OutputDiffPanel` showing outputs, metrics, and plots with hash values
- Change indicators: `[~]` modified (yellow), `[+]` added (green), `[-]` removed (red), `[ ]` unchanged (dim)
- Hash values truncated to 8 chars with `old -> new` format
- Debug logging for exception handlers (per Copilot review feedback)

### Implementation Details

- New `diff_panels.py` module with `InputDiffPanel` and `OutputDiffPanel` widgets
- `OutputChange` TypedDict for tracking output file changes
- Integration with `explain.get_stage_explanation()` for input changes
- Integration with `StageLock` and `cache.hash_file()` for output changes

## Test Plan

- [x] 26 new tests for diff panels helper functions and panel initialization
- [x] Updated existing TUI tests
- [x] All 2066 tests pass
- [x] ruff format, ruff check, basedpyright all pass

Closes #151, Closes #152

🤖 Generated with [Claude Code](https://claude.ai/code)