### PR TITLE
feat(cli): add pivot import-dvc command

### DIFF
--- a/src/pivot/cli/__init__.py
+++ b/src/pivot/cli/__init__.py
@@ -12,7 +12,16 @@ COMMAND_CATEGORIES = {
     "Inspection": ["list", "metrics", "params", "plots", "data", "history", "show"],
     "Versioning": ["track", "checkout"],
     "Remote": ["remote", "push", "pull"],
-    "Other": ["init", "export", "config", "completion", "schema", "check-ignore", "doctor"],
+    "Other": [
+        "init",
+        "export",
+        "import-dvc",
+        "config",
+        "completion",
+        "schema",
+        "check-ignore",
+        "doctor",
+    ],
 }
 
 # Lazy command registry: command_name -> (module_path, attr_name, help_text)
@@ -22,6 +31,11 @@ _LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
     "explain": ("pivot.cli.run", "explain_cmd", "Show detailed breakdown of why stages would run."),
     "list": ("pivot.cli.list", "list_cmd", "List registered stages."),
     "export": ("pivot.cli.export", "export", "Export pipeline to DVC YAML format."),
+    "import-dvc": (
+        "pivot.cli.import_dvc",
+        "import_dvc",
+        "Import DVC pipeline and convert to Pivot format.",
+    ),
     "track": ("pivot.cli.track", "track", "Track files/directories for caching."),
     "status": ("pivot.cli.status", "status", "Show pipeline, tracked files, and remote status."),
     "checkout": (

--- a/src/pivot/cli/import_dvc.py
+++ b/src/pivot/cli/import_dvc.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import pathlib
+
+import click
+
+from pivot.cli import decorators as cli_decorators
+from pivot.cli import helpers as cli_helpers
+
+
+@cli_decorators.pivot_command(auto_discover=False)
+@click.option(
+    "--input",
+    "-i",
+    "input_path",
+    type=click.Path(exists=True, path_type=pathlib.Path),
+    default=None,
+    help="Path to dvc.yaml (default: auto-detect in current directory)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=pathlib.Path),
+    default="pivot.yaml",
+    help="Output path for pivot.yaml (default: pivot.yaml)",
+)
+@click.option(
+    "--params",
+    "-p",
+    type=click.Path(exists=True, path_type=pathlib.Path),
+    default=None,
+    help="Path to params.yaml (default: auto-detect)",
+)
+@click.option(
+    "--notes",
+    "-n",
+    type=click.Path(path_type=pathlib.Path),
+    default=".pivot/migration-notes.md",
+    help="Path for migration notes (default: .pivot/migration-notes.md)",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing files",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be generated without writing files",
+)
+@click.pass_context
+def import_dvc(
+    ctx: click.Context,
+    input_path: pathlib.Path | None,
+    output: pathlib.Path,
+    params: pathlib.Path | None,
+    notes: pathlib.Path,
+    force: bool,
+    dry_run: bool,
+) -> None:
+    """Import DVC pipeline and convert to Pivot format.
+
+    Reads dvc.yaml (and optionally dvc.lock, params.yaml) and generates
+    pivot.yaml with migration notes for manual review.
+
+    Shell commands in DVC stages cannot be automatically converted to Python
+    functions. You must create corresponding Python functions and update
+    the generated pivot.yaml manually.
+    """
+    from pivot import dvc_import, path_policy, project
+
+    cli_ctx = cli_helpers.get_cli_context(ctx)
+    quiet = cli_ctx["quiet"]
+
+    proj_root = project.get_project_root()
+
+    # Auto-detect input file
+    if input_path is None:
+        input_path = _find_dvc_yaml(proj_root)
+        if input_path is None:
+            raise click.ClickException(
+                "No dvc.yaml found in current directory. Use --input to specify the path."
+            )
+
+    # Auto-detect dvc.lock
+    dvc_lock_path = input_path.parent / "dvc.lock"
+    if not dvc_lock_path.exists():
+        dvc_lock_path = None
+
+    # Auto-detect params.yaml
+    if params is None:
+        params_path = input_path.parent / "params.yaml"
+        if not params_path.exists():
+            params_path = None
+    else:
+        params_path = params
+
+    # Validate output paths
+    path_policy.require_valid_path(
+        str(output),
+        path_policy.PathType.CLI_OUTPUT,
+        proj_root,
+        context="import-dvc --output",
+    )
+    path_policy.require_valid_path(
+        str(notes),
+        path_policy.PathType.CLI_OUTPUT,
+        proj_root,
+        context="import-dvc --notes",
+    )
+
+    # Convert pipeline
+    if not quiet:
+        click.echo(f"Importing from {input_path}...")
+
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=input_path,
+        dvc_lock_path=dvc_lock_path,
+        params_yaml_path=params_path,
+        project_root=proj_root,
+    )
+
+    stats = result["stats"]
+    notes_list = result["notes"]
+
+    # Report progress
+    if not quiet:
+        click.echo(f"  [OK] Converted {stats['stages_converted']} stages")
+        if params_path:
+            click.echo(f"  [OK] Inlined params from {params_path.name}")
+        if stats["stages_with_shell_commands"] > 0:
+            click.echo(
+                f"  [WARN] {stats['stages_with_shell_commands']} stages use shell commands "
+                + "(see migration notes)"
+            )
+        click.echo("  [INFO] First 'pivot run' will rebuild cache (DVC hashes not migrated)")
+
+    if dry_run:
+        if not quiet:
+            click.echo("")
+            click.echo("Dry run - no files written.")
+            click.echo("")
+            click.echo("Would create:")
+            click.echo(f"  {output}")
+            click.echo(f"  {notes}")
+        return
+
+    # Write output files
+    dvc_import.write_pivot_yaml(result["stages"], output, force=force)
+    dvc_import.write_migration_notes(notes_list, stats, notes, force=force)
+
+    if not quiet:
+        click.echo("")
+        click.echo("Created:")
+        click.echo(f"  {output} ({stats['stages_converted']} stages)")
+        click.echo(f"  {notes}")
+        click.echo("")
+        click.echo("Next steps:")
+        click.echo(f"  1. Review {notes} for required changes")
+        click.echo("  2. Run 'pivot run --dry-run' to verify configuration")
+
+
+def _find_dvc_yaml(root: pathlib.Path) -> pathlib.Path | None:
+    """Find dvc.yaml in the given directory."""
+    dvc_yaml = root / "dvc.yaml"
+    if dvc_yaml.exists():
+        return dvc_yaml
+    return None

