### PR TITLE
docs: add lock schema versioning and multi-process safety documentation

### DIFF
--- a/src/pivot/storage/lock.py
+++ b/src/pivot/storage/lock.py
@@ -92,6 +92,7 @@ def _convert_to_storage_format(data: LockData) -> StorageLockData:
     outs_list.sort(key=lambda e: e["path"])
 
     return StorageLockData(
+        schema_version=1,
         code_manifest=data["code_manifest"],
         params=data["params"],
         deps=deps_list,

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -175,6 +175,8 @@ class OutEntry(TypedDict):
 class StorageLockData(TypedDict):
     """Storage format for lock files (list-based, relative paths)."""
 
+    # Schema version for forward compatibility (missing = v0, current = v1)
+    schema_version: NotRequired[int]
     code_manifest: dict[str, str]
     params: dict[str, Any]
     deps: list[DepEntry]


### PR DESCRIPTION
## Summary
- Add `schema_version` field to `StorageLockData` for future lock file migrations
- Document concurrent `pivot run` safety in `docs/architecture/execution.md`
- Update `StateDB` docstring to explain the multi-process MVCC model

## Context
Part of roadmap review from #165. These changes address:
1. **Lock schema versioning** - Enables safe future schema evolution (missing = v0, current = v1)
2. **Multi-process safety documentation** - Documents that concurrent `pivot run` invocations are safe and supported

## Test plan
- [x] All 260 storage tests pass
- [x] Type checker: 0 errors, 0 warnings
- [x] Linter: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)