### PR TITLE
feat(tui): add row-level data diff display in Output panel (#154)

### DIFF
--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -432,6 +432,9 @@ _TUI_BINDINGS: list[textual.binding.BindingType] = [
     textual.binding.Binding("l", "nav_right", "Right", show=False),
     textual.binding.Binding("left", "nav_left", "Left", show=False),
     textual.binding.Binding("right", "nav_right", "Right", show=False),
+    # Changed-item navigation (in detail panel only)
+    textual.binding.Binding("n", "next_changed", "Next Change", show=False),
+    textual.binding.Binding("N", "prev_changed", "Prev Change", show=False),
     # Tab mnemonic keys (shift+letter)
     textual.binding.Binding("L", "goto_tab_logs", "Logs Tab", show=False),
     textual.binding.Binding("I", "goto_tab_input", "Input Tab", show=False),
@@ -743,6 +746,18 @@ class _BaseTuiApp(textual.app.App[_AppReturnT]):
         panel = self._get_active_diff_panel()
         if self._focused_panel == "detail" and panel:
             panel.expand_details()
+
+    def action_next_changed(self) -> None:  # pragma: no cover
+        """Move selection to next changed item."""
+        panel = self._get_active_diff_panel()
+        if self._focused_panel == "detail" and panel:
+            panel.select_next_changed()
+
+    def action_prev_changed(self) -> None:  # pragma: no cover
+        """Move selection to previous changed item."""
+        panel = self._get_active_diff_panel()
+        if self._focused_panel == "detail" and panel:
+            panel.select_prev_changed()
 
     @override
     async def action_quit(self) -> None:  # pragma: no cover


### PR DESCRIPTION
## Summary

Add row-level data diff functionality to the TUI Output panel. When users expand a data file (CSV, JSON, JSONL) with Enter, they now see schema changes and row-level diffs instead of just hash comparisons.

## Changes

### Security hardening (`src/pivot/show/data.py`)
- Hash validation pattern for xxhash64 (16 hex characters) to prevent path traversal
- Symlink escape prevention check
- Secure temp file permissions (`os.fchmod(fd, 0o600)`) before writing data

### Data diff rendering (`src/pivot/tui/diff_panels.py`)
- `_is_data_file()` - detect CSV/JSON/JSONL files
- `_render_data_diff()` - render row-level diff with temp file scoped to call
- `_render_file_added()` - render detail for newly added files
- `_render_hash_detail()` - render hash-only detail for non-data files or cache miss
- `_format_diff_result()` - format DataDiffResult as Rich markup (rows, columns, schema changes, row changes)

### Changed-item navigation
- `select_next_changed()` / `select_prev_changed()` in base panel class
- `_is_changed()` overrides in both InputDiffPanel and OutputDiffPanel
- `n`/`N` key bindings and action handlers in run.py

### Tests (`tests/show/test_data.py`)
- Updated tests to use valid 16-char xxhash64 hash format
- Added `test_restore_data_from_cache_invalid_hash` for security validation
- Added `test_restore_data_from_cache_symlink_blocked` for symlink check

## Test plan

- [x] All 2113 tests pass
- [x] `ruff format`, `ruff check`, `basedpyright` all pass
- [ ] Manual testing: `pivot watch` or `pivot run` with CSV/JSON outputs, navigate with j/k, expand with Enter, use n/N to jump between changes

Closes #154

---
Generated with [Claude Code](https://claude.ai/code)