### PR TITLE
Fix aiohttp ClientResponse.read() API for streaming downloads

### DIFF
--- a/src/pivot/remote/storage.py
+++ b/src/pivot/remote/storage.py
@@ -150,7 +150,7 @@ async def _stream_download_to_fd(
     async with response["Body"] as stream:
         while True:
             chunk: bytes = await asyncio.wait_for(
-                stream.read(STREAM_CHUNK_SIZE),
+                stream.content.read(STREAM_CHUNK_SIZE),
                 timeout=STREAM_READ_TIMEOUT,
             )
             if not chunk:


### PR DESCRIPTION
## Overview

Fixes S3 streaming downloads failing with newer aiohttp versions.

**Issue:** N/A (discovered during usage)

## Root Cause

When streaming from S3, the code enters an async context manager for `response["Body"]`:

```python
async with response["Body"] as stream:
    chunk = await stream.read(STREAM_CHUNK_SIZE)
```

The `response["Body"]` is aiobotocore's `StreamingBody` wrapper, which has a `read(amt)` method that correctly uses `self.__wrapped__.content.read()` internally. However, `StreamingBody.__aenter__` returns the **unwrapped** `aiohttp.ClientResponse`:

```python
async def __aenter__(self):
    return await self.__wrapped__.__aenter__()  # Returns raw aiohttp.ClientResponse!
```

So after entering the context manager, `stream` is the raw `aiohttp.ClientResponse`, not the wrapper. `ClientResponse.read()` reads the entire body and does not accept a size argument—`content.read(size)` is the correct API for chunked reads.

## Fix

Change `stream.read(STREAM_CHUNK_SIZE)` → `stream.content.read(STREAM_CHUNK_SIZE)` to use the `StreamReader` which properly supports chunked reads.

This is **backwards compatible**—`ClientResponse.content` (a `StreamReader`) with `.read(size)` has been the standard aiohttp API since at least v3.9.2 (the minimum version aiobotocore supports). The original code was always using the wrong API; it may have worked in older versions due to different error handling behavior.

## Testing & Validation

- [x] Covered by automated tests (updated mocks to match new API)
- [x] Manual testing: Verified `pivot pull` works

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added or updated

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>