### PR TITLE
feat(stage_def): add type-safe Dep/Out descriptors

### DIFF
--- a/src/pivot/stage_def.py
+++ b/src/pivot/stage_def.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import pathlib  # noqa: TC003 - used at runtime in _load/_save methods
-import sys
-import weakref
+import dataclasses
+import pathlib  # noqa: TC003 - used at runtime in _load_deps and _save_outs
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    NamedTuple,
-    Protocol,
-    cast,
-    get_origin,
-    get_type_hints,
+    Generic,
+    TypeVar,
     overload,
     override,
 )
@@ -19,330 +15,250 @@ from typing import (
 import pydantic
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from pivot import loaders
 
 
-class DepSpec(NamedTuple):
+T = TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True)
+class DepSpec:
     """Specification for a dependency."""
 
     path: str
     loader: loaders.Loader[Any]
+    descriptor: Dep[Any]
 
 
-class OutSpec(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class OutSpec:
     """Specification for an output."""
 
     path: str
     loader: loaders.Loader[Any]
+    descriptor: Out[Any]
 
 
-class _BaseDescriptor[T]:
-    """Base descriptor for typed file access with WeakKeyDictionary storage."""
+class Dep(Generic[T]):  # noqa: UP046 - basedpyright doesn't support PEP 695 syntax yet
+    """Dependency descriptor with type-safe access.
 
-    name: str
+    Use as a class field to declare a file dependency:
+
+        class MyParams(StageDef):
+            data: Dep[pandas.DataFrame] = Dep("input.csv", loaders.CSV())
+
+    After calling _load_deps(), accessing the field returns typed data:
+
+        params = MyParams()
+        params._load_deps(project_root)
+        df = params.data  # Type: pandas.DataFrame
+    """
+
+    __slots__: ClassVar[tuple[str, ...]] = ("path", "loader", "_name")
+
     path: str
     loader: loaders.Loader[T]
-    _data: weakref.WeakKeyDictionary[object, T]
-    _error_template: str
-
-    def __init__(
-        self, name: str, path: str, loader: loaders.Loader[T], error_template: str
-    ) -> None:
-        self.name = name
-        self.path = path
-        self.loader = loader
-        self._data = weakref.WeakKeyDictionary()
-        self._error_template = error_template
-
-    @overload
-    def __get__(self, obj: None, owner: type[object]) -> _BaseDescriptor[T]: ...
-
-    @overload
-    def __get__(self, obj: object, owner: type[object]) -> T: ...
-
-    def __get__(self, obj: object | None, owner: type[object]) -> _BaseDescriptor[T] | T:
-        if obj is None:
-            return self
-        if obj not in self._data:
-            raise RuntimeError(self._error_template.format(name=self.name))
-        return self._data[obj]
-
-    def _clear(self, obj: object) -> None:
-        """Clear data for the given instance."""
-        self._data.pop(obj, None)
-
-
-class DepDescriptor[T](_BaseDescriptor[T]):
-    """Descriptor for typed dependency access."""
-
-    def __init__(self, name: str, path: str, loader: loaders.Loader[T]) -> None:
-        super().__init__(
-            name, path, loader, "Dependency '{name}' not loaded - ensure _load_deps() was called"
-        )
-
-    def _load(self, obj: object, project_root: pathlib.Path) -> None:
-        """Load data for the given instance."""
-        full_path = project_root / self.path
-        data = self.loader.load(full_path)
-        self._data[obj] = data
-
-
-class OutDescriptor[T](_BaseDescriptor[T]):
-    """Descriptor for typed output access."""
-
-    def __init__(self, name: str, path: str, loader: loaders.Loader[T]) -> None:
-        super().__init__(
-            name, path, loader, "Output '{name}' not assigned - set it before calling _save_outs()"
-        )
-
-    def __set__(self, obj: object, value: T) -> None:
-        self._data[obj] = value
-        # Track assignment on the StageDef instance
-        parent: StageDef | None = getattr(obj, "_parent_stage_def", None)
-        if parent is not None:
-            parent._assigned_outs.add(self.name)  # pyright: ignore[reportPrivateUsage] - internal tracking
-
-    def _save(self, obj: object, project_root: pathlib.Path) -> None:
-        """Save data for the given instance."""
-        if obj not in self._data:
-            raise RuntimeError(f"Output '{self.name}' was never assigned")
-        full_path = project_root / self.path
-        full_path.parent.mkdir(parents=True, exist_ok=True)
-        self.loader.save(self._data[obj], full_path)
-
-
-def _create_loader_from_annotation(
-    annotation: type[Any],
-) -> loaders.Loader[Any]:
-    """Create a loader instance from a type annotation like CSV[DataFrame]."""
-    from pivot import loaders
-
-    origin = get_origin(annotation)
-    if origin is None:
-        # Direct class reference (e.g., PathOnly without type param)
-        if issubclass(annotation, loaders.Loader):
-            return annotation()  # pyright: ignore[reportUnknownVariableType] - generic loader
-        raise TypeError(f"Invalid loader annotation: {annotation}")
-
-    # Generic type like CSV[DataFrame]
-    if isinstance(origin, type) and issubclass(origin, loaders.Loader):
-        return origin()  # pyright: ignore[reportUnknownVariableType] - generic loader
-
-    raise TypeError(f"Invalid loader annotation: {annotation}")
-
-
-def _process_nested_class(
-    nested_cls: type[object],
-    descriptor_cls: type[DepDescriptor[Any]] | type[OutDescriptor[Any]],
-    spec_cls: type[DepSpec] | type[OutSpec],
-    parent_globals: dict[str, Any],
-) -> tuple[dict[str, DepSpec | OutSpec], type[object]]:
-    """Process a nested deps/outs class and create descriptors."""
-    specs: dict[str, DepSpec | OutSpec] = {}
-
-    # Get annotations from the nested class, resolving string annotations
-    try:
-        annotations = get_type_hints(nested_cls, globalns=parent_globals)
-    except NameError:
-        # Forward reference couldn't be resolved - fall back to raw annotations
-        raw_annotations = getattr(nested_cls, "__annotations__", {})
-        # Check for unresolved string annotations
-        for name, ann in raw_annotations.items():
-            if isinstance(ann, str):
-                msg = f"Cannot resolve type annotation '{ann}' for '{name}'. "
-                msg += "Ensure all loader types are imported."
-                raise TypeError(msg) from None
-        annotations = raw_annotations
-
-    # Create a new namespace class with descriptors
-    namespace_dict: dict[str, DepDescriptor[Any] | OutDescriptor[Any] | Callable[..., None]] = {}
-
-    for name, annotation in annotations.items():
-        # Get default value (the path string)
-        default = getattr(nested_cls, name, None)
-        if default is None:
-            raise ValueError(f"Missing default path for '{name}'")
-
-        path = str(default)
-        loader = _create_loader_from_annotation(annotation)
-
-        specs[name] = spec_cls(path=path, loader=loader)
-        descriptor = descriptor_cls(name=name, path=path, loader=loader)
-        namespace_dict[name] = descriptor
-
-    # Add __init__ that takes parent reference
-    def namespace_init(self: _NamespaceInstance) -> None:
-        self._parent_stage_def = None  # pyright: ignore[reportPrivateUsage] - protocol attribute
-
-    namespace_dict["__init__"] = namespace_init
-
-    # Create namespace class dynamically
-    namespace_cls = type(f"{nested_cls.__name__}Namespace", (object,), namespace_dict)
-
-    return specs, namespace_cls
-
-
-class _NamespaceInstance(Protocol):
-    """Protocol for namespace instances that track their parent StageDef."""
-
-    _parent_stage_def: StageDef | None
-
-
-class _NamespaceDescriptor:
-    """Descriptor for accessing deps/outs namespace from class or instance."""
-
-    _cls_attr: str
-    _instance_attr: str
     _name: str
 
-    def __init__(self, cls_attr: str, instance_attr: str, name: str) -> None:
-        self._cls_attr = cls_attr
-        self._instance_attr = instance_attr
+    def __init__(self, path: str, loader: loaders.Loader[T]) -> None:
+        self.path = path
+        self.loader = loader
+        self._name = ""
+
+    def __set_name__(self, owner: type[StageDef], name: str) -> None:
         self._name = name
+        # Register this dep with the owner's _deps_specs
+        # Copy parent specs to ensure inheritance works (child gets parent deps + its own)
+        if "_deps_specs" not in owner.__dict__:
+            parent_specs = getattr(owner, "_deps_specs", {})
+            owner._deps_specs = dict(parent_specs)  # pyright: ignore[reportPrivateUsage] - descriptor needs to access class internals
+        owner._deps_specs[name] = DepSpec(  # pyright: ignore[reportPrivateUsage] - descriptor needs to access class internals
+            path=self.path, loader=self.loader, descriptor=self
+        )
 
     @overload
-    def __get__(self, obj: None, owner: type[StageDef]) -> type[object]: ...
+    def __get__(self, obj: None, _owner: type[StageDef]) -> Dep[T]: ...
 
     @overload
-    def __get__(self, obj: StageDef, owner: type[StageDef]) -> _NamespaceInstance: ...
+    def __get__(self, obj: StageDef, _owner: type[StageDef]) -> T: ...
 
-    def __get__(
-        self, obj: StageDef | None, owner: type[StageDef]
-    ) -> type[object] | _NamespaceInstance:
+    def __get__(self, obj: StageDef | None, _owner: type[StageDef]) -> Dep[T] | T:
         if obj is None:
-            # Class access - return the namespace class with descriptors
-            namespace_cls: type[object] | None = getattr(owner, self._cls_attr)
-            if namespace_cls is None:
-                raise AttributeError(f"No {self._name} defined for this StageDef")
-            return namespace_cls
-        # Instance access - return the instance namespace
-        namespace_instance: _NamespaceInstance | None = getattr(obj, self._instance_attr)
-        if namespace_instance is None:
-            raise AttributeError(f"No {self._name} defined for this StageDef")
-        return namespace_instance
+            return self
+        if self._name not in obj._deps_data:  # pyright: ignore[reportPrivateUsage] - descriptor needs to access instance internals
+            raise RuntimeError(f"Dependency '{self._name}' not loaded. Call _load_deps() first.")
+        return obj._deps_data[self._name]  # pyright: ignore[reportPrivateUsage] - descriptor needs to access instance internals
+
+
+class Out(Generic[T]):  # noqa: UP046 - basedpyright doesn't support PEP 695 syntax yet
+    """Output descriptor with type-safe access.
+
+    Use as a class field to declare a file output:
+
+        class MyParams(StageDef):
+            result: Out[dict[str, int]] = Out("output.json", loaders.JSON())
+
+    Assign values and they're saved when _save_outs() is called:
+
+        params = MyParams()
+        params.result = {"count": 1}  # Type-checked assignment
+        params._save_outs(project_root)
+    """
+
+    __slots__: ClassVar[tuple[str, ...]] = ("path", "loader", "_name")
+
+    path: str
+    loader: loaders.Loader[T]
+    _name: str
+
+    def __init__(self, path: str, loader: loaders.Loader[T]) -> None:
+        self.path = path
+        self.loader = loader
+        self._name = ""
+
+    def __set_name__(self, owner: type[StageDef], name: str) -> None:
+        self._name = name
+        # Register this out with the owner's _outs_specs
+        # Copy parent specs to ensure inheritance works (child gets parent outs + its own)
+        if "_outs_specs" not in owner.__dict__:
+            parent_specs = getattr(owner, "_outs_specs", {})
+            owner._outs_specs = dict(parent_specs)  # pyright: ignore[reportPrivateUsage] - descriptor needs to access class internals
+        owner._outs_specs[name] = OutSpec(  # pyright: ignore[reportPrivateUsage] - descriptor needs to access class internals
+            path=self.path, loader=self.loader, descriptor=self
+        )
+
+    @overload
+    def __get__(self, obj: None, _owner: type[StageDef]) -> Out[T]: ...
+
+    @overload
+    def __get__(self, obj: StageDef, _owner: type[StageDef]) -> T: ...
+
+    def __get__(self, obj: StageDef | None, _owner: type[StageDef]) -> Out[T] | T:
+        if obj is None:
+            return self
+        if self._name not in obj._outs_data:  # pyright: ignore[reportPrivateUsage] - descriptor needs to access instance internals
+            raise RuntimeError(
+                f"Output '{self._name}' not yet assigned. "
+                + f"Assign a value to params.{self._name} first."
+            )
+        return obj._outs_data[self._name]  # pyright: ignore[reportPrivateUsage] - descriptor needs to access instance internals
+
+    def __set__(self, obj: StageDef, value: T) -> None:
+        obj._outs_data[self._name] = value  # pyright: ignore[reportPrivateUsage] - descriptor needs to access instance internals
 
 
 class StageDef(pydantic.BaseModel):
-    """Base class for stage definitions with typed deps/outs."""
+    """Base class for stage definitions with typed deps/outs.
+
+    Use Dep and Out descriptors to declare typed file dependencies:
+
+        class ProcessParams(StageDef):
+            # Parameters (regular Pydantic fields)
+            threshold: float = 0.5
+
+            # Dependencies (Dep descriptors - type-safe!)
+            data: Dep[pandas.DataFrame] = Dep("input.csv", loaders.CSV())
+
+            # Outputs (Out descriptors - type-safe!)
+            result: Out[dict[str, int]] = Out("output.json", loaders.JSON())
+
+    In your stage function:
+
+        @stage
+        def process(params: ProcessParams) -> None:
+            params._load_deps(project_root)
+
+            df = params.data  # Type: pandas.DataFrame (type-checked!)
+            params.result = {"count": len(df)}  # Type-checked assignment!
+
+            params._save_outs(project_root)
+    """
 
     model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
         arbitrary_types_allowed=True,
-        ignored_types=(_NamespaceDescriptor,),
     )
 
     _deps_specs: ClassVar[dict[str, DepSpec]] = {}
     _outs_specs: ClassVar[dict[str, OutSpec]] = {}
