### PR TITLE
fix: LMDB multi-process safety - make workers read-only

### DIFF
--- a/src/pivot/storage/cache.py
+++ b/src/pivot/storage/cache.py
@@ -87,7 +87,7 @@ def hash_file(path: pathlib.Path, state_db: state_mod.StateDB | None = None) -> 
                     hasher.update(chunk)
         file_hash = hasher.hexdigest()
 
-    if state_db is not None:
+    if state_db is not None and not state_db.readonly:
         state_db.save(path, file_stat, file_hash)
 
     return file_hash

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Literal, NotRequired, TypedDict, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, TypeGuard
+
+if TYPE_CHECKING:
+    from pivot.run_history import RunCacheEntry
 
 # =============================================================================
 # Execution Types
@@ -56,6 +59,18 @@ class OnError(enum.StrEnum):
     IGNORE = "ignore"
 
 
+class DeferredWrites(TypedDict, total=False):
+    """Deferred StateDB writes from worker for coordinator to apply.
+
+    Uses total=False so keys are only present when there's data to write.
+    Stage name and output paths are passed separately by coordinator.
+    """
+
+    dep_generations: dict[str, int]  # {dep_path: generation}
+    run_cache_input_hash: str
+    run_cache_entry: RunCacheEntry
+
+
 class StageResult(TypedDict):
     """Result from executing a single stage."""
 
@@ -63,6 +78,7 @@ class StageResult(TypedDict):
     reason: str
     output_lines: list[tuple[str, bool]]
     metrics: NotRequired[list[tuple[str, float]]]  # (name, duration_ms) for cross-process
+    deferred_writes: NotRequired[DeferredWrites]
 
 
 # =============================================================================

--- a/tests/execution/test_execution_modes.py
+++ b/tests/execution/test_execution_modes.py
@@ -632,6 +632,13 @@ def test_run_cache_restores_directory_output(
     assert result1["status"] == StageStatus.RAN
     assert execution_count[0] == 1
 
+    # Apply deferred writes (simulating what coordinator does)
+    if "deferred_writes" in result1:
+        state_db_path = worker_env.parent / "state.db"
+        output_paths = [out.path for out in stage_info["outs"]]
+        with state.StateDB(state_db_path) as db:
+            db.apply_deferred_writes("test_stage", output_paths, result1["deferred_writes"])
+
     # Verify directory output exists
     output_dir = tmp_path / "output_dir"
     assert output_dir.is_dir()


### PR DESCRIPTION
## Summary

- Workers now open StateDB in readonly mode, returning deferred writes for the coordinator to apply atomically
- Prevents LMDB corruption from writing after fork() in multiprocessing scenarios
- MDB_NOTLS flag is already enabled by default in Python lmdb library

## Changes

**Core LMDB safety:**
- Add `readonly` parameter to `StateDB` with `_check_write_allowed()` guard
- Add `DeferredWrites` TypedDict for worker→coordinator communication  
- Add `apply_deferred_writes()` for atomic batch writes in single transaction
- Coordinator keeps StateDB open during execution loop and applies deferred writes

**Code quality improvements:**
- Consolidate 6 StateDB opens in `worker.py` down to 2
- Extract `_cleanup_restored_paths()` helper to reduce duplication
- Fix potential Manager resource leak by moving thread creation into try block
- Extract `_DB_FULL_MSG` constant for repeated error message

## Test plan

- [x] All 2265 tests pass
- [x] ruff format, ruff check, basedpyright all pass
- [x] Readonly mode tests added
- [x] apply_deferred_writes tests added

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)