### PR TITLE
fix(tui): improve security, type safety, and selection stability in diff panels

### DIFF
--- a/src/pivot/tui/diff.py
+++ b/src/pivot/tui/diff.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, override
 
+import rich.markup
 import textual.app
 import textual.binding
 import textual.containers
@@ -39,11 +40,12 @@ class DiffSummaryPanel(textual.widgets.Static):
         summary_lines = list[str]()
 
         # File path and status
+        escaped_path = rich.markup.escape(self._result["path"])
         if self._result["reorder_only"]:
-            summary_lines.append(f"[bold blue]{self._result['path']}[/] - REORDER ONLY")
+            summary_lines.append(f"[bold blue]{escaped_path}[/] - REORDER ONLY")
             summary_lines.append("[dim]Same content, different row order[/]")
         else:
-            summary_lines.append(f"[bold]{self._result['path']}[/]")
+            summary_lines.append(f"[bold]{escaped_path}[/]")
 
         # Row counts
         old_rows = self._result["old_rows"]


### PR DESCRIPTION
## Summary

Follow-up improvements to the TUI diff panels (#153) based on code analysis:

### Security
- Add `escape()` for Rich markup on all user-controlled strings (stage names, paths, log lines, messages) to prevent markup injection
- Add error notification when watch mode crashes, informing users to restart `pivot watch`

### Type Safety
- Add `assert_never` for exhaustive match statements on `ChangeType`
- Use `MetricValue` type for metric formatting functions
- Use `OutputType` literal type for output type labels

### Performance
- Convert linear search in `_find_*_change` methods to O(1) dict lookups using `_code_by_key`, `_dep_by_path`, `_param_by_key`, `_output_by_path`

### Stability
- Track selection by stage name instead of index - preserves selected stage when stages are reloaded in watch mode
- Add try/catch for `pathlib.Path.resolve()` with fallback to raw path in metric diffs

### Code Quality
- Extract `_format_status` method to base class
- Create `_append_hash_detail` shared helper for hash detail rendering
- Consolidate TabbedDetailPanel query loops into single loop for diff panels
- Add debug logging for thread join timeout result
- Fix 0-0 percentage calculation to show `0.0%` instead of misleading infinity

## Test Plan
- [x] All 2075 tests pass
- [x] Type checker passes (0 errors, 3 expected warnings from `assert_never`)
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.ai/code)