-    _deps_namespace_cls: ClassVar[type[object] | None] = None
-    _outs_namespace_cls: ClassVar[type[object] | None] = None
 
-    _deps_instance: _NamespaceInstance | None = pydantic.PrivateAttr(default=None)
-    _outs_instance: _NamespaceInstance | None = pydantic.PrivateAttr(default=None)
-    _assigned_outs: set[str] = pydantic.PrivateAttr(default_factory=set)
-
-    # Use parameterized descriptors for deps/outs access
-    deps: ClassVar[_NamespaceDescriptor] = _NamespaceDescriptor(
-        "_deps_namespace_cls", "_deps_instance", "dependencies"
-    )
-    outs: ClassVar[_NamespaceDescriptor] = _NamespaceDescriptor(
-        "_outs_namespace_cls", "_outs_instance", "outputs"
-    )
+    _deps_data: dict[str, Any] = pydantic.PrivateAttr(default_factory=dict)
+    _outs_data: dict[str, Any] = pydantic.PrivateAttr(default_factory=dict)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
-        module = sys.modules.get(cls.__module__)
-        parent_globals = vars(module) if module else {}
-
-        # Process nested deps class if defined
-        nested_deps = cls.__dict__.get("deps")
-        if nested_deps is not None and isinstance(nested_deps, type):
-            specs, namespace_cls = _process_nested_class(
-                nested_deps, DepDescriptor, DepSpec, parent_globals
-            )
-            cls._deps_specs = cast("dict[str, DepSpec]", specs)
-            cls._deps_namespace_cls = namespace_cls
-            delattr(cls, "deps")
-        elif not hasattr(cls, "_deps_specs") or cls._deps_specs is StageDef._deps_specs:
-            cls._deps_specs = {}
-            cls._deps_namespace_cls = None
-
-        # Process nested outs class if defined
-        nested_outs = cls.__dict__.get("outs")
-        if nested_outs is not None and isinstance(nested_outs, type):
-            specs, namespace_cls = _process_nested_class(
-                nested_outs, OutDescriptor, OutSpec, parent_globals
-            )
-            cls._outs_specs = cast("dict[str, OutSpec]", specs)
-            cls._outs_namespace_cls = namespace_cls
-            delattr(cls, "outs")
-        elif not hasattr(cls, "_outs_specs") or cls._outs_specs is StageDef._outs_specs:
-            cls._outs_specs = {}
-            cls._outs_namespace_cls = None
+        # Copy parent specs to child class to ensure inheritance works
+        # (child gets parent deps/outs even if it doesn't define any new ones)
+        if "_deps_specs" not in cls.__dict__:
+            parent_specs = getattr(cls, "_deps_specs", {})
+            cls._deps_specs = dict(parent_specs)
+        if "_outs_specs" not in cls.__dict__:
+            parent_specs = getattr(cls, "_outs_specs", {})
+            cls._outs_specs = dict(parent_specs)
 
     @override
