### PR TITLE
fix: address code review issues for lock files, error handling, and StageDef validation

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -75,10 +75,13 @@ code_manifest:
   func:helper: "def456"
 params:
   learning_rate: 0.01
-dep_hashes:
-  data.csv: "789..."
-output_hashes:
-  model.pkl: "012..."
+deps:
+  - path: data.csv
+    hash: "789abc..."
+outs:
+  - path: model.pkl
+    hash: "012def..."
+dep_generations: {}
 ```
 
 ## Data Flow

--- a/src/pivot/cli/checkout.py
+++ b/src/pivot/cli/checkout.py
@@ -17,7 +17,7 @@ def _get_stage_output_info(project_root: pathlib.Path) -> dict[str, OutputHash]:
     cache_dir = project_root / ".pivot" / "cache"
 
     for stage_name in registry.REGISTRY.list_stages():
-        stage_lock = lock.StageLock(stage_name, cache_dir)
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
         lock_data = stage_lock.read()
         if lock_data and "output_hashes" in lock_data:
             for out_path, out_hash in lock_data["output_hashes"].items():

--- a/src/pivot/cli/init.py
+++ b/src/pivot/cli/init.py
@@ -16,7 +16,7 @@ cache/
 state.db
 state.lmdb/
 
-# Lock files
+# Config lock (ruamel.yaml temporary file)
 config.yaml.lock
 """
 
@@ -47,6 +47,8 @@ def init(ctx: click.Context, force: bool) -> None:
             )
 
     pivot_dir.mkdir(exist_ok=True)
+    # Create stages directory for git-tracked lock files
+    (pivot_dir / "stages").mkdir(exist_ok=True)
     gitignore_path = pivot_dir / ".gitignore"
 
     # Warn if overwriting existing .gitignore with custom content
@@ -70,6 +72,7 @@ def init(ctx: click.Context, force: bool) -> None:
         click.echo()
         click.echo("Created:")
         click.echo("  .pivot/")
+        click.echo("  .pivot/stages/")
         click.echo("  .pivot/.gitignore")
         if created_pivotignore:
             click.echo("  .pivotignore")

--- a/src/pivot/executor/commit.py
+++ b/src/pivot/executor/commit.py
@@ -38,7 +38,7 @@ def commit_pending(cache_dir: pathlib.Path | None = None) -> list[str]:
                 continue
 
             # Write to production lock (without dep_generations - that's internal to pending)
-            production_lock = lock.StageLock(stage_name, cache_dir)
+            production_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
             production_lock.write(pending_data)
 
             # Record dependency generations from execution time (not commit time!)

--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -909,7 +909,7 @@ def _check_uncached_incremental_outputs(
         stage_outs = stage_info["outs"]
 
         # Read lock file to get cached output hashes
-        stage_lock = lock.StageLock(stage_name, cache_dir)
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
         lock_data = stage_lock.read()
         output_hashes = lock_data.get("output_hashes", {}) if lock_data else {}
 
@@ -937,7 +937,7 @@ def _write_run_history(
 
     stages_records = dict[str, run_history.StageRunRecord]()
     for name, state in stage_states.items():
-        stage_lock = lock.StageLock(name, cache_dir)
+        stage_lock = lock.StageLock(name, lock.get_stages_dir(cache_dir))
         lock_data = stage_lock.read()
 
         if lock_data:

--- a/src/pivot/executor/worker.py
+++ b/src/pivot/executor/worker.py
@@ -114,7 +114,7 @@ def execute_stage(
     checkout_modes = [cache.CheckoutMode(m) for m in stage_info["checkout_modes"]]
 
     # Production lock for skip detection, pending lock for --no-commit mode
-    production_lock = lock.StageLock(stage_name, cache_dir)
+    production_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
     pending_lock = lock.get_pending_lock(stage_name, project_root)
     current_fingerprint = stage_info["fingerprint"]
     stage_outs = stage_info["outs"]

--- a/src/pivot/explain.py
+++ b/src/pivot/explain.py
@@ -102,7 +102,7 @@ def get_stage_explanation(
     force: bool = False,
 ) -> StageExplanation:
     """Compute detailed explanation of why a stage would run."""
-    stage_lock = lock.StageLock(stage_name, cache_dir)
+    stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
     lock_data = stage_lock.read()
 
     if not lock_data:

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -283,6 +283,17 @@ class StageRegistry:
         # Convert params to instance (instantiate class if needed)
         params_instance = _resolve_params(params, func, stage_name)
 
+        # StageDef stages manage their own deps/outs - disallow overrides
+        if isinstance(params_instance, stage_def.StageDef):
+            if deps:
+                raise exceptions.ValidationError(
+                    f"Stage '{stage_name}': cannot override deps for StageDef stages"
+                )
+            if outs:
+                raise exceptions.ValidationError(
+                    f"Stage '{stage_name}': cannot override outs for StageDef stages"
+                )
+
         # Extract deps/outs from StageDef if not explicitly provided
         deps_list: Sequence[str] = deps if deps is not None else ()
         outs_list: Sequence[outputs.OutSpec] = outs if outs is not None else ()

--- a/src/pivot/show/common.py
+++ b/src/pivot/show/common.py
@@ -24,12 +24,12 @@ def read_lock_files_from_head(
     if not stage_names:
         return {}
 
-    lock_paths = [f".pivot/cache/stages/{name}.lock" for name in stage_names]
+    lock_paths = [f"{lock.STAGES_REL_PATH}/{name}.lock" for name in stage_names]
     lock_contents = git.read_files_from_head(lock_paths)
 
     result = dict[str, StorageLockData | None]()
     for stage_name in stage_names:
-        lock_path = f".pivot/cache/stages/{stage_name}.lock"
+        lock_path = f"{lock.STAGES_REL_PATH}/{stage_name}.lock"
         content = lock_contents.get(lock_path)
         if content is None:
             result[stage_name] = None

--- a/src/pivot/show/plots.py
+++ b/src/pivot/show/plots.py
@@ -70,7 +70,7 @@ def get_plot_hashes_from_lock(
     result = dict[str, str | None]()
     for stage_name in registry.REGISTRY.list_stages():
         info = registry.REGISTRY.get(stage_name)
-        stage_lock = lock.StageLock(stage_name, cache_dir)
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
         lock_data = stage_lock.read()
 
         for out in info["outs"]:

--- a/src/pivot/storage/cache.py
+++ b/src/pivot/storage/cache.py
@@ -128,20 +128,18 @@ def _scandir_recursive(path: pathlib.Path) -> Generator[os.DirEntry[str]]:
 
     DirEntry objects cache stat results, avoiding redundant syscalls.
     Symlinks are skipped to prevent loops.
+    PermissionError propagates to caller - partial hashes would be incorrect.
     """
-    try:
-        with os.scandir(path) as entries:
-            for entry in entries:
-                if entry.is_symlink():
-                    continue
-                if _should_skip_entry(entry):
-                    continue
-                if entry.is_file():
-                    yield entry
-                elif entry.is_dir():
-                    yield from _scandir_recursive(pathlib.Path(entry.path))
-    except PermissionError:
-        pass  # Skip unreadable directories rather than failing the entire walk
+    with os.scandir(path) as entries:
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if _should_skip_entry(entry):
+                continue
+            if entry.is_file():
+                yield entry
+            elif entry.is_dir():
+                yield from _scandir_recursive(pathlib.Path(entry.path))
 
 
 def hash_directory(

--- a/src/pivot/storage/restore.py
+++ b/src/pivot/storage/restore.py
@@ -88,9 +88,9 @@ def get_lock_data_from_revision(
     stage_name: str, rev: str, cache_dir: pathlib.Path
 ) -> StorageLockData | None:
     """Read and parse lock file for a stage from a git revision."""
-    rel_path = str(
-        cache_dir.relative_to(project.get_project_root()) / "stages" / f"{stage_name}.lock"
-    )
+    # Lock files are at .pivot/stages/, not .pivot/cache/stages/
+    stages_dir = lock.get_stages_dir(cache_dir)
+    rel_path = str(stages_dir.relative_to(project.get_project_root()) / f"{stage_name}.lock")
     content = git.read_file_from_revision(rel_path, rev)
     if content is None:
         return None

--- a/src/pivot/tui/diff_panels.py
+++ b/src/pivot/tui/diff_panels.py
@@ -720,7 +720,7 @@ class OutputDiffPanel(_SelectableExpandablePanel):
             return
 
         cache_dir = _get_cache_dir()
-        stage_lock = lock.StageLock(stage_name, cache_dir)
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(cache_dir))
         lock_data = stage_lock.read()
 
         output_changes = _compute_output_changes(lock_data, self._registry_info)

--- a/tests/cli/test_cli_metrics.py
+++ b/tests/cli/test_cli_metrics.py
@@ -286,7 +286,7 @@ def test_metrics_diff_integration(
             git,
             "read_files_from_head",
             return_value={
-                ".pivot/cache/stages/train.lock": lock_content.encode(),
+                ".pivot/stages/train.lock": lock_content.encode(),
                 "metrics.json": json.dumps(head_metrics).encode(),
             },
         )

--- a/tests/cli/test_cli_params.py
+++ b/tests/cli/test_cli_params.py
@@ -226,7 +226,7 @@ def test_params_diff_no_changes(
         mocker.patch.object(
             git,
             "read_files_from_head",
-            return_value={".pivot/cache/stages/stage.lock": lock_content.encode()},
+            return_value={".pivot/stages/stage.lock": lock_content.encode()},
         )
 
         result = runner.invoke(cli.cli, ["params", "diff"])
@@ -269,7 +269,7 @@ def test_params_diff_with_changes(
         mocker.patch.object(
             git,
             "read_files_from_head",
-            return_value={".pivot/cache/stages/stage.lock": lock_content.encode()},
+            return_value={".pivot/stages/stage.lock": lock_content.encode()},
         )
 
         result = runner.invoke(cli.cli, ["params", "diff"])
@@ -313,7 +313,7 @@ def test_params_diff_json_format(
         mocker.patch.object(
             git,
             "read_files_from_head",
-            return_value={".pivot/cache/stages/stage.lock": lock_content.encode()},
+            return_value={".pivot/stages/stage.lock": lock_content.encode()},
         )
 
         result = runner.invoke(cli.cli, ["params", "diff", "--json"])
@@ -358,7 +358,7 @@ def test_params_diff_md_format(
         mocker.patch.object(
             git,
             "read_files_from_head",
-            return_value={".pivot/cache/stages/stage.lock": lock_content.encode()},
+            return_value={".pivot/stages/stage.lock": lock_content.encode()},
         )
 
         result = runner.invoke(cli.cli, ["params", "diff", "--md"])

--- a/tests/core/test_explain.py
+++ b/tests/core/test_explain.py
@@ -259,7 +259,7 @@ def test_get_stage_explanation_no_lock(tmp_path: Path) -> None:
         deps=[],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result == StageExplanation(
@@ -275,7 +275,7 @@ def test_get_stage_explanation_no_lock(tmp_path: Path) -> None:
 
 def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
     """Returns will_run=False when stage unchanged."""
-    stage_lock = lock.StageLock("unchanged_stage", tmp_path)
+    stage_lock = lock.StageLock("unchanged_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:unchanged_stage": "abc123"},
@@ -292,7 +292,7 @@ def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
         deps=[],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is False
@@ -304,7 +304,7 @@ def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
 
 def test_get_stage_explanation_code_changed(tmp_path: Path) -> None:
     """Returns detailed code changes when code differs."""
-    stage_lock = lock.StageLock("code_stage", tmp_path)
+    stage_lock = lock.StageLock("code_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:code_stage": "old_hash", "func:helper": "helper_old"},
@@ -321,7 +321,7 @@ def test_get_stage_explanation_code_changed(tmp_path: Path) -> None:
         deps=[],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -337,7 +337,7 @@ def test_get_stage_explanation_params_changed(tmp_path: Path) -> None:
     class TrainParams(pydantic.BaseModel):
         learning_rate: float = 0.01
 
-    stage_lock = lock.StageLock("param_stage", tmp_path)
+    stage_lock = lock.StageLock("param_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:param_stage": "abc"},
@@ -355,7 +355,7 @@ def test_get_stage_explanation_params_changed(tmp_path: Path) -> None:
         deps=[],
         params_instance=TrainParams(),
         overrides=overrides,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -374,7 +374,7 @@ def test_get_stage_explanation_deps_changed(tmp_path: Path) -> None:
     data_file.write_text("id,value\n1,10\n")
     normalized_path = str(project.normalize_path(str(data_file)))
 
-    stage_lock = lock.StageLock("dep_stage", tmp_path)
+    stage_lock = lock.StageLock("dep_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:dep_stage": "abc"},
@@ -391,7 +391,7 @@ def test_get_stage_explanation_deps_changed(tmp_path: Path) -> None:
         deps=[str(data_file)],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -412,7 +412,7 @@ def test_get_stage_explanation_multiple_changes(tmp_path: Path) -> None:
     data_file.write_text("x,y\n1,2\n")
     normalized_path = str(project.normalize_path(str(data_file)))
 
-    stage_lock = lock.StageLock("multi_stage", tmp_path)
+    stage_lock = lock.StageLock("multi_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:multi_stage": "old_code"},
@@ -429,7 +429,7 @@ def test_get_stage_explanation_multiple_changes(tmp_path: Path) -> None:
         deps=[str(data_file)],
         params_instance=Params(),
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -440,7 +440,7 @@ def test_get_stage_explanation_multiple_changes(tmp_path: Path) -> None:
 
 def test_get_stage_explanation_missing_deps(tmp_path: Path) -> None:
     """Returns will_run=True with reason when deps are missing."""
-    stage_lock = lock.StageLock("missing_deps_stage", tmp_path)
+    stage_lock = lock.StageLock("missing_deps_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:missing_deps_stage": "abc"},
@@ -457,7 +457,7 @@ def test_get_stage_explanation_missing_deps(tmp_path: Path) -> None:
         deps=["nonexistent.csv"],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -479,7 +479,7 @@ def test_get_stage_explanation_invalid_params(
         model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="forbid")
         learning_rate: float = 0.01
 
-    stage_lock = lock.StageLock("stage", tmp_path)
+    stage_lock = lock.StageLock("stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:stage": "abc"},
@@ -496,7 +496,7 @@ def test_get_stage_explanation_invalid_params(
         deps=[],
         params_instance=StrictParams(),
         overrides=invalid_params_yaml,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
     )
 
     assert result["will_run"] is True
@@ -522,7 +522,7 @@ def test_get_stage_explanation_force_without_changes(
     fingerprint = {f"self:{stage_name}": "abc123"}
 
     if create_lock:
-        stage_lock = lock.StageLock(stage_name, tmp_path)
+        stage_lock = lock.StageLock(stage_name, tmp_path / "stages")
         stage_lock.write(
             LockData(
                 code_manifest=fingerprint,
@@ -539,7 +539,7 @@ def test_get_stage_explanation_force_without_changes(
         deps=[],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
         force=True,
     )
 
@@ -556,7 +556,7 @@ def test_get_stage_explanation_force_without_changes(
 
 def test_get_stage_explanation_force_with_code_changes(tmp_path: Path) -> None:
     """Force with code changes shows code changes but is_forced=True."""
-    stage_lock = lock.StageLock("code_stage", tmp_path)
+    stage_lock = lock.StageLock("code_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:code_stage": "old_hash"},
@@ -573,7 +573,7 @@ def test_get_stage_explanation_force_with_code_changes(tmp_path: Path) -> None:
         deps=[],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
         force=True,
     )
 
@@ -586,7 +586,7 @@ def test_get_stage_explanation_force_with_code_changes(tmp_path: Path) -> None:
 
 def test_get_stage_explanation_force_with_missing_deps(tmp_path: Path) -> None:
     """Force with missing deps shows missing deps but is_forced=True."""
-    stage_lock = lock.StageLock("dep_stage", tmp_path)
+    stage_lock = lock.StageLock("dep_stage", tmp_path / "stages")
     stage_lock.write(
         LockData(
             code_manifest={"self:dep_stage": "abc"},
@@ -603,7 +603,7 @@ def test_get_stage_explanation_force_with_missing_deps(tmp_path: Path) -> None:
         deps=["nonexistent.csv"],
         params_instance=None,
         overrides=None,
-        cache_dir=tmp_path,
+        cache_dir=tmp_path / "cache",
         force=True,
     )
 

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -1129,7 +1129,7 @@ def test_executor_output_hashes_in_lock_file(pipeline_dir: pathlib.Path) -> None
 
     executor.run(show_output=False)
 
-    lock_file = pipeline_dir / ".pivot" / "cache" / "stages" / "process.lock"
+    lock_file = pipeline_dir / ".pivot" / "stages" / "process.lock"
     assert lock_file.exists()
 
     # Storage format uses 'outs' list (not 'output_hashes' dict)
@@ -1152,7 +1152,7 @@ def test_executor_lock_file_deterministic_sort(pipeline_dir: pathlib.Path) -> No
 
     executor.run(show_output=False)
 
-    lock_file = pipeline_dir / ".pivot" / "cache" / "stages" / "process.lock"
+    lock_file = pipeline_dir / ".pivot" / "stages" / "process.lock"
     lock_data = yaml.safe_load(lock_file.read_text())
 
     # Storage format uses 'deps' and 'outs' lists (sorted by path)
@@ -1187,8 +1187,7 @@ def test_executor_directory_output_cached(pipeline_dir: pathlib.Path) -> None:
 def test_executor_lock_file_missing_outs_triggers_rerun(pipeline_dir: pathlib.Path) -> None:
     """Lock file without outs section triggers re-execution."""
     (pipeline_dir / "input.txt").write_text("data")
-    cache_dir = pipeline_dir / ".pivot" / "cache"
-    stages_dir = cache_dir / "stages"
+    stages_dir = pipeline_dir / ".pivot" / "stages"
     stages_dir.mkdir(parents=True)
 
     # Create lock file without outs (incomplete)

--- a/tests/remote/test_transfer.py
+++ b/tests/remote/test_transfer.py
@@ -95,7 +95,9 @@ def test_get_local_cache_hashes_ignores_invalid_structure(tmp_path: Path) -> Non
 @pytest.fixture
 def lock_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".pivot" / "cache" / "stages").mkdir(parents=True)
+    # Lock files are at .pivot/stages/, cache at .pivot/cache/
+    (tmp_path / ".pivot" / "stages").mkdir(parents=True)
+    (tmp_path / ".pivot" / "cache").mkdir(parents=True)
     return tmp_path
 
 
@@ -114,7 +116,7 @@ def test_get_stage_output_hashes_file_output(
     cache_dir = lock_project / ".pivot" / "cache"
 
     lock_data = make_valid_lock_content(outs=[{"path": "output.csv", "hash": "abc123def45678"}])
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
@@ -150,7 +152,7 @@ def test_get_stage_output_hashes_directory_output(
             }
         ]
     )
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
@@ -168,7 +170,7 @@ def test_get_stage_output_hashes_multiple_stages(
         lock_data = make_valid_lock_content(
             outs=[{"path": f"out{i}.csv", "hash": f"hash{i}{'0' * 11}"}]
         )
-        lock_path = cache_dir / "stages" / f"{stage}.lock"
+        lock_path = lock_project / ".pivot" / "stages" / f"{stage}.lock"
         with lock_path.open("w") as f:
             yaml.dump(lock_data, f)
 
@@ -189,7 +191,7 @@ def test_get_stage_output_hashes_skips_uncached(
             {"path": "uncached.csv", "hash": None},
         ]
     )
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
@@ -214,7 +216,7 @@ def test_get_stage_dep_hashes(
             {"path": "config.yaml", "hash": "dep2hash1234567"},
         ]
     )
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
@@ -240,7 +242,7 @@ def test_get_stage_dep_hashes_with_manifest(
             }
         ]
     )
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
@@ -412,7 +414,7 @@ async def test_push_async_with_stages(
     (files_dir / "ab" / ("c" * 14)).write_text("content1")
 
     lock_data = make_valid_lock_content(outs=[{"path": "out.csv", "hash": hash1}])
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
@@ -466,7 +468,7 @@ async def test_pull_async_all_already_local(
     (files_dir / "ab" / ("c" * 14)).write_text("content1")
 
     lock_data = make_valid_lock_content(outs=[{"path": "out.csv", "hash": hash1}])
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
@@ -492,7 +494,7 @@ async def test_pull_async_downloads_missing(
 
     hash1 = "ab" + "c" * 14
     lock_data = make_valid_lock_content(outs=[{"path": "out.csv", "hash": hash1}])
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
@@ -544,7 +546,7 @@ async def test_pull_async_handles_failures(
 
     hash1 = "ab" + "c" * 14
     lock_data = make_valid_lock_content(outs=[{"path": "out.csv", "hash": hash1}])
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
@@ -577,7 +579,7 @@ async def test_pull_async_includes_deps(
         outs=[{"path": "out.csv", "hash": out_hash}],
         deps=[{"path": "in.csv", "hash": dep_hash}],
     )
-    lock_path = cache_dir / "stages" / "my_stage.lock"
+    lock_path = lock_project / ".pivot" / "stages" / "my_stage.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)

--- a/tests/show/test_data.py
+++ b/tests/show/test_data.py
@@ -1315,7 +1315,7 @@ dep_generations: {}
 """
 
     def mock_read_files(paths: list[str]) -> dict[str, str | None]:
-        return {".pivot/cache/stages/process_data.lock": lock_content}
+        return {".pivot/stages/process_data.lock": lock_content}
 
     monkeypatch.setattr(git, "read_files_from_head", mock_read_files)
 
@@ -1383,7 +1383,7 @@ def test_get_data_hashes_from_head_invalid_yaml(
 
     # Invalid YAML
     def mock_read_files(paths: list[str]) -> dict[str, str | None]:
-        return {".pivot/cache/stages/process_data.lock": "invalid: yaml: content: ["}
+        return {".pivot/stages/process_data.lock": "invalid: yaml: content: ["}
 
     monkeypatch.setattr(git, "read_files_from_head", mock_read_files)
 
@@ -1417,7 +1417,7 @@ def test_get_data_hashes_from_head_missing_outs_key(
 
     # Lock file without outs key
     def mock_read_files(paths: list[str]) -> dict[str, str | None]:
-        return {".pivot/cache/stages/process_data.lock": "fingerprint: abc123\n"}
+        return {".pivot/stages/process_data.lock": "fingerprint: abc123\n"}
 
     monkeypatch.setattr(git, "read_files_from_head", mock_read_files)
 
@@ -1450,7 +1450,7 @@ def test_get_data_hashes_from_head_outs_not_list(
 
     # Lock file with outs as string instead of list
     def mock_read_files(paths: list[str]) -> dict[str, str | None]:
-        return {".pivot/cache/stages/process_data.lock": "outs: not_a_list\n"}
+        return {".pivot/stages/process_data.lock": "outs: not_a_list\n"}
 
     monkeypatch.setattr(git, "read_files_from_head", mock_read_files)
 

--- a/tests/show/test_metrics.py
+++ b/tests/show/test_metrics.py
@@ -621,7 +621,7 @@ def test_get_metric_info_from_head_with_metric_stage(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/my_stage.lock": lock_content.encode()},
+        return_value={".pivot/stages/my_stage.lock": lock_content.encode()},
     )
 
     result = metrics.get_metric_info_from_head()
@@ -669,7 +669,7 @@ def test_get_metric_info_from_head_invalid_lock_yaml(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/my_stage.lock": b":\n  :\n invalid"},
+        return_value={".pivot/stages/my_stage.lock": b":\n  :\n invalid"},
     )
 
     result = metrics.get_metric_info_from_head()
@@ -696,7 +696,7 @@ def test_get_metric_info_from_head_lock_missing_outs(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/my_stage.lock": lock_content.encode()},
+        return_value={".pivot/stages/my_stage.lock": lock_content.encode()},
     )
 
     result = metrics.get_metric_info_from_head()
@@ -723,7 +723,7 @@ def test_get_metric_info_from_head_outs_not_list(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/my_stage.lock": lock_content.encode()},
+        return_value={".pivot/stages/my_stage.lock": lock_content.encode()},
     )
 
     result = metrics.get_metric_info_from_head()

--- a/tests/show/test_params.py
+++ b/tests/show/test_params.py
@@ -160,7 +160,7 @@ def test_get_params_from_head_with_lock_file(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/train.lock": lock_content.encode()},
+        return_value={".pivot/stages/train.lock": lock_content.encode()},
     )
 
     result = params.get_params_from_head()
@@ -234,7 +234,7 @@ def test_get_params_from_head_invalid_yaml(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/train.lock": b"invalid yaml: {"},
+        return_value={".pivot/stages/train.lock": b"invalid yaml: {"},
     )
 
     result = params.get_params_from_head()
@@ -260,7 +260,7 @@ def test_get_params_from_head_missing_params_key(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/train.lock": lock_content.encode()},
+        return_value={".pivot/stages/train.lock": lock_content.encode()},
     )
 
     result = params.get_params_from_head()
@@ -286,7 +286,7 @@ def test_get_params_from_head_empty_params(
     mocker.patch.object(
         git,
         "read_files_from_head",
-        return_value={".pivot/cache/stages/train.lock": lock_content.encode()},
+        return_value={".pivot/stages/train.lock": lock_content.encode()},
     )
 
     result = params.get_params_from_head()
@@ -320,8 +320,8 @@ def test_get_params_from_head_filters_by_stage_names(
         git,
         "read_files_from_head",
         return_value={
-            ".pivot/cache/stages/stage_a.lock": lock_a.encode(),
-            ".pivot/cache/stages/stage_b.lock": lock_b.encode(),
+            ".pivot/stages/stage_a.lock": lock_a.encode(),
+            ".pivot/stages/stage_b.lock": lock_b.encode(),
         },
     )
 

--- a/tests/show/test_plots.py
+++ b/tests/show/test_plots.py
@@ -116,7 +116,9 @@ def test_get_plot_hashes_from_lock_with_hash(set_project_root: Path) -> None:
 
     # Create lock file with hash
     cache_dir = set_project_root / ".pivot" / "cache"
-    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stages_dir = lock.get_stages_dir(cache_dir)
+    stages_dir.mkdir(parents=True, exist_ok=True)
+    stage_lock = lock.StageLock("test_stage", stages_dir)
     stage_lock.write(
         LockData(
             code_manifest={},
@@ -149,7 +151,9 @@ def test_get_plot_hashes_from_lock_with_none_hash(set_project_root: Path) -> Non
 
     # Create lock file with None hash (uncached output)
     cache_dir = set_project_root / ".pivot" / "cache"
-    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stages_dir = lock.get_stages_dir(cache_dir)
+    stages_dir.mkdir(parents=True, exist_ok=True)
+    stage_lock = lock.StageLock("test_stage", stages_dir)
     stage_lock.write(
         LockData(
             code_manifest={},
@@ -229,7 +233,9 @@ def test_get_plot_hashes_from_head_returns_committed_hash(
 
     # Create and commit lock file with hash
     cache_dir = set_project_root / ".pivot" / "cache"
-    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stages_dir = lock.get_stages_dir(cache_dir)
+    stages_dir.mkdir(parents=True, exist_ok=True)
+    stage_lock = lock.StageLock("test_stage", stages_dir)
     stage_lock.write(
         LockData(
             code_manifest={},
@@ -273,7 +279,9 @@ def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
 
     # Create and commit lock file with original hash
     cache_dir = set_project_root / ".pivot" / "cache"
-    stage_lock = lock.StageLock("test_stage", cache_dir)
+    stages_dir = lock.get_stages_dir(cache_dir)
+    stages_dir.mkdir(parents=True, exist_ok=True)
+    stage_lock = lock.StageLock("test_stage", stages_dir)
     stage_lock.write(
         LockData(
             code_manifest={},

--- a/tests/storage/test_cache.py
+++ b/tests/storage/test_cache.py
@@ -221,8 +221,8 @@ def test_hash_directory_marks_executable(tmp_path: pathlib.Path) -> None:
     assert manifest_dict["script.sh"]["isexec"] is True
 
 
-def test_hash_directory_skips_unreadable_subdirs(tmp_path: pathlib.Path) -> None:
-    """Unreadable subdirectories are skipped rather than causing failure."""
+def test_hash_directory_raises_on_unreadable_subdirs(tmp_path: pathlib.Path) -> None:
+    """Unreadable subdirectories raise PermissionError (fail-fast, no partial hashes)."""
     test_dir = tmp_path / "mydir"
     test_dir.mkdir()
     (test_dir / "readable.txt").write_text("content")
@@ -232,10 +232,8 @@ def test_hash_directory_skips_unreadable_subdirs(tmp_path: pathlib.Path) -> None
     unreadable.chmod(0o000)
 
     try:
-        _, manifest = cache.hash_directory(test_dir)
-        relpaths = [e["relpath"] for e in manifest]
-        assert "readable.txt" in relpaths
-        assert "unreadable/hidden.txt" not in relpaths
+        with pytest.raises(PermissionError):
+            cache.hash_directory(test_dir)
     finally:
         unreadable.chmod(0o755)
 

--- a/tests/storage/test_incremental_out.py
+++ b/tests/storage/test_incremental_out.py
@@ -189,7 +189,7 @@ def test_integration_second_run_appends_to_output(
 
     # Simulate code change by modifying the lock file's code_manifest
     # Keep output_hashes so we can restore
-    stage_lock = lock.StageLock("append_stage", cache_dir)
+    stage_lock = lock.StageLock("append_stage", lock.get_stages_dir(cache_dir))
     lock_data = stage_lock.read()
     assert lock_data is not None
     lock_data["code_manifest"] = {"self:fake": "changed_hash"}

--- a/tests/storage/test_lock.py
+++ b/tests/storage/test_lock.py
@@ -334,8 +334,8 @@ def test_atomic_write_no_partial_file(tmp_path: Path) -> None:
 
 def test_lock_directory_created(tmp_path: Path) -> None:
     """Lock file parent directories are created automatically."""
-    nested_cache = tmp_path / "deep" / "nested" / "cache"
-    stage_lock = lock.StageLock("nested_stage", nested_cache)
+    stages_dir = tmp_path / "deep" / "nested" / "stages"
+    stage_lock = lock.StageLock("nested_stage", stages_dir)
 
     stage_lock.write(
         {
@@ -348,7 +348,7 @@ def test_lock_directory_created(tmp_path: Path) -> None:
     )
 
     assert stage_lock.path.exists()
-    assert stage_lock.path.parent == nested_cache / "stages"
+    assert stage_lock.path.parent == stages_dir
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/test_restore.py
+++ b/tests/storage/test_restore.py
@@ -112,7 +112,7 @@ def test_resolve_targets_as_stage(git_repo: GitRepo, monkeypatch: pytest.MonkeyP
 
     # Create lock file for stage
     cache_dir = repo_path / ".pivot" / "cache"
-    (cache_dir / "stages").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
     lock_content = {
         "code_manifest": {"func:main": "abc123"},
         "params": {},
@@ -120,7 +120,7 @@ def test_resolve_targets_as_stage(git_repo: GitRepo, monkeypatch: pytest.MonkeyP
         "outs": [{"path": "model.pkl", "hash": "def456"}],
         "dep_generations": {},
     }
-    (cache_dir / "stages" / "train.lock").write_text(yaml.dump(lock_content))
+    (repo_path / ".pivot" / "stages" / "train.lock").write_text(yaml.dump(lock_content))
 
     sha = commit("add lock file")[:7]
     monkeypatch.setattr(project, "_project_root_cache", repo_path)
@@ -351,7 +351,7 @@ def test_restore_targets_from_revision_output_with_stage(
 
     # Create lock file for stage
     cache_dir = repo_path / ".pivot" / "cache"
-    (cache_dir / "stages").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
     lock_content = {
         "code_manifest": {"func:main": "abc123"},
         "params": {},
@@ -359,7 +359,7 @@ def test_restore_targets_from_revision_output_with_stage(
         "outs": [{"path": "model.pkl", "hash": "def456"}],
         "dep_generations": {},
     }
-    (cache_dir / "stages" / "train.lock").write_text(yaml.dump(lock_content))
+    (repo_path / ".pivot" / "stages" / "train.lock").write_text(yaml.dump(lock_content))
 
     sha = commit("add lock")
 


### PR DESCRIPTION
## Summary

Addresses multiple correctness issues identified during code review:

- **Lock file location**: Move lock files from `.pivot/cache/stages/` to `.pivot/stages/` so they can be git-tracked for reproducibility
- **Error handling**: Raise `ParamsError` on `params.yaml` parse errors instead of silently returning empty dict
- **PermissionError propagation**: Let `PermissionError` propagate in directory hashing (fail-fast vs partial hashes)
- **StageDef validation**: Disallow `deps`/`outs` overrides for StageDef stages (prevents DAG/cache tracking different paths than stage actually uses)
- **Lock parse warnings**: Add warning log when lock file parsing fails
- **Documentation**: Update lock file format in docs to match actual implementation

## Test plan

- [x] All 2250 tests pass
- [x] `ruff format .` - no changes
- [x] `ruff check .` - all checks passed
- [x] `basedpyright .` - 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)