### PR TITLE
docs: fix StageDef documentation and remove 'what' comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Workers receive pickled functions—lambdas, closures, and `__main__` definition
 
 ## StageDef Conventions
 
-StageDef and custom loaders must be **module-level** (required for type hint resolution and pickling). Loader code is fingerprinted—changes trigger re-runs. YAML `deps`/`outs` completely replace StageDef defaults.
+StageDef and custom loaders must be **module-level** (required for type hint resolution and pickling). Loader code is fingerprinted—changes trigger re-runs. StageDef stages manage their own deps/outs and cannot be overridden via decorator or YAML.
 
 ## Code Quality
 

--- a/src/pivot/cli/init.py
+++ b/src/pivot/cli/init.py
@@ -47,7 +47,6 @@ def init(ctx: click.Context, force: bool) -> None:
             )
 
     pivot_dir.mkdir(exist_ok=True)
-    # Create stages directory for git-tracked lock files
     (pivot_dir / "stages").mkdir(exist_ok=True)
     gitignore_path = pivot_dir / ".gitignore"
 

--- a/src/pivot/storage/lock.py
+++ b/src/pivot/storage/lock.py
@@ -140,12 +140,7 @@ class StageLock:
     path: Path
 
     def __init__(self, stage_name: str, stages_dir: Path) -> None:
-        """Initialize a stage lock.
-
-        Args:
-            stage_name: Name of the stage
-            stages_dir: Directory containing lock files (e.g., .pivot/stages/)
-        """
+        """Initialize a stage lock for the given stage in stages_dir."""
         if not stage_name or not _VALID_STAGE_NAME.match(stage_name):
             raise ValueError(f"Invalid stage name: {stage_name!r}")
         if len(stage_name) > _MAX_STAGE_NAME_LEN:

--- a/src/pivot/storage/restore.py
+++ b/src/pivot/storage/restore.py
@@ -88,7 +88,6 @@ def get_lock_data_from_revision(
     stage_name: str, rev: str, cache_dir: pathlib.Path
 ) -> StorageLockData | None:
     """Read and parse lock file for a stage from a git revision."""
-    # Lock files are at .pivot/stages/, not .pivot/cache/stages/
     stages_dir = lock.get_stages_dir(cache_dir)
     rel_path = str(stages_dir.relative_to(project.get_project_root()) / f"{stage_name}.lock")
     content = git.read_file_from_revision(rel_path, rev)


### PR DESCRIPTION
## Summary

Fix documentation/code mismatch and style violations from code review (#202).

- Update CLAUDE.md line 67: clarify that StageDef stages manage their own deps/outs and cannot be overridden via decorator or YAML
- Simplify `StageLock.__init__` docstring to one line (per project style guidelines)
- Remove "what" comments that describe obvious code in `init.py` and `restore.py`

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)