-    def model_post_init(self, context: Any) -> None:
-        """Initialize deps and outs namespace instances after pydantic init."""
-        if self._deps_namespace_cls is not None:
-            self._deps_instance = self._deps_namespace_cls()  # pyright: ignore[reportAttributeAccessIssue] - dynamic namespace class
-            self._deps_instance._parent_stage_def = self  # pyright: ignore[reportOptionalMemberAccess,reportPrivateUsage] - just assigned above, protocol attribute
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Serialize model, excluding Dep/Out descriptor fields."""
+        descriptor_names = set(self._deps_specs.keys()) | set(self._outs_specs.keys())
+        return super().model_dump(exclude=descriptor_names, **kwargs)
 
-        if self._outs_namespace_cls is not None:
-            self._outs_instance = self._outs_namespace_cls()  # pyright: ignore[reportAttributeAccessIssue] - dynamic namespace class
-            self._outs_instance._parent_stage_def = self  # pyright: ignore[reportOptionalMemberAccess,reportPrivateUsage] - just assigned above, protocol attribute
+    @override
+    def __getattribute__(self, name: str) -> Any:
+        # Check if this is a Dep or Out using the specs registry
+        # We can't rely on __dict__ because Pydantic moves descriptors
+        cls = type(self)
+        if name in cls._deps_specs:
+            spec = cls._deps_specs[name]
+            return spec.descriptor.__get__(self, cls)  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] - descriptor stored in dataclass
+        if name in cls._outs_specs:
+            spec = cls._outs_specs[name]
+            return spec.descriptor.__get__(self, cls)  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] - descriptor stored in dataclass
+        # Otherwise, use normal Pydantic attribute access
+        return super().__getattribute__(name)
+
+    @override
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Check if this is an Out using the specs registry
+        cls = type(self)
+        if name in cls._outs_specs:
+            spec = cls._outs_specs[name]
+            spec.descriptor.__set__(self, value)  # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] - descriptor stored in dataclass
+            return
+        # Otherwise, use normal Pydantic attribute access
+        super().__setattr__(name, value)
 
     def _load_deps(self, project_root: pathlib.Path) -> None:
         """Load all dependencies from disk."""
-        if self._deps_namespace_cls is None or self._deps_instance is None:
-            return
-
         loaded_names: list[str] = []
         try:
-            for name in self._deps_specs:
-                descriptor = cast("DepDescriptor[Any]", getattr(self._deps_namespace_cls, name))
-                descriptor._load(self._deps_instance, project_root)  # pyright: ignore[reportPrivateUsage] - internal API
+            for name, spec in self._deps_specs.items():
+                self._deps_data[name] = spec.loader.load(project_root / spec.path)
                 loaded_names.append(name)
         except Exception:
-            # Clear any partially loaded state
             for loaded_name in loaded_names:
-                descriptor = cast(
-                    "DepDescriptor[Any]", getattr(self._deps_namespace_cls, loaded_name)
-                )
-                descriptor._clear(self._deps_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+                self._deps_data.pop(loaded_name, None)
             raise
 
     def _clear_deps(self) -> None:
         """Clear all loaded dependency data."""
-        if self._deps_namespace_cls is None or self._deps_instance is None:
-            return
-        for name in self._deps_specs:
-            descriptor = cast("DepDescriptor[Any]", getattr(self._deps_namespace_cls, name))
-            descriptor._clear(self._deps_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+        self._deps_data.clear()
 
     def _clear_outs(self) -> None:
         """Clear all output data."""
-        if self._outs_namespace_cls is None or self._outs_instance is None:
-            return
-        for name in self._outs_specs:
-            descriptor = cast("OutDescriptor[Any]", getattr(self._outs_namespace_cls, name))
-            descriptor._clear(self._outs_instance)  # pyright: ignore[reportPrivateUsage] - internal API
+        self._outs_data.clear()
 
     def _save_outs(self, project_root: pathlib.Path) -> None:
         """Save all outputs to disk."""
-        if self._outs_namespace_cls is None or self._outs_instance is None:
-            return
-
-        # Check all outputs were assigned
         for name in self._outs_specs:
-            if name not in self._assigned_outs:
+            if name not in self._outs_data:
                 msg = f"Output '{name}' was declared but never assigned. "
-                msg += f"Assign a value to params.outs.{name} before the stage function returns."
+                msg += f"Assign a value to params.{name} before the stage returns."
                 raise RuntimeError(msg)
 
-        for name in self._outs_specs:
-            descriptor = cast("OutDescriptor[Any]", getattr(self._outs_namespace_cls, name))
-            descriptor._save(self._outs_instance, project_root)  # pyright: ignore[reportPrivateUsage] - internal API
+        for name, spec in self._outs_specs.items():
+            full_path = project_root / spec.path
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            spec.loader.save(self._outs_data[name], full_path)
 
     @classmethod
     def get_deps_paths(cls) -> dict[str, str]:

--- a/tests/config/test_registry.py
+++ b/tests/config/test_registry.py
@@ -929,11 +929,8 @@ def test_registry_restore_preserves_metadata() -> None:
 class _TestStageDef(stage_def.StageDef):
     """Module-level StageDef for testing (required for pickling)."""
 
-    class deps:
-        data: loaders.CSV[pandas.DataFrame] = "data/input.csv"
-
-    class outs:
-        result: loaders.JSON[dict[str, int]] = "output/result.json"
+    data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/input.csv", loaders.CSV())
+    result: stage_def.Out[dict[str, int]] = stage_def.Out("output/result.json", loaders.JSON())
 
     threshold: float = 0.5
 
@@ -1033,13 +1030,10 @@ def test_plain_pydantic_params_still_work() -> None:
 class _MultiDeps(stage_def.StageDef):
     """StageDef with multiple deps/outs for testing."""
 
-    class deps:
-        train: loaders.CSV[pandas.DataFrame] = "data/train.csv"
-        test: loaders.CSV[pandas.DataFrame] = "data/test.csv"
-
-    class outs:
-        model: loaders.Pickle[dict[str, float]] = "models/model.pkl"
-        metrics: loaders.JSON[dict[str, float]] = "metrics.json"
+    train: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/train.csv", loaders.CSV())
+    test: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/test.csv", loaders.CSV())
+    model: stage_def.Out[dict[str, float]] = stage_def.Out("models/model.pkl", loaders.Pickle())
+    metrics: stage_def.Out[dict[str, float]] = stage_def.Out("metrics.json", loaders.JSON())
 
 
 def test_stage_def_multiple_deps_outs() -> None:

--- a/tests/core/test_pipeline_config.py
+++ b/tests/core/test_pipeline_config.py
@@ -1431,19 +1431,16 @@ from pivot import loaders, stage_def
 
 
 class ProcessParams(stage_def.StageDef):
-   class deps:
-       data: loaders.CSV[pandas.DataFrame] = "data/input.csv"
+    data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/input.csv", loaders.CSV())
+    result: stage_def.Out[dict[str, int]] = stage_def.Out("output/result.json", loaders.JSON())
 
-   class outs:
-       result: loaders.JSON[dict[str, int]] = "output/result.json"
-
-   threshold: float = 0.5
+    threshold: float = 0.5
 
 
 def process(params: ProcessParams) -> None:
-   df = params.deps.data
-   result = {"count": len(df[df["a"] > params.threshold])}
-   params.outs.result = result
+    df = params.data
+    result = {"count": len(df[df["a"] > params.threshold])}
+    params.result = result
 """
     )
 

