### PR TITLE
chore: add type stub for loky.process_executor

### DIFF
--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -21,7 +21,7 @@ from typing import (
 
 import filelock
 import loky
-import loky.process_executor  # pyright: ignore[reportMissingTypeStubs]
+import loky.process_executor
 import rich.markup
 import textual  # for textual.work decorator
 import textual.app

--- a/typings/loky/process_executor.pyi
+++ b/typings/loky/process_executor.pyi
@@ -1,0 +1,5 @@
+"""Type stubs for loky.process_executor internals."""
+
+def _python_exit() -> None:
+    """Atexit handler that waits for worker threads to finish."""
+    ...


### PR DESCRIPTION
## Summary

- Add type stub for `loky.process_executor` module
- Remove `# pyright: ignore[reportMissingTypeStubs]` comment from import

This follows the project's pattern of maintaining minimal type stubs in `typings/` for packages without official stubs, rather than using inline ignore comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)