### PR TITLE
fix(tests): clear linecache in fingerprint tests to fix local failures

### DIFF
--- a/tests/fingerprint/test_change_detection.py
+++ b/tests/fingerprint/test_change_detection.py
@@ -1,4 +1,5 @@
 import importlib
+import linecache
 import pathlib
 import sys
 import types
@@ -42,6 +43,7 @@ def _import_fresh(name: str) -> types.ModuleType:
     """Import module fresh, clearing any cached version."""
     if name in sys.modules:
         del sys.modules[name]
+    linecache.clearcache()  # Clear cached source (inspect.getsource uses linecache)
     importlib.invalidate_caches()
     return importlib.import_module(name)
 


### PR DESCRIPTION
## Summary
- Add `linecache.clearcache()` to `_import_fresh()` test helper
- Fixes 5 fingerprint change detection tests that failed locally but passed in CI

## Problem
The `_import_fresh()` test helper was missing `linecache.clearcache()`, causing `inspect.getsource()` to return stale cached source after modifying test module files.

Tests affected:
- `test_function_body_change_causes_miss`
- `test_default_value_change_causes_miss`
- `test_helper_via_direct_import_change_causes_miss`
- `test_helper_via_module_attr_change_causes_miss`
- `test_variable_rename_causes_miss`

## Solution
Add `linecache.clearcache()` before `importlib.invalidate_caches()` in the test helper, aligning it with production code in `watch/engine.py:_invalidate_caches()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)