--- a/tests/test_stage_def.py
+++ b/tests/test_stage_def.py
@@ -1,17 +1,15 @@
-# pyright: reportUnusedFunction=false, reportPrivateUsage=false, reportAssignmentType=false, reportAttributeAccessIssue=false, reportIncompatibleVariableOverride=false, reportUnknownArgumentType=false
+# pyright: reportUnusedFunction=false, reportPrivateUsage=false
 from __future__ import annotations
 
+import pathlib  # noqa: TC003 - needed at runtime for stage_def.Dep[pathlib.Path]
 import pickle
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pandas
 import pydantic
 import pytest
 
 from pivot import loaders, stage_def
-
-if TYPE_CHECKING:
-    import pathlib
 
 # ==============================================================================
 # StageDef base class tests
@@ -35,13 +33,11 @@ def test_stage_def_with_params_only() -> None:
     assert params.epochs == 10
 
 
-def test_stage_def_discovers_deps_class() -> None:
-    """StageDef should discover nested deps class via __init_subclass__."""
+def test_stage_def_discovers_deps() -> None:
+    """StageDef should discover Dep descriptors via __set_name__."""
 
     class TrainParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "data/train.csv"
-
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/train.csv", loaders.CSV())
         learning_rate: float = 0.01
 
     # Should have deps_specs class variable
