### PR TITLE
feat(exceptions): add fuzzy matching suggestions to error messages

### DIFF
--- a/src/pivot/cli/helpers.py
+++ b/src/pivot/cli/helpers.py
@@ -56,7 +56,7 @@ def validate_stages_exist(stages: list[str] | None) -> None:
     registered = set(graph.nodes())
     unknown = [s for s in stages if s not in registered]
     if unknown:
-        raise exceptions.StageNotFoundError(f"Unknown stage(s): {', '.join(unknown)}")
+        raise exceptions.StageNotFoundError(unknown, available_stages=list(registered))
 
 
 def make_progress_callback(action: str) -> Callable[[int], None]:

--- a/src/pivot/cli/params.py
+++ b/src/pivot/cli/params.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import click
 
-from pivot import exceptions
+from pivot import exceptions, registry
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
 from pivot.show import params as params_mod
@@ -38,9 +38,8 @@ def params_show(
     result = params_mod.collect_params_from_stages(stages_list)
 
     if result["unknown_stages"]:
-        raise exceptions.StageNotFoundError(
-            f"Unknown stages: {', '.join(result['unknown_stages'])}"
-        )
+        available = registry.REGISTRY.list_stages()
+        raise exceptions.StageNotFoundError(result["unknown_stages"], available_stages=available)
 
     output = params_mod.format_params_table(result["params"], output_format, precision)
     click.echo(output)
@@ -72,8 +71,9 @@ def params_diff(
     workspace_result = params_mod.collect_params_from_stages(stages_list)
 
     if workspace_result["unknown_stages"]:
+        available = registry.REGISTRY.list_stages()
         raise exceptions.StageNotFoundError(
-            f"Unknown stages: {', '.join(workspace_result['unknown_stages'])}"
+            workspace_result["unknown_stages"], available_stages=available
         )
 
     if not head_result["git_available"]:

--- a/src/pivot/dag.py
+++ b/src/pivot/dag.py
@@ -56,8 +56,9 @@ def build_dag(stages: dict[str, RegistryStageInfo], validate: bool = True) -> nx
 
                 if not producers and validate and not pathlib.Path(dep).exists():
                     raise exceptions.DependencyNotFoundError(
-                        f"Stage '{stage_name}' depends on '{dep}' which is not produced by "
-                        + "any stage and does not exist on disk"
+                        stage=stage_name,
+                        dep=dep,
+                        available_outputs=list(outputs_map.keys()),
                     )
 
     _check_acyclic(graph)

--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -171,7 +171,7 @@ def run(
         registered = set(graph.nodes())
         unknown = [s for s in stages if s not in registered]
         if unknown:
-            raise exceptions.StageNotFoundError(f"Unknown stage(s): {', '.join(unknown)}")
+            raise exceptions.StageNotFoundError(unknown, available_stages=list(registered))
 
     execution_order = dag.get_execution_order(graph, stages, single_stage=single_stage)
 

--- a/tests/cli/test_cli_decorators.py
+++ b/tests/cli/test_cli_decorators.py
@@ -41,12 +41,12 @@ def test_pivot_command_handles_pivot_error(runner: CliRunner) -> None:
 
     @cli_decorators.pivot_command()
     def failing_command() -> None:
-        raise exceptions.StageNotFoundError("Unknown stage: foo")
+        raise exceptions.StageNotFoundError(["foo"])
 
     result = runner.invoke(failing_command)
 
     assert result.exit_code != 0
-    assert "Unknown stage: foo" in result.output
+    assert "Unknown stage(s): foo" in result.output
     assert "pivot list" in result.output
 
 

--- a/tests/cli/test_cli_params.py
+++ b/tests/cli/test_cli_params.py
@@ -406,7 +406,7 @@ def test_params_show_unknown_stage_error(
         result = runner.invoke(cli.cli, ["params", "show", "nonexistent_stage"])
 
         assert result.exit_code != 0
-        assert "Unknown stages: nonexistent_stage" in result.output
+        assert "Unknown stage(s): nonexistent_stage" in result.output
 
 
 def test_params_diff_unknown_stage_error(
@@ -420,7 +420,7 @@ def test_params_diff_unknown_stage_error(
         result = runner.invoke(cli.cli, ["params", "diff", "nonexistent_stage"])
 
         assert result.exit_code != 0
-        assert "Unknown stages: nonexistent_stage" in result.output
+        assert "Unknown stage(s): nonexistent_stage" in result.output
 
 
 def test_params_diff_no_git_warning(


### PR DESCRIPTION
## Summary

Add "Did you mean?" fuzzy matching suggestions to `StageNotFoundError` and `DependencyNotFoundError` for better developer experience, especially for users migrating from DVC.

**Example output:**
```
Error: Unknown stage(s): preproces
  Did you mean: 'preproces' -> 'preprocess'?

Tip: Run 'pivot list' to see available stages
```

## Changes

- Add `_fuzzy_suggest()` helper using `difflib.get_close_matches`
- Update `StageNotFoundError` to accept `available_stages` and suggest similar names
- Update `DependencyNotFoundError` to accept `available_outputs` and suggest similar paths
- Add `__reduce__` methods for multiprocessing pickle support
- Update all raise sites to pass available candidates
- Add comprehensive tests for fuzzy matching behavior

## Files Modified

| File | Change |
|------|--------|
| `src/pivot/exceptions.py` | Add fuzzy matching infrastructure |
| `src/pivot/cli/helpers.py` | Pass available stages to exception |
| `src/pivot/cli/params.py` | Pass available stages to exception (2 locations) |
| `src/pivot/executor/core.py` | Pass available stages to exception |
| `src/pivot/dag.py` | Pass available outputs to exception |
| `tests/cli/test_cli_errors.py` | Add fuzzy matching tests |
| `tests/cli/test_cli_decorators.py` | Update test for new signature |
| `tests/cli/test_cli_params.py` | Update test assertions |

## Test Plan

- [x] All 2359 tests pass
- [x] `ruff format`, `ruff check`, `basedpyright` all pass
- [x] Fuzzy matching works for single typos
- [x] Fuzzy matching works for multiple unknown stages
- [x] No suggestion when no close match found
- [x] Pickling works for multiprocessing

Closes #174

🤖 Generated with [Claude Code](https://claude.ai/code)