### PR TITLE
fix(security): validate hash characters to prevent path traversal

### DIFF
--- a/tests/cli/test_cli_checkout.py
+++ b/tests/cli/test_cli_checkout.py
@@ -257,7 +257,7 @@ def test_checkout_cache_miss_suggests_pull(
         pathlib.Path(".pivot").mkdir()
 
         # Create pvt file pointing to non-existent cache entry
-        pvt_data = track.PvtData(path="data.txt", hash="nonexistent_hash", size=100)
+        pvt_data = track.PvtData(path="data.txt", hash="deadbeef12345678", size=100)
         track.write_pvt_file(pathlib.Path("data.txt.pvt"), pvt_data)
 
         result = runner.invoke(cli.cli, ["checkout", "data.txt"])

--- a/tests/storage/test_cache.py
+++ b/tests/storage/test_cache.py
@@ -492,7 +492,7 @@ def test_restore_directory_atomic_cleans_up_on_cache_miss(
 
     # Create hash with non-existent cache entry
     missing_hash: DirHash = {
-        "hash": "missing123456789",
+        "hash": "1234567890abcdef",
         "manifest": [{"relpath": "file.txt", "hash": "0" * 16, "size": 7, "isexec": False}],
     }
 
@@ -587,10 +587,10 @@ def test_restore_directory_validates_all_entries_before_writing(
 
     # Create manifest with first entry valid, second entry missing
     partial_hash: DirHash = {
-        "hash": "test123456789012",
+        "hash": "abcd1234567890ef",
         "manifest": [
             {"relpath": "first.txt", "hash": first_hash, "size": 5, "isexec": False},
-            {"relpath": "second.txt", "hash": "missing123456789", "size": 6, "isexec": False},
+            {"relpath": "second.txt", "hash": "deadbeef12345678", "size": 6, "isexec": False},
         ],
     }
 

--- a/tests/storage/test_restore.py
+++ b/tests/storage/test_restore.py
@@ -409,7 +409,7 @@ def test_restore_file_cache_miss_error(git_repo: GitRepo, monkeypatch: pytest.Mo
     repo_path, commit = git_repo
 
     # Create a .pvt file that references a hash not in cache
-    pvt_content = {"path": "data.csv", "hash": "nonexistent_hash_abc123", "size": 1024}
+    pvt_content = {"path": "data.csv", "hash": "deadbeef12345678", "size": 1024}
     (repo_path / "data.csv.pvt").write_text(yaml.dump(pvt_content))
 
     sha = commit("add pvt file")
@@ -443,7 +443,7 @@ def test_restore_file_from_cache(git_repo: GitRepo, monkeypatch: pytest.MonkeyPa
     (cache_dir / "files").mkdir(parents=True)
 
     # Create a fake cached file
-    file_hash = "abc123def456"
+    file_hash = "abc123def4567890"
     cache.get_cache_path(cache_dir / "files", file_hash).parent.mkdir(parents=True, exist_ok=True)
     cache.get_cache_path(cache_dir / "files", file_hash).write_bytes(b"cached content")
 

--- a/tests/test_cli_checkout.py
+++ b/tests/test_cli_checkout.py
@@ -217,7 +217,7 @@ def test_checkout_missing_from_cache_errors(
         # Create .pvt file manually without caching the data
         pvt_data: track.PvtData = {
             "path": "data.csv",
-            "hash": "nonexistent_hash",
+            "hash": "abcdef1234567890",
             "size": 100,
         }
         track.write_pvt_file(pathlib.Path("data.csv.pvt"), pvt_data)


### PR DESCRIPTION
## Summary

- **Fixed security vulnerability** in `get_cache_path()` that allowed path traversal via malicious hash values in `.pvt` files
- Hash values must now contain only valid hex characters (`0-9`, `a-f`)
- Updated test files to use valid hex hashes instead of placeholder strings

## Security Issue

Prior to this fix, a malicious `.pvt` file could contain a hash like `../../../etc/passwd` which would cause `get_cache_path()` to return a path outside the cache directory. The fix validates that hashes contain only hex characters before constructing the path.

## Test plan

- [x] All existing tests pass (2307 tests)
- [x] New hash validation test added in `test_cli_security.py`
- [x] Fixed 4 test files that used invalid placeholder hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)