@@ -49,13 +45,11 @@ def test_stage_def_discovers_deps_class() -> None:
     assert "data" in TrainParams._deps_specs
 
 
-def test_stage_def_discovers_outs_class() -> None:
-    """StageDef should discover nested outs class via __init_subclass__."""
+def test_stage_def_discovers_outs() -> None:
+    """StageDef should discover Out descriptors via __set_name__."""
 
     class TrainParams(stage_def.StageDef):
-        class outs:
-            model: loaders.Pickle[dict[str, Any]] = "models/model.pkl"
-
+        model: stage_def.Out[dict[str, Any]] = stage_def.Out("models/model.pkl", loaders.Pickle())
         learning_rate: float = 0.01
 
     # Should have outs_specs class variable
@@ -64,51 +58,59 @@ def test_stage_def_discovers_outs_class() -> None:
 
 
 def test_stage_def_extracts_loader_type() -> None:
-    """StageDef should extract loader type from annotation."""
+    """StageDef should extract loader from Dep descriptor."""
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
 
     spec = ProcessParams._deps_specs["data"]
     assert isinstance(spec.loader, loaders.CSV)
 
 
-def test_stage_def_extracts_path_from_default() -> None:
-    """StageDef should extract file path from default value."""
+def test_stage_def_extracts_path_from_dep() -> None:
+    """StageDef should extract file path from Dep descriptor."""
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "data/input.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/input.csv", loaders.CSV())
 
     spec = ProcessParams._deps_specs["data"]
     assert spec.path == "data/input.csv"
 
 
 def test_stage_def_class_access_returns_descriptor() -> None:
-    """Class attribute access should return descriptor (for framework)."""
+    """Class-level access to deps/outs should be via _deps_specs/_outs_specs."""
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
 
-    # Class access returns descriptor with path attribute
-    descriptor = ProcessParams.deps.data
-    assert hasattr(descriptor, "path")
-    assert descriptor.path == "input.csv"
+    # Access descriptor via specs (Pydantic intercepts direct class attribute access)
+    spec = ProcessParams._deps_specs["data"]
+    assert isinstance(spec.descriptor, stage_def.Dep)  # pyright: ignore[reportAttributeAccessIssue] - descriptor stored in dataclass
+    assert spec.descriptor.path == "input.csv"  # pyright: ignore[reportAttributeAccessIssue] - descriptor stored in dataclass
+    assert spec.path == "input.csv"
+
+
+def test_stage_def_get_deps_paths() -> None:
+    """get_deps_paths() should return dict of name -> path."""
+
+    class ProcessParams(stage_def.StageDef):
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
+
+    paths = ProcessParams.get_deps_paths()
+    assert "data" in paths
+    assert paths["data"] == "input.csv"
 
 
 def test_stage_def_instance_access_before_load_raises() -> None:
     """Instance attribute access before _load_deps() should raise RuntimeError."""
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
 
     params = ProcessParams()
 
     with pytest.raises(RuntimeError, match="not loaded"):
-        _ = params.deps.data
+        _ = params.data
 
 
 def test_stage_def_instance_access_after_load_returns_data(
@@ -120,60 +122,72 @@ def test_stage_def_instance_access_after_load_returns_data(
     csv_file.write_text("a,b\n1,2\n3,4\n")
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "input.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
     # Should return loaded DataFrame
-    df = params.deps.data
+    df = params.data
     assert isinstance(df, pandas.DataFrame)
     assert list(df.columns) == ["a", "b"]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Classes defined in test functions cannot be pickled by Python. "
-        "In real usage, StageDef subclasses are module-level and can be pickled."
-    )
-)
 def test_stage_def_is_picklable() -> None:
