### PR TITLE
feat: persistent AST hash caching for faster fingerprinting

### DIFF
--- a/src/pivot/cli/history.py
+++ b/src/pivot/cli/history.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from pivot import project
+from pivot import config
 from pivot.cli import decorators as cli_decorators
 from pivot.cli import helpers as cli_helpers
 from pivot.storage import state
@@ -24,7 +24,7 @@ def history(ctx: click.Context, limit: int, output_json: bool) -> None:
     cli_ctx = cli_helpers.get_cli_context(ctx)
     quiet = cli_ctx["quiet"]
 
-    state_db_path = project.get_project_root() / ".pivot" / "state.db"
+    state_db_path = config.get_state_db_path()
 
     with state.StateDB(state_db_path) as state_db:
         runs = state_db.list_runs(limit=limit)
@@ -72,7 +72,7 @@ def show_cmd(ctx: click.Context, run_id: str | None, output_json: bool) -> None:
     cli_ctx = cli_helpers.get_cli_context(ctx)
     quiet = cli_ctx["quiet"]
 
-    state_db_path = project.get_project_root() / ".pivot" / "state.db"
+    state_db_path = config.get_state_db_path()
 
     with state.StateDB(state_db_path) as state_db:
         if run_id:

--- a/src/pivot/cli/remote.py
+++ b/src/pivot/cli/remote.py
@@ -78,7 +78,7 @@ def push(
             click.echo(f"Would push {len(local_hashes)} file(s) to '{resolved_name}'")
         return
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(config.get_state_db_path()) as state_db:
         result = transfer.push(
             cache_dir,
             state_dir,
@@ -147,7 +147,7 @@ def pull(
             click.echo(f"Would pull {len(missing)} file(s) from '{resolved_name}'")
         return
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(config.get_state_db_path()) as state_db:
         result = transfer.pull(
             cache_dir,
             state_dir,

--- a/src/pivot/config/__init__.py
+++ b/src/pivot/config/__init__.py
@@ -14,6 +14,7 @@ from pivot.config.io import get_remote_connect_timeout as get_remote_connect_tim
 from pivot.config.io import get_remote_jobs as get_remote_jobs
 from pivot.config.io import get_remote_retries as get_remote_retries
 from pivot.config.io import get_run_history_retention as get_run_history_retention
+from pivot.config.io import get_state_db_path as get_state_db_path
 from pivot.config.io import get_state_dir as get_state_dir
 from pivot.config.io import get_watch_debounce as get_watch_debounce
 from pivot.config.io import load_config_file as load_config_file

--- a/src/pivot/config/io.py
+++ b/src/pivot/config/io.py
@@ -316,6 +316,11 @@ def get_state_dir() -> pathlib.Path:
     return state_dir
 
 
+def get_state_db_path() -> pathlib.Path:
+    """Get path to the StateDB LMDB database."""
+    return get_state_dir() / "state.db"
+
+
 def get_max_workers() -> int:
     """Get max workers from merged config."""
     merged = get_merged_config()

--- a/src/pivot/discovery.py
+++ b/src/pivot/discovery.py
@@ -4,7 +4,7 @@ import logging
 import runpy
 from typing import TYPE_CHECKING
 
-from pivot import metrics, project, registry
+from pivot import fingerprint, metrics, project, registry
 from pivot.pipeline import yaml as pipeline_config
 
 if TYPE_CHECKING:
@@ -75,6 +75,9 @@ def discover_and_register(project_root: Path | None = None) -> str | None:
                 raise DiscoveryError(f"Pipeline {pipeline_path} called sys.exit({e.code})") from e
             except Exception as e:
                 raise DiscoveryError(f"Failed to load {pipeline_path}: {e}") from e
+            finally:
+                # Flush pending AST hash writes even if registration failed partway
+                fingerprint.flush_ast_hash_cache()
 
         return None
 

--- a/src/pivot/executor/commit.py
+++ b/src/pivot/executor/commit.py
@@ -25,10 +25,9 @@ def commit_pending() -> list[str]:
         return []
 
     state_dir = config.get_state_dir()
-    state_db_path = state_dir / "state.db"
     committed = list[str]()
 
-    with state_mod.StateDB(state_db_path) as state_db:
+    with state_mod.StateDB(config.get_state_db_path()) as state_db:
         for stage_name in pending_stages:
             pending_lock = lock.get_pending_lock(stage_name, project_root)
             pending_data = pending_lock.read()

--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -549,10 +549,9 @@ def _verify_tracked_files(project_root: pathlib.Path, checkout_missing: bool = F
 
     with metrics.timed("core.verify_tracked_files"):
         missing = list[str]()
-        state_db_path = config.get_state_dir() / "state.db"
         cache_dir = config.get_cache_dir() / "files"
 
-        with state_mod.StateDB(state_db_path) as state_db:
+        with state_mod.StateDB(config.get_state_db_path()) as state_db:
             for data_path, track_data in tracked_files.items():
                 path = pathlib.Path(data_path)
 
@@ -661,7 +660,7 @@ def _execute_greedy(
     assert output_queue is not None
 
     state_dir = config.get_state_dir()
-    state_db_path = state_dir / "state.db"
+    state_db_path = config.get_state_db_path()
     proj_root = project.get_project_root()
     output_thread: threading.Thread | None = None
 
@@ -1207,7 +1206,6 @@ def _write_run_history(
         stages=stages_records,
     )
 
-    state_db_path = config.get_state_dir() / "state.db"
-    with state_mod.StateDB(state_db_path) as state_db:
+    with state_mod.StateDB(config.get_state_db_path()) as state_db:
         state_db.write_run(manifest)
         state_db.prune_runs(retention)

--- a/src/pivot/fingerprint.py
+++ b/src/pivot/fingerprint.py
@@ -1,9 +1,11 @@
 import ast
+import atexit
 import contextlib
 import dataclasses
 import functools
 import inspect
 import json
+import logging
 import marshal
 import pathlib
 import sys
@@ -19,6 +21,9 @@ from pivot import ast_utils, metrics
 
 if TYPE_CHECKING:
     from pivot import loaders
+    from pivot.storage.state import StateDB
+
+_logger = logging.getLogger(__name__)
 
 _SITE_PACKAGE_PATHS = ("site-packages", "dist-packages")
 
@@ -45,6 +50,94 @@ _is_user_code_cache: weakref.WeakKeyDictionary[object, bool] = weakref.WeakKeyDi
 _get_type_hints_cache: weakref.WeakKeyDictionary[Callable[..., Any], dict[str, Any]] = (
     weakref.WeakKeyDictionary()
 )
+
+# Module-level state for persistent AST hash caching.
+# Fingerprinting happens during discovery (single-threaded in coordinator process).
+# Workers (via ProcessPoolExecutor) have their own memory space and don't share this
+# state - any pending writes in workers are lost, which is fine since workers use
+# readonly StateDB and fingerprinting should complete during discovery.
+_state_db: "StateDB | None" = None
+_state_db_init_attempted: bool = False
+_pending_ast_writes: list[tuple[str, int, int, int, str, str]] = []
+
+
+def _close_state_db() -> None:
+    """Close the readonly StateDB on process exit."""
+    global _state_db
+    if _state_db is not None:
+        _state_db.close()
+        _state_db = None
+
+
+atexit.register(_close_state_db)
+
+
+def _get_state_db() -> "StateDB | None":
+    """Get readonly StateDB for fingerprint caching (graceful degradation).
+
+    Not thread-safe, but fingerprinting runs single-threaded per process
+    (see comment at line 33). Workers use separate memory spaces.
+    """
+    global _state_db, _state_db_init_attempted
+    if _state_db is not None:
+        return _state_db
+    if _state_db_init_attempted:
+        return None  # Already tried and failed
+    _state_db_init_attempted = True
+    try:
+        from pivot.config import io
+        from pivot.storage import state
+
+        _state_db = state.StateDB(io.get_state_db_path(), readonly=True)
+        return _state_db
+    except Exception:
+        # OSError (filesystem), ImportError (module), lmdb.Error, etc.
+        return None
+
+
+def _get_func_source_info(func: Callable[..., Any]) -> tuple[str, int, int, int] | None:
+    """Get (rel_path, mtime_ns, size, inode) for function source file.
+
+    Returns None if source info unavailable (builtins, exec'd code, outside project).
+    """
+    try:
+        file = inspect.getsourcefile(func)
+        if file is None:
+            return None
+        path = pathlib.Path(file).resolve()
+        stat = path.stat()
+        from pivot import project
+
+        project_root = project.get_project_root()
+        rel_path = str(path.relative_to(project_root))
+        return (rel_path, stat.st_mtime_ns, stat.st_size, stat.st_ino)
+    except (TypeError, OSError, ValueError):
+        # TypeError: builtins, exec'd
+        # OSError: file doesn't exist
+        # ValueError: path outside project root
+        return None
+
+
+def flush_ast_hash_cache() -> None:
+    """Flush pending AST hash writes to StateDB (call from coordinator)."""
+    global _pending_ast_writes
+    if not _pending_ast_writes:
+        return
+
+    pending = _pending_ast_writes
+    _pending_ast_writes = []
+
+    try:
+        from pivot.config import io
+        from pivot.storage import state
+
+        with state.StateDB(io.get_state_db_path(), readonly=False) as db:
+            db.save_ast_hash_many(pending)
+        metrics.count("fingerprint.ast_hash_cache.flush")
+    except Exception:
+        # OSError (filesystem), ImportError (module), lmdb.Error, etc.
+        # Log but don't fail - cache is a performance optimization, not critical
+        _logger.debug("Failed to flush AST hash cache (%d entries)", len(pending), exc_info=True)
 
 
 def get_stage_fingerprint(
@@ -406,8 +499,24 @@ def _process_module_dependency(
             manifest[key] = repr(attr_value)
 
 
+def _should_skip_persistent_cache(func: Callable[..., Any]) -> bool:
+    """Check if function should skip persistent cache.
+
+    Skip for:
+    - Closures: `<locals>` in qualname → qualname collision risk
+    - Wrapped functions: has `__wrapped__` → source file mismatch risk
+    """
+    qualname = getattr(func, "__qualname__", "")
+    if "<locals>" in qualname:
+        return True
+    return hasattr(func, "__wrapped__")
+
+
 def hash_function_ast(func: Callable[..., Any]) -> str:
     """Hash function AST (ignores whitespace, comments, docstrings).
+
+    Uses persistent cache in StateDB when available, keyed by
+    (file_path, mtime_ns, size, inode, qualname) for automatic invalidation.
 
     Limitation: Lambdas and functions without source code fall back to id(func),
     which is non-deterministic across runs. This causes unnecessary re-runs for
@@ -415,17 +524,58 @@ def hash_function_ast(func: Callable[..., Any]) -> str:
     pipeline stages for stable fingerprinting.
     """
     with metrics.timed("fingerprint.hash_function_ast"):
+        # 1. Check in-memory WeakKeyDictionary cache first (fastest)
         # WeakKeyDictionary raises TypeError for non-weakly-referenceable functions (builtins)
         try:
             cached = _hash_function_ast_cache.get(func)
             if cached is not None:
-                metrics.count("fingerprint.hash_function_ast.cache_hit")
+                metrics.count("fingerprint.hash_function_ast.memory_cache_hit")
                 return cached
-            result = _compute_function_hash(func)
-            _hash_function_ast_cache[func] = result
-            return result
         except TypeError:
+            # Not weakly referenceable (builtins), compute directly
             return _compute_function_hash(func)
+
+        # 2. Check persistent cache if appropriate
+        source_info: tuple[str, int, int, int] | None = None
+        qualname: str | None = None
+
+        if not _should_skip_persistent_cache(func):
+            source_info = _get_func_source_info(func)
+            if source_info is not None:
+                qualname = getattr(func, "__qualname__", None) or getattr(func, "__name__", None)
+                if qualname is None:
+                    raise RuntimeError(
+                        f"Cannot fingerprint {func!r}: missing __qualname__ and __name__. This indicates a bug in pivot's fingerprinting logic."
+                    )
+                db = _get_state_db()
+                if db is not None:
+                    rel_path, mtime_ns, size, inode = source_info
+                    try:
+                        persistent_cached = db.get_ast_hash(
+                            rel_path, mtime_ns, size, inode, qualname
+                        )
+                        if persistent_cached is not None:
+                            metrics.count("fingerprint.hash_function_ast.persistent_cache_hit")
+                            # Store in memory cache too
+                            _hash_function_ast_cache[func] = persistent_cached
+                            return persistent_cached
+                    except Exception:
+                        # LMDB errors shouldn't break fingerprinting
+                        pass
+
+        # 3. Compute hash
+        result = _compute_function_hash(func)
+
+        # 4. Store in memory cache
+        _hash_function_ast_cache[func] = result
+
+        # 5. Queue persistent write (if source info available and not skipping)
+        if source_info is not None and qualname is not None:
+            rel_path, mtime_ns, size, inode = source_info
+            _pending_ast_writes.append((rel_path, mtime_ns, size, inode, qualname, result))
+            metrics.count("fingerprint.hash_function_ast.persistent_cache_miss")
+
+        return result
 
 
 def _compute_function_hash(func: Callable[..., Any]) -> str:

--- a/src/pivot/pipeline/yaml.py
+++ b/src/pivot/pipeline/yaml.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Annotated, Any, TypedDict, TypeVar
 import pydantic
 import yaml
 
-from pivot import outputs, parameters, path_policy, registry, stage_def, yaml_config
+from pivot import fingerprint, outputs, parameters, path_policy, registry, stage_def, yaml_config
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -179,6 +179,9 @@ def register_from_pipeline_file(pipeline_file: Path) -> None:
 
     for stage_name, stage_config in pipeline.stages.items():
         _register_stage(stage_name, stage_config, global_vars)
+
+    # Flush pending AST hash writes to persistent cache
+    fingerprint.flush_ast_hash_cache()
 
 
 def _register_stage(

--- a/src/pivot/status.py
+++ b/src/pivot/status.py
@@ -191,7 +191,7 @@ def get_remote_status(
     if not local_hashes:
         return RemoteSyncInfo(name=resolved_name, url=url, push_count=0, pull_count=0)
 
-    with state_mod.StateDB(config.get_state_dir() / "state.db") as state_db:
+    with state_mod.StateDB(config.get_state_db_path()) as state_db:
         status = asyncio.run(
             transfer.compare_status(local_hashes, s3_remote, state_db, resolved_name)
         )


### PR DESCRIPTION
## Summary

Cache computed AST hashes in StateDB keyed by `(file_path, mtime_ns, size, inode, qualname)`. This avoids re-parsing source files that haven't changed across pipeline runs, improving fingerprinting performance.

## Changes

- Add `get_ast_hash`/`save_ast_hash_many` to StateDB for persistent storage
- Add `_should_skip_persistent_cache()` to skip closures and wrapped functions (cache key collision risk)
- Flush pending writes after stage registration via `flush_ast_hash_cache()`
- Graceful degradation: cache misses just recompute (no failures)

## Design Notes

- **Single-threaded**: Fingerprinting runs in the coordinator process during discovery
- **Workers isolated**: Worker processes have separate memory; pending writes there are lost (by design - workers use readonly StateDB)
- **Graceful failure**: If DB fails to open, fingerprinting continues without caching

## Test plan

- [x] All existing tests pass (2522 passed)
- [x] New tests for cache roundtrip, key invalidation, and edge cases
- [x] Type checking passes (basedpyright: 0 errors)

🤖 Generated with [Claude Code](https://claude.ai/code)