--- a/src/pivot/dvc_import.py
+++ b/src/pivot/dvc_import.py
@@ -1,0 +1,852 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import pathlib
+import re
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
+
+import ruamel.yaml
+import yaml
+
+from pivot import exceptions, path_policy, project, yaml_config
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Maximum file size for dvc.yaml/dvc.lock (10MB)
+MAX_DVC_FILE_SIZE = 10 * 1024 * 1024
+
+
+class DVCStageConfig(TypedDict, total=False):
+    """Raw DVC stage from dvc.yaml."""
+
+    cmd: str | list[str]
+    deps: list[str | dict[str, Any]]
+    outs: list[str | dict[str, Any]]
+    params: list[str | dict[str, Any]]
+    metrics: list[str | dict[str, Any]]
+    plots: list[str | dict[str, Any]]
+    wdir: str
+    frozen: bool
+    foreach: list[Any] | dict[str, Any]
+    do: DVCStageConfig
+
+
+class DVCConfig(TypedDict):
+    """Top-level dvc.yaml structure."""
+
+    stages: dict[str, DVCStageConfig]
+
+
+class DVCLockStage(TypedDict, total=False):
+    """Stage entry from dvc.lock."""
+
+    cmd: str
+    deps: list[dict[str, Any]]
+    outs: list[dict[str, Any]]
+    params: dict[str, dict[str, Any]]
+
+
+class DVCLock(TypedDict, total=False):
+    """Top-level dvc.lock structure."""
+
+    schema: str
+    stages: dict[str, DVCLockStage]
+
+
+class PivotStageConfig(TypedDict, total=False):
+    """Stage config for pivot.yaml output."""
+
+    python: str
+    deps: list[str]
+    outs: list[str | dict[str, dict[str, bool]]]
+    metrics: list[str]
+    plots: list[str]
+    params: dict[str, Any]
+    cwd: str
+    matrix: dict[str, list[str]]
+
+
+class MigrationNote(TypedDict):
+    """A migration note/warning for the user."""
+
+    stage: str | None
+    severity: Literal["error", "warning", "info"]
+    message: str
+    original_cmd: str | None
+
+
+class ConversionStats(TypedDict):
+    """Statistics about the conversion."""
+
+    stages_converted: int
+    stages_with_shell_commands: int
+    stages_with_warnings: int
+    params_inlined: int
+
+
+class ConversionResult(TypedDict):
+    """Result of converting a DVC pipeline."""
+
+    stages: dict[str, PivotStageConfig]
+    notes: list[MigrationNote]
+    stats: ConversionStats
+
+
+class _ResolveParamsResult(TypedDict):
+    """Result of resolving params."""
+
+    params: dict[str, Any]
+    count: int
+    notes: list[MigrationNote]
+
+
+def parse_dvc_yaml(path: Path) -> DVCConfig:
+    """Parse dvc.yaml with size limit and safe loader."""
+    _check_file_size(path, "dvc.yaml")
+
+    try:
+        with path.open() as f:
+            data = yaml.load(f, Loader=yaml_config.Loader)
+    except yaml.YAMLError as e:
+        raise exceptions.DVCImportError(f"Invalid YAML in {path}: {e}") from e
+
+    if data is None:
+        raise exceptions.DVCImportError(f"dvc.yaml is empty: {path}")
+
+    if not isinstance(data, dict):
+        raise exceptions.DVCImportError(f"dvc.yaml must be a mapping, got {type(data).__name__}")
+
+    if "stages" not in data:
+        raise exceptions.DVCImportError("dvc.yaml missing 'stages' key")
+
+    stages_data: dict[str, DVCStageConfig] = data["stages"]  # pyright: ignore[reportUnknownVariableType] - yaml returns Any
+    if not isinstance(stages_data, dict):
+        raise exceptions.DVCImportError("dvc.yaml 'stages' must be a mapping")
+
+    return DVCConfig(stages=stages_data)  # pyright: ignore[reportUnknownArgumentType] - validated above
+
+
+def parse_dvc_lock(path: Path) -> DVCLock | None:
+    """Parse dvc.lock if present. Returns None if file doesn't exist."""
+    if not path.exists():
+        return None
+
+    _check_file_size(path, "dvc.lock")
+
+    try:
+        with path.open() as f:
+            data = yaml.load(f, Loader=yaml_config.Loader)
+    except yaml.YAMLError as e:
+        logger.warning("Failed to parse dvc.lock: %s", e)
+        return None
+
+    if data is None or not isinstance(data, dict):
+        return None
+
+    schema: str = data["schema"] if "schema" in data else ""  # pyright: ignore[reportUnknownVariableType] - yaml returns Any
+    stages_raw = data["stages"] if "stages" in data else {}  # pyright: ignore[reportUnknownVariableType]
+    stages: dict[str, DVCLockStage] = stages_raw if isinstance(stages_raw, dict) else {}  # pyright: ignore[reportUnknownVariableType]
+
+    return DVCLock(
+        schema=schema if isinstance(schema, str) else "",
+        stages=stages,
+    )
+
+
+def parse_params_yaml(path: Path) -> tuple[dict[str, Any], list[MigrationNote]]:
+    """Parse params.yaml for parameter inlining. Returns (params, notes)."""
+    notes = list[MigrationNote]()
+
+    if not path.exists():
+        return {}, notes
+
+    _check_file_size(path, "params.yaml")
+
+    try:
+        with path.open() as f:
+            data = yaml.load(f, Loader=yaml_config.Loader)
+    except yaml.YAMLError as e:
+        raise exceptions.DVCImportError(f"Invalid YAML in {path}: {e}") from e
+
+    if data is None:
+        return {}, notes
+
+    if not isinstance(data, dict):
+        raise exceptions.DVCImportError(f"params.yaml must be a mapping, got {type(data).__name__}")
+
+    # Check for non-string keys and warn
+    result = dict[str, Any]()
+    non_string_keys = list[str]()
+    for k, v in data.items():  # pyright: ignore[reportUnknownVariableType] - yaml returns Any
+        if isinstance(k, str):
+            result[k] = v
+        else:
+            non_string_keys.append(repr(k))  # pyright: ignore[reportUnknownArgumentType]
+
+    if non_string_keys:
+        notes.append(
+            MigrationNote(
+                stage=None,
+                severity="warning",
+                message=f"params.yaml contains non-string keys that were skipped: {', '.join(non_string_keys)}",
+                original_cmd=None,
+            )
+        )
+
+    return result, notes
+
+
+def _check_file_size(path: Path, name: str) -> None:
+    """Check file size doesn't exceed limit."""
+    try:
+        size = path.stat().st_size
+        if size > MAX_DVC_FILE_SIZE:
+            raise exceptions.DVCImportError(
+                f"{name} exceeds maximum size ({MAX_DVC_FILE_SIZE // (1024 * 1024)}MB)"
+            )
+    except OSError as e:
+        raise exceptions.DVCImportError(f"Cannot read {name}: {e}") from e
+
+
+def convert_pipeline(
+    dvc_yaml_path: Path,
+    dvc_lock_path: Path | None = None,
+    params_yaml_path: Path | None = None,
+    project_root: Path | None = None,
+) -> ConversionResult:
+    """Convert DVC pipeline to Pivot format.
+
+    Args:
+        dvc_yaml_path: Path to dvc.yaml
+        dvc_lock_path: Path to dvc.lock (optional, for param values)
+        params_yaml_path: Path to params.yaml (optional, for param values)
+        project_root: Project root for path validation (default: auto-detect)
+
+    Returns:
+        ConversionResult with stages, notes, and stats
+    """
+    proj_root = project_root or project.get_project_root()
+
+    # Parse input files
+    dvc_config = parse_dvc_yaml(dvc_yaml_path)
+    dvc_lock = parse_dvc_lock(dvc_lock_path) if dvc_lock_path else None
+
+    notes = list[MigrationNote]()
+    if params_yaml_path:
+        params_yaml, params_notes = parse_params_yaml(params_yaml_path)
+        notes.extend(params_notes)
+    else:
+        params_yaml = {}
+
+    stages = dict[str, PivotStageConfig]()
+    stats = ConversionStats(
+        stages_converted=0,
+        stages_with_shell_commands=0,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+
+    for stage_name, dvc_stage in dvc_config["stages"].items():
+        # Handle foreach stages
+        if "foreach" in dvc_stage:
+            converted, stage_notes, params_count = _convert_foreach_stage(
+                stage_name, dvc_stage, params_yaml, dvc_lock, proj_root
+            )
+            stages.update(converted)
+            notes.extend(stage_notes)
+            stats["stages_converted"] += len(converted)
+            # Only count shell commands if do block has cmd
+            if "do" in dvc_stage and "cmd" in dvc_stage["do"]:
+                stats["stages_with_shell_commands"] += len(converted)
+            stats["params_inlined"] += params_count
+        else:
+            pivot_stage, stage_notes, params_count = _convert_stage(
+                stage_name, dvc_stage, params_yaml, dvc_lock, proj_root
+            )
+            stages[stage_name] = pivot_stage
+            notes.extend(stage_notes)
+            stats["stages_converted"] += 1
+            if "cmd" in dvc_stage:
+                stats["stages_with_shell_commands"] += 1
+            stats["params_inlined"] += params_count
+
+    # Count warnings
+    stats["stages_with_warnings"] = sum(1 for n in notes if n["severity"] == "warning")
+
+    return ConversionResult(stages=stages, notes=notes, stats=stats)
+
+
+def _convert_stage(
+    name: str,
+    dvc_stage: DVCStageConfig,
+    params_yaml: dict[str, Any],
+    dvc_lock: DVCLock | None,
+    project_root: Path,
+) -> tuple[PivotStageConfig, list[MigrationNote], int]:
+    """Convert a single DVC stage to Pivot format. Returns (stage, notes, params_count)."""
+    notes = list[MigrationNote]()
+    pivot_stage = PivotStageConfig()
+    params_count = 0
+
+    # cmd -> python (PLACEHOLDER)
+    pivot_stage["python"] = f"PLACEHOLDER.{name}"
+    if "cmd" in dvc_stage:
+        cmd = dvc_stage["cmd"]
+        cmd_str = cmd if isinstance(cmd, str) else " && ".join(str(c) for c in cmd)
+        notes.append(
+            MigrationNote(
+                stage=name,
+                severity="warning",
+                message="Shell command requires manual conversion to Python function",
+                original_cmd=cmd_str,
+            )
+        )
+
+    # deps - validate and pass through
+    if "deps" in dvc_stage:
+        pivot_stage["deps"] = _extract_paths(dvc_stage["deps"], name, "dep", project_root, notes)
+
+    # outs - convert format
+    if "outs" in dvc_stage:
+        pivot_stage["outs"] = _convert_outs(dvc_stage["outs"], name, project_root, notes)
+
+    # metrics
+    if "metrics" in dvc_stage:
+        pivot_stage["metrics"] = _extract_paths(
+            dvc_stage["metrics"], name, "metric", project_root, notes
+        )
+
+    # plots
+    if "plots" in dvc_stage:
+        pivot_stage["plots"] = _extract_paths(dvc_stage["plots"], name, "plot", project_root, notes)
+
+    # params - resolve and inline
+    if "params" in dvc_stage:
+        resolve_result = _resolve_params(dvc_stage["params"], params_yaml, dvc_lock, name)
+        if resolve_result["params"]:
+            pivot_stage["params"] = resolve_result["params"]
+        params_count = resolve_result["count"]
+        notes.extend(resolve_result["notes"])
+
+    # wdir -> cwd (with explicit absolute path check)
+    if "wdir" in dvc_stage:
+        wdir = dvc_stage["wdir"]
+        if pathlib.Path(wdir).is_absolute():
+            notes.append(
+                MigrationNote(
+                    stage=name,
+                    severity="error",
+                    message=f"Absolute wdir path not allowed: '{wdir}'",
+                    original_cmd=None,
+                )
+            )
+        elif _validate_path(wdir, name, "cwd", project_root, notes):
+            pivot_stage["cwd"] = wdir
+
+    # frozen - warning only
+    if "frozen" in dvc_stage and dvc_stage["frozen"]:
+        notes.append(
+            MigrationNote(
+                stage=name,
+                severity="warning",
+                message=(
+                    "Stage has 'frozen: true' which is not supported in Pivot. "
+                    "Stage will run normally."
+                ),
+                original_cmd=None,
+            )
+        )
+
+    return pivot_stage, notes, params_count
+
+
+def _convert_foreach_stage(
+    name: str,
+    dvc_stage: DVCStageConfig,
+    params_yaml: dict[str, Any],
+    dvc_lock: DVCLock | None,
+    project_root: Path,
+) -> tuple[dict[str, PivotStageConfig], list[MigrationNote], int]:
+    """Convert DVC foreach/do stage to Pivot matrix format."""
+    notes = list[MigrationNote]()
+    stages = dict[str, PivotStageConfig]()
+    params_count = 0
+
+    # foreach is guaranteed to exist by caller check (line 257: if "foreach" in dvc_stage)
+    foreach = dvc_stage["foreach"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    do_stage = dvc_stage["do"] if "do" in dvc_stage else None
+
+    if do_stage is None:
+        notes.append(
+            MigrationNote(
+                stage=name,
+                severity="error",
+                message="foreach stage missing 'do' block",
+                original_cmd=None,
+            )
+        )
+        return stages, notes, params_count
+
+    # Validate foreach is not empty and convert to matrix dimension
+    if isinstance(foreach, list):
+        if not foreach:
+            notes.append(
+                MigrationNote(
+                    stage=name,
+                    severity="error",
+                    message="foreach list is empty",
+                    original_cmd=None,
+                )
+            )
+            return stages, notes, params_count
+        matrix_values = [str(v) for v in foreach]
+    elif isinstance(foreach, dict):  # pyright: ignore[reportUnnecessaryIsInstance] - type narrowing
+        if not foreach:
+            notes.append(
+                MigrationNote(
+                    stage=name,
+                    severity="error",
+                    message="foreach dict is empty",
+                    original_cmd=None,
+                )
+            )
+            return stages, notes, params_count
+        matrix_values = list(foreach.keys())
+        # Warn about lost dict values
+        notes.append(
+            MigrationNote(
+                stage=name,
+                severity="warning",
+                message=(
+                    "foreach dict values are not preserved in matrix conversion. "
+                    "Only keys are used as matrix items."
+                ),
+                original_cmd=None,
+            )
+        )
+    else:
+        notes.append(
+            MigrationNote(
+                stage=name,
+                severity="error",
+                message=f"Unsupported foreach type: {type(foreach).__name__}",
+                original_cmd=None,
+            )
+        )
+        return stages, notes, params_count
+
+    # Create a single stage with matrix
+    pivot_stage, stage_notes, params_count = _convert_stage(
+        name, do_stage, params_yaml, dvc_lock, project_root
+    )
+    notes.extend(stage_notes)
+
+    # Add matrix configuration
+    pivot_stage["matrix"] = {"item": matrix_values}
+
+    stages[name] = pivot_stage
+
+    notes.append(
+        MigrationNote(
+            stage=name,
+            severity="info",
+            message=(
+                f"Converted foreach to matrix with {len(matrix_values)} variants. "
+                "Verify ${item} substitutions work correctly."
+            ),
+            original_cmd=None,
+        )
+    )
+
+    return stages, notes, params_count
+
+
+def _extract_paths(
+    items: list[str | dict[str, Any]],
+    stage_name: str,
+    path_type: str,
+    project_root: Path,
+    notes: list[MigrationNote],
+) -> list[str]:
+    """Extract and validate paths from DVC list format (strings or dicts with path keys)."""
+    result = list[str]()
+    for item in items:
+        if isinstance(item, str):
+            if _validate_path(item, stage_name, path_type, project_root, notes):
+                result.append(item)
+        else:
+            # Dict form: {path: {options}} - extract path keys
+            for path in item:
+                if _validate_path(path, stage_name, path_type, project_root, notes):
+                    result.append(path)
+    return result
+
+
+def _convert_outs(
+    outs: list[str | dict[str, Any]],
+    stage_name: str,
+    project_root: Path,
+    notes: list[MigrationNote],
+) -> list[str | dict[str, dict[str, bool]]]:
+    """Convert DVC outs to Pivot format, preserving cache: false options."""
+    result = list[str | dict[str, dict[str, bool]]]()
+    for out in outs:
+        if isinstance(out, str):
+            if _validate_path(out, stage_name, "out", project_root, notes):
+                result.append(out)
+        else:
+            # Dict form: {path: {cache: false, ...}}
+            for path, opts in out.items():
+                if not _validate_path(path, stage_name, "out", project_root, notes):
+                    continue
+                if isinstance(opts, dict) and "cache" in opts and opts["cache"] is False:
+                    result.append({path: {"cache": False}})
+                else:
+                    result.append(path)
+    return result
+
+
+def _validate_path(
+    path: Any,
+    stage_name: str,
+    path_type: str,
+    project_root: Path,
+    notes: list[MigrationNote],
+) -> bool:
+    """Validate path doesn't escape project root."""
+    # Check for non-string paths (YAML allows numeric keys)
+    if not isinstance(path, str):
+        notes.append(
+            MigrationNote(
+                stage=stage_name,
+                severity="error",
+                message=f"Invalid {path_type}: expected string path, got {type(path).__name__}",
+                original_cmd=None,
+            )
+        )
+        return False
+
+    # For paths with ${} interpolation, validate literal parts don't contain traversal
+    if "${" in path:
+        literal_parts = re.sub(r"\$\{[^}]*\}", "", path)
+        if ".." in literal_parts:
+            notes.append(
+                MigrationNote(
+                    stage=stage_name,
+                    severity="error",
+                    message=f"Path traversal not allowed in {path_type}: '{path}'",
+                    original_cmd=None,
+                )
+            )
+            return False
+        return True
+
+    try:
+        path_policy.require_valid_path(
+            path,
+            path_policy.PathType.DEP,  # DEP allows relative paths
+            project_root,
+            context=f"stage '{stage_name}' {path_type}",
+        )
+        return True
+    except exceptions.SecurityValidationError as e:
+        notes.append(
+            MigrationNote(
+                stage=stage_name,
+                severity="error",
+                message=f"Invalid {path_type} path '{path}': {e}",
+                original_cmd=None,
+            )
+        )
+        return False
+
+
+def _resolve_params(
+    dvc_params: list[str | dict[str, Any]],
+    params_yaml: dict[str, Any],
+    dvc_lock: DVCLock | None,
+    stage_name: str,
+) -> _ResolveParamsResult:
+    """Resolve DVC param references to actual values.
+
+    DVC param formats:
+    - "train.lr" -> params.yaml: train.lr
+    - "params.yaml:train.lr" -> explicit file:key
+    - "params.yaml:" -> whole file (not supported, skip)
+    - {"params.yaml": ["train.lr", "train.epochs"]} -> list of keys
+    """
+    result = dict[str, Any]()
+    notes = list[MigrationNote]()
+    count = 0
+
+    # Track seen leaf keys to detect collisions
+    seen_keys: dict[str, str] = {}  # leaf_key -> original full key
+
+    # Try to get params from lock file first (actual values used)
+    lock_params = dict[str, Any]()
+    if dvc_lock and "stages" in dvc_lock:
+        dvc_lock_stages = dvc_lock["stages"]
+        if stage_name in dvc_lock_stages:
+            lock_stage = dvc_lock_stages[stage_name]
+            if "params" in lock_stage:
+                for file_params in lock_stage["params"].values():
+                    if isinstance(file_params, dict):  # pyright: ignore[reportUnnecessaryIsInstance] - runtime check
+                        lock_params.update(file_params)
+
+    for param in dvc_params:
+        if isinstance(param, str):
+            # Handle "file:key" format
+            if ":" in param:
+                file_part, key_part = param.split(":", 1)
+                if not key_part:
+                    # Whole file dep - skip (can't inline whole file)
+                    continue
+                # Warn if using non-default params file
+                if file_part != "params.yaml":
+                    notes.append(
+                        MigrationNote(
+                            stage=stage_name,
+                            severity="warning",
+                            message=(
+                                f"Param '{param}' references '{file_part}' which is not loaded. "
+                                "Only params.yaml values are inlined."
+                            ),
+                            original_cmd=None,
+                        )
+                    )
+                param_key = key_part
+            else:
+                param_key = param
+
+            # Look up value: lock > params.yaml
+            value = _get_nested_value(lock_params, param_key)
+            if value is None:
+                value = _get_nested_value(params_yaml, param_key)
+
+            if value is not None:
+                # Use leaf key name for Pivot params
+                leaf_key = param_key.split(".")[-1]
+
+                # Check for collision
+                if leaf_key in seen_keys and seen_keys[leaf_key] != param_key:
+                    notes.append(
+                        MigrationNote(
+                            stage=stage_name,
+                            severity="warning",
+                            message=(
+                                f"Param key collision: '{param_key}' and '{seen_keys[leaf_key]}' "
+                                f"both map to leaf key '{leaf_key}'. Using value from '{param_key}'."
+                            ),
+                            original_cmd=None,
+                        )
+                    )
+
+                seen_keys[leaf_key] = param_key
+                result[leaf_key] = value
+                count += 1
+
+        else:
+            # Dict form: {"params.yaml": ["key1", "key2"]}
+            for file_name, keys in param.items():
+                # Warn if using non-default params file
+                if file_name != "params.yaml":
+                    notes.append(
+                        MigrationNote(
+                            stage=stage_name,
+                            severity="warning",
+                            message=(
+                                f"Params from '{file_name}' are not loaded. "
+                                "Only params.yaml values are inlined."
+                            ),
+                            original_cmd=None,
+                        )
+                    )
+                if not isinstance(keys, list):
+                    continue
+                for key in keys:  # pyright: ignore[reportUnknownVariableType] - validated above
+                    if not isinstance(key, str):
+                        continue
+                    value = _get_nested_value(lock_params, key)
+                    if value is None:
+                        value = _get_nested_value(params_yaml, key)
+                    if value is not None:
+                        leaf_key = key.split(".")[-1]
+
+                        # Check for collision
+                        if leaf_key in seen_keys and seen_keys[leaf_key] != key:
+                            notes.append(
+                                MigrationNote(
+                                    stage=stage_name,
+                                    severity="warning",
+                                    message=(
+                                        f"Param key collision: '{key}' and '{seen_keys[leaf_key]}' "
+                                        f"both map to leaf key '{leaf_key}'. Using value from '{key}'."
+                                    ),
+                                    original_cmd=None,
+                                )
+                            )
+
+                        seen_keys[leaf_key] = key
+                        result[leaf_key] = value
+                        count += 1
+
+    return _ResolveParamsResult(params=result, count=count, notes=notes)
+
+
+def _get_nested_value(data: dict[str, Any], dotted_key: str) -> Any:
+    """Get value from nested dict using dotted key path."""
+    keys = dotted_key.split(".")
+    current: Any = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        if key not in current:
+            return None
+        current = current[key]  # pyright: ignore[reportUnknownVariableType] - traversing Any dict
+    return current  # pyright: ignore[reportUnknownVariableType]
+
+
+@contextlib.contextmanager
+def _atomic_write(output_path: Path) -> Generator[int]:
+    """Context manager for atomic file writes using temp file + rename."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=output_path.parent, suffix=".tmp")
+    try:
+        yield fd
+        os.rename(tmp_path, output_path)
+    except BaseException:
+        # Close fd if still open (fdopen may not have been called or may have failed)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def write_pivot_yaml(
+    stages: dict[str, PivotStageConfig],
+    output_path: Path,
+    force: bool = False,
+) -> None:
+    """Write pivot.yaml atomically."""
+    if output_path.exists() and not force:
+        raise exceptions.DVCImportError(
+            f"Output file '{output_path}' already exists. Use --force to overwrite."
+        )
+
+    output = {"stages": stages}
+
+    yaml_writer = ruamel.yaml.YAML(typ="rt")
+    yaml_writer.default_flow_style = False
+    with _atomic_write(output_path) as fd, os.fdopen(fd, "w") as f:
+        yaml_writer.dump(output, f)
+
+
+def write_migration_notes(
+    notes: list[MigrationNote],
+    stats: ConversionStats,
+    output_path: Path,
+    force: bool = False,
+) -> None:
+    """Write migration notes as markdown."""
+    if output_path.exists() and not force:
+        raise exceptions.DVCImportError(
+            f"Notes file '{output_path}' already exists. Use --force to overwrite."
+        )
+
+    content = _generate_migration_notes_content(notes, stats)
+
+    with _atomic_write(output_path) as fd, os.fdopen(fd, "w") as f:
+        f.write(content)
+
+
+def _add_notes_section(
+    lines: list[str],
+    title: str,
+    items: list[MigrationNote],
+) -> None:
+    """Add a section of notes to the markdown output."""
+    if not items:
+        return
+    lines.extend([f"## {title}", ""])
+    for note in items:
+        prefix = f"Stage '{note['stage']}': " if note["stage"] else ""
+        lines.append(f"- {prefix}{note['message']}")
+    lines.append("")
+
+
+def _generate_migration_notes_content(
+    notes: list[MigrationNote],
+    stats: ConversionStats,
+) -> str:
+    """Generate migration notes markdown content."""
+    lines = [
+        "# DVC to Pivot Migration Notes",
+        "",
+        "## WARNING - Security Review Required",
+        "",
+        "Shell commands from dvc.yaml are shown below. **Review carefully before executing.**",
+        "",
+        "## Summary",
+        "",
+        f"- {stats['stages_converted']} stages converted",
+        f"- {stats['stages_with_shell_commands']} require Python function mapping",
+        f"- {stats['stages_with_warnings']} warnings",
+        f"- {stats['params_inlined']} params inlined",
+        "",
+    ]
+
+    # Group notes by severity
+    errors = [n for n in notes if n["severity"] == "error"]
+    warnings = [n for n in notes if n["severity"] == "warning"]
+    infos = [n for n in notes if n["severity"] == "info"]
+
+    # Shell command notes (the main ones requiring action)
+    shell_notes = [n for n in warnings if n["original_cmd"]]
+    if shell_notes:
+        lines.extend(["## Required: Python Function Mapping", ""])
+        for note in shell_notes:
+            stage = note["stage"] or "unknown"
+            cmd = note["original_cmd"] or ""
+            # Escape backticks in command for markdown
+            escaped_cmd = cmd.replace("`", "\\`")
+            lines.extend(
+                [
+                    f"### Stage: {stage}",
+                    "",
+                    f"- **Original command:** `{escaped_cmd}`",
+                    f"- **Current:** `python: PLACEHOLDER.{stage}`",
+                    f"- **Action:** Create a Python function and update to e.g. `python: src.{stage}.main`",
+                    "",
+                ]
+            )
+
+    # Use helper for simple sections
+    _add_notes_section(lines, "Errors", errors)
+    other_warnings = [n for n in warnings if not n["original_cmd"]]
+    _add_notes_section(lines, "Warnings", other_warnings)
+    _add_notes_section(lines, "Notes", infos)
+
+    # Next steps
+    lines.extend(
+        [
+            "## Next Steps",
+            "",
+            "1. Create Python functions for each PLACEHOLDER entry",
+            "2. Update `pivot.yaml` with correct `python:` paths",
+            "3. Run `pivot run --dry-run` to verify configuration",
+            "4. Run `pivot run` to execute and build cache",
+            "",
+            "**Note:** DVC hashes are not migrated. The first `pivot run` will rebuild all caches.",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)

--- a/tests/cli/test_cli_import_dvc.py
+++ b/tests/cli/test_cli_import_dvc.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import contextlib
+import pathlib
+import shutil
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from pivot import cli
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+
+FIXTURES_DIR = pathlib.Path(__file__).parent.parent / "fixtures" / "dvc_import"
+
+
+@pytest.fixture
+def dvc_project(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create minimal project structure for DVC import tests."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".pivot").mkdir()
+    return tmp_path
+
+
+# =============================================================================
+# Basic Command Tests
+# =============================================================================
+
+
+def test_import_dvc_help_shows_options(runner: CliRunner) -> None:
+    """import-dvc command shows help with options."""
+    result = runner.invoke(cli.cli, ["import-dvc", "--help"])
+    assert result.exit_code == 0
+    assert "--input" in result.output or "-i" in result.output
+    assert "--output" in result.output or "-o" in result.output
+    assert "--force" in result.output
+    assert "--dry-run" in result.output
+
+
+def test_import_dvc_creates_pivot_yaml(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc creates pivot.yaml from dvc.yaml."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert (dvc_project / "pivot.yaml").exists()
+        assert "Converted 2 stages" in result.output
+
+
+def test_import_dvc_with_explicit_input(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc with --input flag reads specified file."""
+    src = FIXTURES_DIR / "simple" / "dvc.yaml"
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc", "--input", str(src)])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert (dvc_project / "pivot.yaml").exists()
+
+
+def test_import_dvc_custom_output_path(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc with --output writes to specified path."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc", "--output", "custom.yaml"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert (dvc_project / "custom.yaml").exists()
+        assert not (dvc_project / "pivot.yaml").exists()
+
+
+def test_import_dvc_generates_migration_notes(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc creates migration notes file."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        notes_path = dvc_project / ".pivot" / "migration-notes.md"
+        assert notes_path.exists()
+        content = notes_path.read_text()
+        assert "DVC to Pivot Migration Notes" in content
+
+
+# =============================================================================
+# Overwrite Behavior Tests
+# =============================================================================
+
+
+def test_import_dvc_refuses_overwrite_without_force(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc errors on existing pivot.yaml without --force."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+    (dvc_project / "pivot.yaml").write_text("existing content")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+
+def test_import_dvc_force_overwrites(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc with --force overwrites existing files."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+    (dvc_project / "pivot.yaml").write_text("old content")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc", "--force"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        content = (dvc_project / "pivot.yaml").read_text()
+        assert "old content" not in content
+        assert "stages:" in content
+
+
+# =============================================================================
+# Dry Run Tests
+# =============================================================================
+
+
+def test_import_dvc_dry_run_no_files_created(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc --dry-run shows output without creating files."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc", "--dry-run"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Dry run" in result.output
+        assert not (dvc_project / "pivot.yaml").exists()
+        assert not (dvc_project / ".pivot" / "migration-notes.md").exists()
+
+
+# =============================================================================
+# Auto-Detection Tests
+# =============================================================================
+
+
+def test_import_dvc_auto_detects_files(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc auto-detects dvc.yaml and params.yaml."""
+    shutil.copy(FIXTURES_DIR / "with_params" / "dvc.yaml", dvc_project / "dvc.yaml")
+    shutil.copy(FIXTURES_DIR / "with_params" / "params.yaml", dvc_project / "params.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "params.yaml" in result.output
+
+        # Check params were inlined
+        with open(dvc_project / "pivot.yaml") as f:
+            pivot_yaml = yaml.safe_load(f)
+
+        train_params = pivot_yaml["stages"]["train"].get("params", {})
+        assert train_params.get("learning_rate") == 0.01
+
+
+def test_import_dvc_no_dvc_yaml_error(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+) -> None:
+    """import-dvc without dvc.yaml shows error."""
+    (tmp_path / ".git").mkdir()
+
+    with contextlib.chdir(tmp_path):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code != 0
+        assert "No dvc.yaml found" in result.output
+
+
+# =============================================================================
+# Output Validation Tests
+# =============================================================================
+
+
+def test_import_dvc_generated_yaml_has_stages(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """Generated pivot.yaml has correct stage structure."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["import-dvc"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+
+        with open(dvc_project / "pivot.yaml") as f:
+            pivot_yaml = yaml.safe_load(f)
+
+        assert "stages" in pivot_yaml
+        assert "preprocess" in pivot_yaml["stages"]
+        assert "train" in pivot_yaml["stages"]
+
+        # Check stage has required fields
+        preprocess = pivot_yaml["stages"]["preprocess"]
+        assert "python" in preprocess
+        assert preprocess["python"] == "PLACEHOLDER.preprocess"
+        assert "deps" in preprocess
+        assert "data/raw.csv" in preprocess["deps"]
+
+
+def test_import_dvc_quiet_mode(
+    runner: CliRunner,
+    dvc_project: pathlib.Path,
+) -> None:
+    """import-dvc with --quiet suppresses output."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", dvc_project / "dvc.yaml")
+
+    with contextlib.chdir(dvc_project):
+        result = runner.invoke(cli.cli, ["--quiet", "import-dvc"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert result.output.strip() == ""
+        assert (dvc_project / "pivot.yaml").exists()
+
+
+# =============================================================================
+# Path Validation Tests
+# =============================================================================
+
+
+def test_import_dvc_output_path_validation(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+) -> None:
+    """import-dvc validates output path stays within project."""
+    shutil.copy(FIXTURES_DIR / "simple" / "dvc.yaml", tmp_path / "dvc.yaml")
+
+    (tmp_path / ".git").mkdir()
+
+    with contextlib.chdir(tmp_path):
+        result = runner.invoke(cli.cli, ["import-dvc", "--output", "/etc/pivot.yaml"])
+
+        assert result.exit_code != 0
+        # Should fail path validation

--- a/tests/fixtures/dvc_import/complex/dvc.yaml
+++ b/tests/fixtures/dvc_import/complex/dvc.yaml
@@ -1,0 +1,28 @@
+stages:
+  preprocess:
+    cmd: python src/preprocess.py
+    wdir: src
+    deps:
+      - data/raw.csv
+    outs:
+      - data/clean.csv:
+          cache: false
+
+  train:
+    cmd: python train.py --epochs 100
+    deps:
+      - data/clean.csv
+    outs:
+      - models/model.pkl
+    metrics:
+      - metrics/train_metrics.json
+    plots:
+      - plots/loss_curve.csv
+
+  frozen_stage:
+    cmd: python generate_report.py
+    frozen: true
+    deps:
+      - models/model.pkl
+    outs:
+      - reports/report.html

--- a/tests/fixtures/dvc_import/foreach/dvc.yaml
+++ b/tests/fixtures/dvc_import/foreach/dvc.yaml
@@ -1,0 +1,13 @@
+stages:
+  process:
+    foreach:
+      - train
+      - test
+      - validation
+    do:
+      cmd: python process.py data/${item}.csv
+      deps:
+        - data/${item}.csv
+        - src/process.py
+      outs:
+        - processed/${item}.csv

--- a/tests/fixtures/dvc_import/simple/dvc.lock
+++ b/tests/fixtures/dvc_import/simple/dvc.lock
@@ -1,0 +1,34 @@
+schema: '2.0'
+stages:
+  preprocess:
+    cmd: python src/preprocess.py data/raw.csv
+    deps:
+      - path: data/raw.csv
+        hash: md5
+        md5: abc123
+        size: 1024
+      - path: src/preprocess.py
+        hash: md5
+        md5: def456
+        size: 512
+    outs:
+      - path: data/clean.csv
+        hash: md5
+        md5: ghi789
+        size: 2048
+  train:
+    cmd: python src/train.py --lr 0.01
+    deps:
+      - path: data/clean.csv
+        hash: md5
+        md5: ghi789
+        size: 2048
+      - path: src/train.py
+        hash: md5
+        md5: jkl012
+        size: 768
+    outs:
+      - path: models/model.pkl
+        hash: md5
+        md5: mno345
+        size: 4096

--- a/tests/fixtures/dvc_import/simple/dvc.yaml
+++ b/tests/fixtures/dvc_import/simple/dvc.yaml
@@ -1,0 +1,16 @@
+stages:
+  preprocess:
+    cmd: python src/preprocess.py data/raw.csv
+    deps:
+      - data/raw.csv
+      - src/preprocess.py
+    outs:
+      - data/clean.csv
+
+  train:
+    cmd: python src/train.py --lr 0.01
+    deps:
+      - data/clean.csv
+      - src/train.py
+    outs:
+      - models/model.pkl

--- a/tests/fixtures/dvc_import/with_params/dvc.yaml
+++ b/tests/fixtures/dvc_import/with_params/dvc.yaml
@@ -1,0 +1,23 @@
+stages:
+  train:
+    cmd: python train.py
+    deps:
+      - data/features.csv
+    params:
+      - train.learning_rate
+      - train.epochs
+      - model.hidden_size
+    outs:
+      - models/model.pkl
+    metrics:
+      - metrics/scores.json
+
+  evaluate:
+    cmd: python evaluate.py
+    deps:
+      - models/model.pkl
+      - data/test.csv
+    params:
+      - params.yaml:evaluate.threshold
+    outs:
+      - results/predictions.csv

--- a/tests/fixtures/dvc_import/with_params/params.yaml
+++ b/tests/fixtures/dvc_import/with_params/params.yaml
@@ -1,0 +1,9 @@
+train:
+  learning_rate: 0.01
+  epochs: 100
+
+model:
+  hidden_size: 256
+
+evaluate:
+  threshold: 0.5

--- a/tests/test_dvc_import.py
+++ b/tests/test_dvc_import.py
@@ -1,0 +1,1092 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from pivot import dvc_import, exceptions
+
+FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures" / "dvc_import"
+
+
+# =============================================================================
+# parse_dvc_yaml tests
+# =============================================================================
+
+
+def test_parse_simple_dvc_yaml() -> None:
+    """Parse basic dvc.yaml with stages."""
+    result = dvc_import.parse_dvc_yaml(FIXTURES_DIR / "simple" / "dvc.yaml")
+    assert "stages" in result
+    assert "preprocess" in result["stages"]
+    assert "train" in result["stages"]
+
+
+def test_parse_dvc_yaml_extracts_cmd() -> None:
+    """Parses cmd field from stages."""
+    result = dvc_import.parse_dvc_yaml(FIXTURES_DIR / "simple" / "dvc.yaml")
+    assert result["stages"]["preprocess"].get("cmd") == "python src/preprocess.py data/raw.csv"
+
+
+def test_parse_dvc_yaml_extracts_deps() -> None:
+    """Parses deps list from stages."""
+    result = dvc_import.parse_dvc_yaml(FIXTURES_DIR / "simple" / "dvc.yaml")
+    deps = result["stages"]["preprocess"].get("deps", [])
+    assert "data/raw.csv" in deps
+    assert "src/preprocess.py" in deps
+
+
+def test_parse_dvc_yaml_extracts_outs() -> None:
+    """Parses outs list from stages."""
+    result = dvc_import.parse_dvc_yaml(FIXTURES_DIR / "simple" / "dvc.yaml")
+    outs = result["stages"]["preprocess"].get("outs", [])
+    assert "data/clean.csv" in outs
+
+
+def test_parse_dvc_yaml_missing_file(tmp_path: pathlib.Path) -> None:
+    """Raises error for missing file."""
+    with pytest.raises(exceptions.DVCImportError, match="Cannot read"):
+        dvc_import.parse_dvc_yaml(tmp_path / "nonexistent.yaml")
+
+
+def test_parse_dvc_yaml_empty_file(tmp_path: pathlib.Path) -> None:
+    """Raises error for empty file."""
+    empty_file = tmp_path / "dvc.yaml"
+    empty_file.write_text("")
+    with pytest.raises(exceptions.DVCImportError, match="empty"):
+        dvc_import.parse_dvc_yaml(empty_file)
+
+
+def test_parse_dvc_yaml_missing_stages(tmp_path: pathlib.Path) -> None:
+    """Raises error when stages key is missing."""
+    bad_file = tmp_path / "dvc.yaml"
+    bad_file.write_text("vars:\n  - foo.yaml\n")
+    with pytest.raises(exceptions.DVCImportError, match="missing 'stages'"):
+        dvc_import.parse_dvc_yaml(bad_file)
+
+
+def test_parse_dvc_yaml_size_limit(tmp_path: pathlib.Path) -> None:
+    """Raises error for oversized file."""
+    large_file = tmp_path / "dvc.yaml"
+    # Create file larger than limit
+    large_file.write_text("x" * (dvc_import.MAX_DVC_FILE_SIZE + 1))
+    with pytest.raises(exceptions.DVCImportError, match="exceeds maximum size"):
+        dvc_import.parse_dvc_yaml(large_file)
+
+
+# =============================================================================
+# parse_dvc_lock tests
+# =============================================================================
+
+
+def test_parse_dvc_lock_returns_none_for_missing() -> None:
+    """Returns None when dvc.lock doesn't exist."""
+    result = dvc_import.parse_dvc_lock(pathlib.Path("/nonexistent/dvc.lock"))
+    assert result is None
+
+
+def test_parse_dvc_lock_extracts_stages() -> None:
+    """Extracts stages from dvc.lock."""
+    result = dvc_import.parse_dvc_lock(FIXTURES_DIR / "simple" / "dvc.lock")
+    assert result is not None
+    assert "stages" in result
+    assert "preprocess" in result["stages"]
+    assert "train" in result["stages"]
+
+
+# =============================================================================
+# parse_params_yaml tests
+# =============================================================================
+
+
+def test_parse_params_yaml() -> None:
+    """Parses params.yaml correctly."""
+    result, notes = dvc_import.parse_params_yaml(FIXTURES_DIR / "with_params" / "params.yaml")
+    assert result["train"]["learning_rate"] == 0.01
+    assert result["train"]["epochs"] == 100
+    assert result["model"]["hidden_size"] == 256
+    assert len(notes) == 0
+
+
+def test_parse_params_yaml_missing_returns_empty() -> None:
+    """Returns empty dict when file doesn't exist."""
+    result, notes = dvc_import.parse_params_yaml(pathlib.Path("/nonexistent/params.yaml"))
+    assert result == {}
+    assert len(notes) == 0
+
+
+def test_parse_params_yaml_warns_on_non_string_keys(tmp_path: pathlib.Path) -> None:
+    """Warns when params.yaml has non-string keys."""
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("123: numeric_key\ntrue: bool_key\nvalid: string_key\n")
+
+    result, notes = dvc_import.parse_params_yaml(params_file)
+
+    assert "valid" in result
+    assert 123 not in result
+    assert len(notes) == 1
+    assert notes[0]["severity"] == "warning"
+    assert "non-string keys" in notes[0]["message"]
+
+
+# =============================================================================
+# convert_pipeline tests
+# =============================================================================
+
+
+def test_convert_simple_stage(tmp_path: pathlib.Path) -> None:
+    """Converts basic DVC stage to Pivot format."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "simple" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    assert "preprocess" in stages
+    assert stages["preprocess"].get("python") == "PLACEHOLDER.preprocess"
+    assert "data/raw.csv" in stages["preprocess"].get("deps", [])
+    assert "data/clean.csv" in stages["preprocess"].get("outs", [])
+
+
+def test_convert_stage_generates_shell_command_note(tmp_path: pathlib.Path) -> None:
+    """Shell commands generate migration notes."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "simple" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    notes = result["notes"]
+
+    # Should have notes for shell commands
+    shell_notes = [n for n in notes if n["original_cmd"]]
+    assert len(shell_notes) >= 2  # preprocess and train both have cmd
+
+
+def test_convert_stage_with_params_inlines_values(tmp_path: pathlib.Path) -> None:
+    """Params from params.yaml are inlined."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "with_params" / "dvc.yaml",
+        params_yaml_path=FIXTURES_DIR / "with_params" / "params.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    # train stage should have inlined params
+    train_params = stages["train"].get("params", {})
+    assert train_params.get("learning_rate") == 0.01
+    assert train_params.get("epochs") == 100
+
+
+def test_convert_foreach_to_matrix(tmp_path: pathlib.Path) -> None:
+    """DVC foreach converts to Pivot matrix."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "foreach" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    assert "process" in stages
+    process_stage = stages["process"]
+    assert "matrix" in process_stage
+    assert process_stage["matrix"]["item"] == ["train", "test", "validation"]
+
+
+def test_convert_outs_cache_false(tmp_path: pathlib.Path) -> None:
+    """Outputs with cache: false are preserved."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "complex" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    preprocess_outs = stages["preprocess"].get("outs", [])
+    # Should have dict format with cache: false
+    cache_false_out = [o for o in preprocess_outs if isinstance(o, dict)]
+    assert len(cache_false_out) == 1
+
+
+def test_convert_wdir_to_cwd(tmp_path: pathlib.Path) -> None:
+    """DVC wdir converts to Pivot cwd."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "complex" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    assert stages["preprocess"].get("cwd") == "src"
+
+
+def test_frozen_stage_generates_warning(tmp_path: pathlib.Path) -> None:
+    """Frozen stages generate warning notes."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "complex" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    notes = result["notes"]
+
+    frozen_notes = [n for n in notes if "frozen" in n["message"].lower()]
+    assert len(frozen_notes) == 1
+    assert frozen_notes[0]["stage"] == "frozen_stage"
+
+
+def test_convert_metrics_preserved(tmp_path: pathlib.Path) -> None:
+    """Metrics are preserved in conversion."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "complex" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    assert "metrics/train_metrics.json" in stages["train"].get("metrics", [])
+
+
+def test_convert_plots_preserved(tmp_path: pathlib.Path) -> None:
+    """Plots are preserved in conversion."""
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=FIXTURES_DIR / "complex" / "dvc.yaml",
+        project_root=tmp_path,
+    )
+    stages = result["stages"]
+
+    assert "plots/loss_curve.csv" in stages["train"].get("plots", [])
+
+
+# =============================================================================
+# path validation tests
+# =============================================================================
+
+
+def test_path_traversal_rejected(tmp_path: pathlib.Path) -> None:
+    """Paths with traversal outside project are rejected."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  evil:
+    cmd: echo
+    deps:
+      - ../../../etc/passwd
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+    notes = result["notes"]
+
+    error_notes = [n for n in notes if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "etc/passwd" in error_notes[0]["message"]
+
+
+def test_interpolated_paths_allowed(tmp_path: pathlib.Path) -> None:
+    """Paths with ${} interpolation are allowed without validation."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  templated:
+    cmd: echo
+    deps:
+      - data/${item}.csv
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    # Should not have error notes for the interpolated path
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 0
+
+
+def test_non_string_dict_key_in_deps_generates_error(tmp_path: pathlib.Path) -> None:
+    """Non-string keys in deps dict generate error notes."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    # YAML allows numeric keys - this creates {123: {cache: false}}
+    dvc_yaml.write_text("""
+stages:
+  test:
+    cmd: echo
+    outs:
+      - 123:
+          cache: false
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "expected string path" in error_notes[0]["message"]
+    assert "int" in error_notes[0]["message"]
+
+
+def test_interpolation_path_with_traversal_rejected(tmp_path: pathlib.Path) -> None:
+    """Interpolation paths with traversal in literal parts are rejected."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  evil:
+    cmd: echo
+    deps:
+      - ${item}/../../../etc/passwd
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "Path traversal not allowed" in error_notes[0]["message"]
+
+
+# =============================================================================
+# param format tests
+# =============================================================================
+
+
+def test_param_formats_dotted_key(tmp_path: pathlib.Path) -> None:
+    """Dotted key format resolves params."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.001\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - train.lr
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    train_params = result["stages"]["train"].get("params", {})
+    assert train_params.get("lr") == 0.001
+
+
+def test_param_formats_explicit_file(tmp_path: pathlib.Path) -> None:
+    """File:key format resolves params."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("model:\n  hidden: 256\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - params.yaml:model.hidden
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    train_params = result["stages"]["train"].get("params", {})
+    assert train_params.get("hidden") == 256
+
+
+def test_param_formats_nested(tmp_path: pathlib.Path) -> None:
+    """Nested key format resolves params."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("model:\n  config:\n    layers: 12\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - model.config.layers
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    train_params = result["stages"]["train"].get("params", {})
+    assert train_params.get("layers") == 12
+
+
+# =============================================================================
+# param collision and multi-file tests
+# =============================================================================
+
+
+def test_param_key_collision_warns(tmp_path: pathlib.Path) -> None:
+    """Warns when multiple params map to same leaf key."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\nmodel:\n  lr: 0.001\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - train.lr
+      - model.lr
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+
+    collision_notes = [n for n in result["notes"] if "collision" in n["message"].lower()]
+    assert len(collision_notes) == 1
+    assert "lr" in collision_notes[0]["message"]
+
+
+def test_non_default_param_file_warns(tmp_path: pathlib.Path) -> None:
+    """Warns when params reference non-default file."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - custom.yaml:train.lr
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+
+    file_notes = [n for n in result["notes"] if "custom.yaml" in n["message"]]
+    assert len(file_notes) == 1
+    assert "not loaded" in file_notes[0]["message"]
+
+
+def test_params_inlined_stat_updated(tmp_path: pathlib.Path) -> None:
+    """Stats correctly count inlined params."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n  epochs: 100\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - train.lr
+      - train.epochs
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+
+    assert result["stats"]["params_inlined"] == 2
+
+
+# =============================================================================
+# wdir validation tests
+# =============================================================================
+
+
+def test_absolute_wdir_rejected(tmp_path: pathlib.Path) -> None:
+    """Absolute wdir paths generate error."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  test:
+    cmd: echo
+    wdir: /tmp/work
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "Absolute wdir" in error_notes[0]["message"]
+
+
+# =============================================================================
+# foreach edge case tests
+# =============================================================================
+
+
+def test_empty_foreach_list_error(tmp_path: pathlib.Path) -> None:
+    """Empty foreach list generates error."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  process:
+    foreach: []
+    do:
+      cmd: echo
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "empty" in error_notes[0]["message"].lower()
+
+
+def test_empty_foreach_dict_error(tmp_path: pathlib.Path) -> None:
+    """Empty foreach dict generates error."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  process:
+    foreach: {}
+    do:
+      cmd: echo
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "empty" in error_notes[0]["message"].lower()
+
+
+def test_dict_foreach_warns_about_lost_values(tmp_path: pathlib.Path) -> None:
+    """Dict foreach warns that values are not preserved."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  process:
+    foreach:
+      lr_001: {val: 0.001}
+      lr_01: {val: 0.01}
+    do:
+      cmd: echo ${item}
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    value_notes = [n for n in result["notes"] if "values are not preserved" in n["message"]]
+    assert len(value_notes) == 1
+
+
+# =============================================================================
+# write_pivot_yaml tests
+# =============================================================================
+
+
+def test_write_pivot_yaml_creates_file(tmp_path: pathlib.Path) -> None:
+    """write_pivot_yaml creates output file."""
+    output_path = tmp_path / "pivot.yaml"
+    stages = {"test": dvc_import.PivotStageConfig(python="test.main", deps=["data.csv"])}
+
+    dvc_import.write_pivot_yaml(stages, output_path)
+
+    assert output_path.exists()
+    content = output_path.read_text()
+    assert "test:" in content
+    assert "python: test.main" in content
+
+
+def test_write_pivot_yaml_refuses_overwrite_without_force(tmp_path: pathlib.Path) -> None:
+    """write_pivot_yaml errors on existing file without force."""
+    output_path = tmp_path / "pivot.yaml"
+    output_path.write_text("existing content")
+
+    with pytest.raises(exceptions.DVCImportError, match="already exists"):
+        dvc_import.write_pivot_yaml({}, output_path)
+
+
+def test_write_pivot_yaml_overwrites_with_force(tmp_path: pathlib.Path) -> None:
+    """write_pivot_yaml overwrites with force=True."""
+    output_path = tmp_path / "pivot.yaml"
+    output_path.write_text("old content")
+
+    dvc_import.write_pivot_yaml(
+        {"new": dvc_import.PivotStageConfig(python="new.main")}, output_path, force=True
+    )
+
+    content = output_path.read_text()
+    assert "new:" in content
+
+
+# =============================================================================
+# write_migration_notes tests
+# =============================================================================
+
+
+def test_write_migration_notes_creates_file(tmp_path: pathlib.Path) -> None:
+    """write_migration_notes creates output file."""
+    notes_path = tmp_path / ".pivot" / "migration-notes.md"
+    notes: list[dvc_import.MigrationNote] = [
+        dvc_import.MigrationNote(
+            stage="train",
+            severity="warning",
+            message="Shell command needs conversion",
+            original_cmd="python train.py",
+        )
+    ]
+    stats = dvc_import.ConversionStats(
+        stages_converted=1,
+        stages_with_shell_commands=1,
+        stages_with_warnings=1,
+        params_inlined=0,
+    )
+
+    dvc_import.write_migration_notes(notes, stats, notes_path)
+
+    assert notes_path.exists()
+    content = notes_path.read_text()
+    assert "DVC to Pivot Migration Notes" in content
+    assert "train" in content
+
+
+def test_write_migration_notes_includes_security_warning(tmp_path: pathlib.Path) -> None:
+    """Migration notes include security warning."""
+    notes_path = tmp_path / "notes.md"
+    notes: list[dvc_import.MigrationNote] = []
+    stats = dvc_import.ConversionStats(
+        stages_converted=0,
+        stages_with_shell_commands=0,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+
+    dvc_import.write_migration_notes(notes, stats, notes_path)
+
+    content = notes_path.read_text()
+    assert "Security Review Required" in content
+
+
+def test_write_migration_notes_escapes_commands(tmp_path: pathlib.Path) -> None:
+    """Commands with backticks are escaped in notes."""
+    notes_path = tmp_path / "notes.md"
+    notes: list[dvc_import.MigrationNote] = [
+        dvc_import.MigrationNote(
+            stage="test",
+            severity="warning",
+            message="test",
+            original_cmd="echo `whoami`",
+        )
+    ]
+    stats = dvc_import.ConversionStats(
+        stages_converted=1,
+        stages_with_shell_commands=1,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+
+    dvc_import.write_migration_notes(notes, stats, notes_path)
+
+    content = notes_path.read_text()
+    assert "\\`whoami\\`" in content
+
+
+# =============================================================================
+# parse_dvc_yaml error handling tests (additional coverage)
+# =============================================================================
+
+
+def test_parse_dvc_yaml_invalid_yaml(tmp_path: pathlib.Path) -> None:
+    """Raises error for invalid YAML syntax."""
+    bad_file = tmp_path / "dvc.yaml"
+    bad_file.write_text("stages:\n  - invalid: [unbalanced")
+    with pytest.raises(exceptions.DVCImportError, match="Invalid YAML"):
+        dvc_import.parse_dvc_yaml(bad_file)
+
+
+def test_parse_dvc_yaml_non_dict_root(tmp_path: pathlib.Path) -> None:
+    """Raises error when root is not a dict."""
+    bad_file = tmp_path / "dvc.yaml"
+    bad_file.write_text("- item1\n- item2\n")
+    with pytest.raises(exceptions.DVCImportError, match="must be a mapping"):
+        dvc_import.parse_dvc_yaml(bad_file)
+
+
+def test_parse_dvc_yaml_non_dict_stages(tmp_path: pathlib.Path) -> None:
+    """Raises error when stages is not a dict."""
+    bad_file = tmp_path / "dvc.yaml"
+    bad_file.write_text("stages:\n  - stage1\n  - stage2\n")
+    with pytest.raises(exceptions.DVCImportError, match="'stages' must be a mapping"):
+        dvc_import.parse_dvc_yaml(bad_file)
+
+
+# =============================================================================
+# parse_dvc_lock error handling tests
+# =============================================================================
+
+
+def test_parse_dvc_lock_invalid_yaml(tmp_path: pathlib.Path) -> None:
+    """Returns None for invalid YAML in dvc.lock."""
+    lock_file = tmp_path / "dvc.lock"
+    lock_file.write_text("stages:\n  - invalid: [unbalanced")
+    result = dvc_import.parse_dvc_lock(lock_file)
+    assert result is None
+
+
+def test_parse_dvc_lock_non_dict_returns_none(tmp_path: pathlib.Path) -> None:
+    """Returns None when dvc.lock is not a dict."""
+    lock_file = tmp_path / "dvc.lock"
+    lock_file.write_text("- item1\n- item2\n")
+    result = dvc_import.parse_dvc_lock(lock_file)
+    assert result is None
+
+
+# =============================================================================
+# foreach error handling tests
+# =============================================================================
+
+
+def test_foreach_missing_do_block(tmp_path: pathlib.Path) -> None:
+    """foreach without 'do' block generates error."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  process:
+    foreach:
+      - a
+      - b
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "missing 'do' block" in error_notes[0]["message"]
+
+
+def test_foreach_unsupported_type(tmp_path: pathlib.Path) -> None:
+    """foreach with unsupported type generates error."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  process:
+    foreach: "not_a_list_or_dict"
+    do:
+      cmd: echo ${item}
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+
+    error_notes = [n for n in result["notes"] if n["severity"] == "error"]
+    assert len(error_notes) == 1
+    assert "Unsupported foreach type" in error_notes[0]["message"]
+
+
+# =============================================================================
+# dict-form params handling tests
+# =============================================================================
+
+
+def test_dict_params_with_non_list_keys_skipped(tmp_path: pathlib.Path) -> None:
+    """Dict-form params with non-list keys are skipped."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - params.yaml:
+          nested: not_a_list
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    # Should not crash, just skip the invalid format
+    assert "train" in result["stages"]
+
+
+def test_dict_params_with_non_string_key_skipped(tmp_path: pathlib.Path) -> None:
+    """Dict-form params with non-string keys are skipped."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("123: numeric_value\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - params.yaml:
+          - 123
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    # Should not crash, just skip non-string keys
+    train_params = result["stages"]["train"].get("params", {})
+    assert 123 not in train_params
+
+
+# =============================================================================
+# migration notes section helper tests
+# =============================================================================
+
+
+def test_write_migration_notes_includes_error_section(tmp_path: pathlib.Path) -> None:
+    """Migration notes include error section when errors present."""
+    notes_path = tmp_path / "notes.md"
+    notes: list[dvc_import.MigrationNote] = [
+        dvc_import.MigrationNote(
+            stage="broken",
+            severity="error",
+            message="Critical error occurred",
+            original_cmd=None,
+        )
+    ]
+    stats = dvc_import.ConversionStats(
+        stages_converted=0,
+        stages_with_shell_commands=0,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+
+    dvc_import.write_migration_notes(notes, stats, notes_path)
+
+    content = notes_path.read_text()
+    assert "## Errors" in content
+    assert "Critical error occurred" in content
+    assert "Stage 'broken'" in content
+
+
+def test_write_migration_notes_empty_section_omitted(tmp_path: pathlib.Path) -> None:
+    """Empty note sections are not written."""
+    notes_path = tmp_path / "notes.md"
+    notes: list[dvc_import.MigrationNote] = []
+    stats = dvc_import.ConversionStats(
+        stages_converted=1,
+        stages_with_shell_commands=0,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+
+    dvc_import.write_migration_notes(notes, stats, notes_path)
+
+    content = notes_path.read_text()
+    assert "## Errors" not in content
+    assert "## Warnings" not in content
+
+
+def test_write_migration_notes_refuses_overwrite_without_force(tmp_path: pathlib.Path) -> None:
+    """write_migration_notes refuses to overwrite without force."""
+    notes_path = tmp_path / "notes.md"
+    notes_path.write_text("existing content")
+
+    stats = dvc_import.ConversionStats(
+        stages_converted=0,
+        stages_with_shell_commands=0,
+        stages_with_warnings=0,
+        params_inlined=0,
+    )
+    with pytest.raises(exceptions.DVCImportError, match="already exists"):
+        dvc_import.write_migration_notes([], stats, notes_path)
+
+
+# =============================================================================
+# params.yaml error handling tests
+# =============================================================================
+
+
+def test_parse_params_yaml_invalid_yaml(tmp_path: pathlib.Path) -> None:
+    """Returns empty dict and no error for invalid YAML."""
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("invalid: [unbalanced")
+    with pytest.raises(exceptions.DVCImportError, match="Invalid YAML"):
+        dvc_import.parse_params_yaml(params_file)
+
+
+def test_parse_params_yaml_empty_returns_empty(tmp_path: pathlib.Path) -> None:
+    """Returns empty dict for empty params.yaml."""
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("")
+    result, _ = dvc_import.parse_params_yaml(params_file)
+    assert result == {}
+
+
+def test_parse_params_yaml_non_dict_raises(tmp_path: pathlib.Path) -> None:
+    """Raises error when params.yaml is not a dict."""
+    params_file = tmp_path / "params.yaml"
+    params_file.write_text("- item1\n- item2\n")
+    with pytest.raises(exceptions.DVCImportError, match="must be a mapping"):
+        dvc_import.parse_params_yaml(params_file)
+
+
+# =============================================================================
+# dict-form deps/outs tests
+# =============================================================================
+
+
+def test_dict_form_deps_extracted(tmp_path: pathlib.Path) -> None:
+    """Dict-form deps are extracted correctly."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    deps:
+      - data/input.csv: {}
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+    assert "data/input.csv" in result["stages"]["train"].get("deps", [])
+
+
+def test_dict_form_outs_without_cache_false(tmp_path: pathlib.Path) -> None:
+    """Dict-form outs without cache:false are converted to simple paths."""
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    outs:
+      - output.csv: {persist: true}
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        project_root=tmp_path,
+    )
+    outs = result["stages"]["train"].get("outs", [])
+    # Should be a simple string path, not a dict
+    assert "output.csv" in outs
+
+
+# =============================================================================
+# dvc.lock params extraction tests
+# =============================================================================
+
+
+def test_params_from_dvc_lock_used(tmp_path: pathlib.Path) -> None:
+    """Parameters from dvc.lock are used when available (nested structure)."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - train.lr
+""")
+
+    # DVC lock file stores params in nested structure matching params.yaml
+    dvc_lock = tmp_path / "dvc.lock"
+    dvc_lock.write_text("""
+stages:
+  train:
+    params:
+      params.yaml:
+        train:
+          lr: 0.001
+""")
+
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        dvc_lock_path=dvc_lock,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    # Should use lock value (0.001) over params.yaml value (0.01)
+    assert result["stages"]["train"].get("params", {}).get("lr") == 0.001
+
+
+# =============================================================================
+# params string form with colon tests
+# =============================================================================
+
+
+def test_params_whole_file_dep_skipped(tmp_path: pathlib.Path) -> None:
+    """Whole file params deps (file:) are skipped."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - params.yaml:
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+    # Should not have any params (whole file dep is skipped)
+    train_params = result["stages"]["train"].get("params", {})
+    assert len(train_params) == 0
+
+
+# =============================================================================
+# dict-form params with non-default file tests
+# =============================================================================
+
+
+def test_dict_form_params_non_default_file_warns(tmp_path: pathlib.Path) -> None:
+    """Dict-form params referencing non-default file warns."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - custom.yaml:
+          - train.lr
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+
+    file_notes = [n for n in result["notes"] if "custom.yaml" in n["message"]]
+    assert len(file_notes) == 1
+    assert "not loaded" in file_notes[0]["message"]
+
+
+def test_dict_form_params_with_params_yaml_inlined(tmp_path: pathlib.Path) -> None:
+    """Dict-form params from params.yaml are inlined."""
+    params_yaml = tmp_path / "params.yaml"
+    params_yaml.write_text("train:\n  lr: 0.01\n")
+
+    dvc_yaml = tmp_path / "dvc.yaml"
+    dvc_yaml.write_text("""
+stages:
+  train:
+    cmd: echo
+    params:
+      - params.yaml:
+          - train.lr
+""")
+    result = dvc_import.convert_pipeline(
+        dvc_yaml_path=dvc_yaml,
+        params_yaml_path=params_yaml,
+        project_root=tmp_path,
+    )
+
+    train_params = result["stages"]["train"].get("params", {})
+    assert train_params.get("lr") == 0.01


### PR DESCRIPTION
## Summary

Add `pivot import-dvc` command to convert DVC pipelines to Pivot format (Phase 1 of #171).

### Features
- Parse `dvc.yaml`, `dvc.lock`, and `params.yaml` files
- Convert DVC stages to Pivot format with `PLACEHOLDER.{stage}` python paths
- Inline params from `params.yaml` into stage configs
- Convert `foreach`/`do` to Pivot matrix syntax
- Generate migration notes with:
  - Security warnings for shell commands
  - Required Python function mapping
  - Warnings for unsupported features (frozen, multi-file params)

### Security
- Path traversal validation (rejects `../../../etc/passwd`)
- Absolute wdir path rejection
- 10MB file size limits
- Safe YAML loading (no arbitrary code execution)

### CLI Options
```
pivot import-dvc [-i INPUT] [-o OUTPUT] [-p PARAMS] [-n NOTES] [--force] [--dry-run]
```

### Files
- `src/pivot/dvc_import.py` - Core conversion logic (~830 lines)
- `src/pivot/cli/import_dvc.py` - CLI wrapper (~170 lines)
- `tests/test_dvc_import.py` - Unit tests (40 tests)
- `tests/cli/test_cli_import_dvc.py` - CLI integration tests (13 tests)

Closes #171

🤖 Generated with [Claude Code](https://claude.ai/code)