-    """StageDef should be picklable (paths only, not loaded data)."""
+    """StageDef pickling is tested in tests/test_stage_def_pickle.py.
 
+    This test documents that inline (function-local) classes cannot be pickled
+    by Python - this is a Python limitation, not a StageDef limitation.
+    For real usage, StageDef subclasses must be module-level.
+    """
+
+    # Inline classes cannot be pickled - this is expected Python behavior
     class SimpleParams(stage_def.StageDef):
         threshold: float = 0.5
 
     params = SimpleParams(threshold=0.7)
-    pickled = pickle.dumps(params)
-    restored = pickle.loads(pickled)
 
-    assert restored.threshold == 0.7
+    # Verify the limitation exists
+    with pytest.raises(AttributeError, match="Can't get local object"):
+        pickle.dumps(params)
+
+    # Real pickle tests are in tests/test_stage_def_pickle.py with module-level classes
 
 
-def test_stage_def_output_assignment_tracking() -> None:
-    """StageDef should track output assignments."""
+def test_stage_def_output_assignment() -> None:
+    """StageDef should track output assignments via Out descriptor."""
 
     class ProcessParams(stage_def.StageDef):
-        class outs:
-            result: loaders.JSON[dict[str, int]] = "output.json"
+        result: stage_def.Out[dict[str, int]] = stage_def.Out("output.json", loaders.JSON())
 
     params = ProcessParams()
-    params.outs.result = {"value": 42}
+    params.result = {"value": 42}
 
-    # Should be marked as assigned
-    assert "result" in params._assigned_outs
+    # Should be stored in _outs_data
+    assert "result" in params._outs_data
+    assert params._outs_data["result"] == {"value": 42}
+
+
+def test_stage_def_output_access_before_assignment_raises() -> None:
+    """Accessing an Out before assignment should raise RuntimeError."""
+
+    class ProcessParams(stage_def.StageDef):
+        result: stage_def.Out[dict[str, int]] = stage_def.Out("output.json", loaders.JSON())
+
+    params = ProcessParams()
+
+    with pytest.raises(RuntimeError, match="not yet assigned"):
+        _ = params.result
 
 
 def test_stage_def_save_outs_raises_if_not_assigned(tmp_path: pathlib.Path) -> None:
     """_save_outs() should raise if output was declared but never assigned."""
 
     class ProcessParams(stage_def.StageDef):
-        class outs:
-            result: loaders.JSON[dict[str, int]] = "output.json"
+        result: stage_def.Out[dict[str, int]] = stage_def.Out("output.json", loaders.JSON())
 
     params = ProcessParams()
-    # Never assign params.outs.result
+    # Never assign params.result
 
     with pytest.raises(RuntimeError, match="never assigned"):
         params._save_outs(tmp_path)
@@ -183,11 +197,10 @@ def test_stage_def_save_outs_writes_file(tmp_path: pathlib.Path) -> None:
     """_save_outs() should write assigned outputs to files."""
 
     class ProcessParams(stage_def.StageDef):
-        class outs:
-            result: loaders.JSON[dict[str, int]] = "output.json"
+        result: stage_def.Out[dict[str, int]] = stage_def.Out("output.json", loaders.JSON())
 
     params = ProcessParams()
-    params.outs.result = {"value": 42}
+    params.result = {"value": 42}
     params._save_outs(tmp_path)
 
     # Should have written the file
@@ -196,13 +209,12 @@ def test_stage_def_save_outs_writes_file(tmp_path: pathlib.Path) -> None:
     assert "42" in output_file.read_text()
 
 
-def test_stage_def_get_deps_paths() -> None:
+def test_stage_def_get_deps_paths_multiple() -> None:
     """get_deps_paths() should return dict of name -> path."""
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            train: loaders.CSV[pandas.DataFrame] = "data/train.csv"
-            test: loaders.CSV[pandas.DataFrame] = "data/test.csv"
+        train: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/train.csv", loaders.CSV())
+        test: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data/test.csv", loaders.CSV())
 
     paths = ProcessParams.get_deps_paths()
 
@@ -213,9 +225,8 @@ def test_stage_def_get_outs_paths() -> None:
     """get_outs_paths() should return dict of name -> path."""
 
     class ProcessParams(stage_def.StageDef):
-        class outs:
-            model: loaders.Pickle[dict[str, Any]] = "models/model.pkl"
-            metrics: loaders.JSON[dict[str, float]] = "metrics.json"
+        model: stage_def.Out[dict[str, Any]] = stage_def.Out("models/model.pkl", loaders.Pickle())
+        metrics: stage_def.Out[dict[str, float]] = stage_def.Out("metrics.json", loaders.JSON())
 
     paths = ProcessParams.get_outs_paths()
 
@@ -229,28 +240,26 @@ def test_stage_def_multiple_deps_loaded(tmp_path: pathlib.Path) -> None:
     (tmp_path / "test.csv").write_text("x,y\n3,4\n")
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            train: loaders.CSV[pandas.DataFrame] = "train.csv"
-            test: loaders.CSV[pandas.DataFrame] = "test.csv"
+        train: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("train.csv", loaders.CSV())
+        test: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("test.csv", loaders.CSV())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
-    assert isinstance(params.deps.train, pandas.DataFrame)
-    assert isinstance(params.deps.test, pandas.DataFrame)
+    assert isinstance(params.train, pandas.DataFrame)
+    assert isinstance(params.test, pandas.DataFrame)
 
 
 def test_stage_def_multiple_outs_saved(tmp_path: pathlib.Path) -> None:
     """Multiple outs should all be saveable."""
 
     class ProcessParams(stage_def.StageDef):
-        class outs:
-            model: loaders.JSON[dict[str, int]] = "model.json"
-            metrics: loaders.JSON[dict[str, float]] = "metrics.json"
+        model: stage_def.Out[dict[str, int]] = stage_def.Out("model.json", loaders.JSON())
+        metrics: stage_def.Out[dict[str, float]] = stage_def.Out("metrics.json", loaders.JSON())
 
     params = ProcessParams()
-    params.outs.model = {"weights": 1}
-    params.outs.metrics = {"accuracy": 0.95}
+    params.model = {"weights": 1}
+    params.metrics = {"accuracy": 0.95}
     params._save_outs(tmp_path)
 
     assert (tmp_path / "model.json").exists()
@@ -264,18 +273,15 @@ def test_stage_def_json_loader_roundtrip(tmp_path: pathlib.Path) -> None:
     input_file.write_text('{"key": "value"}')
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            config: loaders.JSON[dict[str, str]] = "config.json"
-
-        class outs:
-            result: loaders.JSON[dict[str, str]] = "result.json"
+        config: stage_def.Dep[dict[str, str]] = stage_def.Dep("config.json", loaders.JSON())
+        result: stage_def.Out[dict[str, str]] = stage_def.Out("result.json", loaders.JSON())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
-    assert params.deps.config == {"key": "value"}
+    assert params.config == {"key": "value"}
 
-    params.outs.result = {"processed": "data"}
+    params.result = {"processed": "data"}
     params._save_outs(tmp_path)
 
     assert (tmp_path / "result.json").exists()
@@ -288,13 +294,12 @@ def test_stage_def_yaml_loader(tmp_path: pathlib.Path) -> None:
     yaml_file.write_text("key: value\nlist:\n  - a\n  - b\n")
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            config: loaders.YAML[dict[str, Any]] = "config.yaml"
+        config: stage_def.Dep[dict[str, Any]] = stage_def.Dep("config.yaml", loaders.YAML())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
-    assert params.deps.config == {"key": "value", "list": ["a", "b"]}
+    assert params.config == {"key": "value", "list": ["a", "b"]}
 
 
 def test_stage_def_pickle_loader(tmp_path: pathlib.Path) -> None:
@@ -304,18 +309,15 @@ def test_stage_def_pickle_loader(tmp_path: pathlib.Path) -> None:
     pkl_file.write_bytes(pickle.dumps({"complex": [1, 2, 3]}))
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.Pickle[dict[str, list[int]]] = "data.pkl"
-
-        class outs:
-            result: loaders.Pickle[dict[str, int]] = "result.pkl"
+        data: stage_def.Dep[dict[str, list[int]]] = stage_def.Dep("data.pkl", loaders.Pickle())
+        result: stage_def.Out[dict[str, int]] = stage_def.Out("result.pkl", loaders.Pickle())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
-    assert params.deps.data == {"complex": [1, 2, 3]}
+    assert params.data == {"complex": [1, 2, 3]}
 
-    params.outs.result = {"value": 42}
+    params.result = {"value": 42}
     params._save_outs(tmp_path)
 
     loaded = pickle.loads((tmp_path / "result.pkl").read_bytes())
@@ -329,14 +331,13 @@ def test_stage_def_pathonly_loader(tmp_path: pathlib.Path) -> None:
     data_file.write_bytes(b"binary data")
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.PathOnly = "data.bin"
+        data: stage_def.Dep[pathlib.Path] = stage_def.Dep("data.bin", loaders.PathOnly())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
     # Should return the path itself
-    path = params.deps.data
+    path = params.data
     assert path == tmp_path / "data.bin"
     assert path.exists()
 
@@ -348,13 +349,12 @@ def test_stage_def_csv_with_default_config(tmp_path: pathlib.Path) -> None:
     csv_file.write_text("a,b\n1,2\n")
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            data: loaders.CSV[pandas.DataFrame] = "data.csv"
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data.csv", loaders.CSV())
 
     params = ProcessParams()
     params._load_deps(tmp_path)
 
-    assert list(params.deps.data.columns) == ["a", "b"]
+    assert list(params.data.columns) == ["a", "b"]
 
 
 def test_stage_def_load_failure_clears_state(tmp_path: pathlib.Path) -> None:
@@ -364,9 +364,8 @@ def test_stage_def_load_failure_clears_state(tmp_path: pathlib.Path) -> None:
     # Don't create second.csv
 
     class ProcessParams(stage_def.StageDef):
-        class deps:
-            first: loaders.CSV[pandas.DataFrame] = "first.csv"
-            second: loaders.CSV[pandas.DataFrame] = "second.csv"
+        first: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("first.csv", loaders.CSV())
+        second: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("second.csv", loaders.CSV())
 
     params = ProcessParams()
 
@@ -375,7 +374,7 @@ def test_stage_def_load_failure_clears_state(tmp_path: pathlib.Path) -> None:
 
     # Should have cleared any partial state
     with pytest.raises(RuntimeError, match="not loaded"):
-        _ = params.deps.first
+        _ = params.first
 
 
 def test_stage_def_params_validation() -> None:
@@ -391,3 +390,75 @@ def test_stage_def_params_validation() -> None:
     # Invalid
     with pytest.raises(pydantic.ValidationError):
         ProcessParams(threshold=2.0)
+
+
+# ==============================================================================
+# Inheritance tests
+# ==============================================================================
+
+
+def test_stage_def_child_inherits_parent_deps(tmp_path: pathlib.Path) -> None:
+    """Child StageDef should inherit parent's deps."""
+    # Create test files
+    (tmp_path / "parent.csv").write_text("a,b\n1,2\n")
+    (tmp_path / "child.csv").write_text("x,y\n3,4\n")
+
+    class ParentParams(stage_def.StageDef):
+        parent_data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("parent.csv", loaders.CSV())
+
+    class ChildParams(ParentParams):
+        child_data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("child.csv", loaders.CSV())
+
+    # Child should have both deps
+    assert "parent_data" in ChildParams.get_deps_paths()
+    assert "child_data" in ChildParams.get_deps_paths()
+
+    # Both should be loadable
+    params = ChildParams()
+    params._load_deps(tmp_path)
+
+    assert isinstance(params.parent_data, pandas.DataFrame)
+    assert isinstance(params.child_data, pandas.DataFrame)
+
+
+def test_stage_def_child_inherits_parent_outs(tmp_path: pathlib.Path) -> None:
+    """Child StageDef should inherit parent's outs."""
+
+    class ParentParams(stage_def.StageDef):
+        parent_out: stage_def.Out[dict[str, int]] = stage_def.Out("parent.json", loaders.JSON())
+
+    class ChildParams(ParentParams):
+        child_out: stage_def.Out[dict[str, int]] = stage_def.Out("child.json", loaders.JSON())
+
+    # Child should have both outs
+    assert "parent_out" in ChildParams.get_outs_paths()
+    assert "child_out" in ChildParams.get_outs_paths()
+
+    # Both should be saveable
+    params = ChildParams()
+    params.parent_out = {"parent": 1}
+    params.child_out = {"child": 2}
+    params._save_outs(tmp_path)
+
+    assert (tmp_path / "parent.json").exists()
+    assert (tmp_path / "child.json").exists()
+
+
+def test_stage_def_child_without_new_deps_inherits_all(tmp_path: pathlib.Path) -> None:
+    """Child StageDef without new deps should still inherit parent's deps."""
+    (tmp_path / "data.csv").write_text("a,b\n1,2\n")
+
+    class ParentParams(stage_def.StageDef):
+        data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("data.csv", loaders.CSV())
+
+    class ChildParams(ParentParams):
+        # No new deps, just a new param
+        threshold: float = 0.5
+
+    # Child should inherit parent's deps
+    assert "data" in ChildParams.get_deps_paths()
+
+    # Should be loadable
+    params = ChildParams()
+    params._load_deps(tmp_path)
+    assert isinstance(params.data, pandas.DataFrame)

--- a/tests/test_stage_def_pickle.py
+++ b/tests/test_stage_def_pickle.py
@@ -1,0 +1,111 @@
+# pyright: reportPrivateUsage=false
+"""Tests for StageDef pickling - critical for multiprocessing execution.
+
+These tests verify that StageDef instances can be pickled and unpickled,
+which is required for multiprocessing workers to receive stage params.
+"""
+
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+import pandas  # noqa: TC002 - needed at runtime for type annotation
+
+from pivot import loaders, stage_def  # noqa: TC001 - needed at runtime for Dep/Out descriptors
+
+# ==============================================================================
+# Module-level StageDef classes (required for pickling)
+# ==============================================================================
+
+
+class SimpleParams(stage_def.StageDef):
+    """StageDef with only params, no deps/outs."""
+
+    threshold: float = 0.5
+    name: str = "test"
+
+
+class ParamsWithDeps(stage_def.StageDef):
+    """StageDef with deps."""
+
+    threshold: float = 0.5
+    data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
+
+
+class ParamsWithOuts(stage_def.StageDef):
+    """StageDef with outs."""
+
+    threshold: float = 0.5
+    result: stage_def.Out[dict[str, Any]] = stage_def.Out("output.json", loaders.JSON())
+
+
+class ParamsWithDepsAndOuts(stage_def.StageDef):
+    """StageDef with both deps and outs."""
+
+    threshold: float = 0.5
+    data: stage_def.Dep[pandas.DataFrame] = stage_def.Dep("input.csv", loaders.CSV())
+    result: stage_def.Out[dict[str, Any]] = stage_def.Out("output.json", loaders.JSON())
+
+
+# ==============================================================================
+# Pickle tests
+# ==============================================================================
+
+
+def test_simple_params_is_picklable() -> None:
+    """StageDef with only params should be picklable."""
+    params = SimpleParams(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert restored.threshold == 0.7
+    assert restored.name == "test"
+
+
+def test_params_with_deps_is_picklable() -> None:
+    """StageDef with deps should be picklable."""
+    params = ParamsWithDeps(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert restored.threshold == 0.7
+    # The deps specs should still be accessible after unpickling
+    assert "data" in restored._deps_specs
+    assert restored._deps_specs["data"].path == "input.csv"
+
+
+def test_params_with_outs_is_picklable() -> None:
+    """StageDef with outs should be picklable."""
+    params = ParamsWithOuts(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert restored.threshold == 0.7
+    # The outs specs should still be accessible after unpickling
+    assert "result" in restored._outs_specs
+    assert restored._outs_specs["result"].path == "output.json"
+
+
+def test_params_with_deps_and_outs_is_picklable() -> None:
+    """StageDef with both deps and outs should be picklable."""
+    params = ParamsWithDepsAndOuts(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert restored.threshold == 0.7
+    # Both deps and outs specs should be accessible after unpickling
+    assert "data" in restored._deps_specs
+    assert "result" in restored._outs_specs
+    assert restored._deps_specs["data"].path == "input.csv"
+    assert restored._outs_specs["result"].path == "output.json"
+
+
+def test_pickle_roundtrip_preserves_class_identity() -> None:
+    """Unpickled instance should be same class type."""
+    params = ParamsWithDeps(threshold=0.7)
+    pickled = pickle.dumps(params)
+    restored = pickle.loads(pickled)
+
+    assert type(restored) is ParamsWithDeps
+    assert isinstance(restored, stage_def.StageDef)


### PR DESCRIPTION
## Summary

- Replace nested `class deps:`/`class outs:` syntax with `Dep[T]`/`Out[T]` descriptors
- Provides proper type inference when accessing loaded dependencies and outputs
- Override `model_dump()` to exclude descriptor fields from JSON serialization
- Add `output_queue` fixture to reduce executor test boilerplate
- Delete exploratory `type_safety_final.py` file

## Example

```python
class ProcessParams(StageDef):
    data: Dep[pandas.DataFrame] = Dep("input.csv", loaders.CSV())
    result: Out[dict[str, int]] = Out("output.json", loaders.JSON())
    threshold: float = 0.5

@stage()
def process(params: ProcessParams) -> None:
    df = params.data  # Type: pandas.DataFrame (inferred!)
    params.result = {"count": len(df)}  # Type-checked assignment
```

## Test plan

- [x] All 2258 tests pass
- [x] Type checking clean with basedpyright
- [x] Added pickle tests for StageDef classes
- [x] Added CLI integration test for end-to-end StageDef usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)