### PR TITLE
feat(cli): add shell completion for config keys

### DIFF
--- a/src/pivot/cli/config.py
+++ b/src/pivot/cli/config.py
@@ -5,6 +5,7 @@ import click
 import pydantic
 
 from pivot import config, exceptions
+from pivot.cli import completion
 
 
 def _format_value(value: Any) -> str:
@@ -73,7 +74,7 @@ def config_list(use_global: bool, use_local: bool, output_json: bool) -> None:
 
 
 @config_cmd.command("get")
-@click.argument("key")
+@click.argument("key", shell_complete=completion.complete_config_keys)
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def config_get(key: str, output_json: bool) -> None:
     """Get a configuration value by dotted key."""
@@ -90,7 +91,7 @@ def config_get(key: str, output_json: bool) -> None:
 
 
 @config_cmd.command("set")
-@click.argument("key")
+@click.argument("key", shell_complete=completion.complete_config_keys)
 @click.argument("value")
 @click.option("--global", "use_global", is_flag=True, help="Set in global config")
 def config_set(key: str, value: str, use_global: bool) -> None:
@@ -109,7 +110,7 @@ def config_set(key: str, value: str, use_global: bool) -> None:
 
 
 @config_cmd.command("unset")
-@click.argument("key")
+@click.argument("key", shell_complete=completion.complete_config_keys)
 @click.option("--global", "use_global", is_flag=True, help="Unset from global config")
 def config_unset(key: str, use_global: bool) -> None:
     """Remove a configuration value (reverts to default or inherited value)."""

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,3 +1,4 @@
+import pydantic
 import pytest
 
 from pivot import config, exceptions
@@ -51,6 +52,19 @@ def test_config_defaults_has_remotes_section() -> None:
 def test_config_defaults_has_default_remote() -> None:
     defaults = config.PivotConfig.get_default()
     assert defaults.default_remote == ""
+
+
+def test_pivot_config_rejects_invalid_remote_name() -> None:
+    """PivotConfig Pydantic validator rejects invalid remote names."""
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        config.PivotConfig(remotes={"has space": "s3://bucket"})
+    assert "invalid remote name" in str(exc_info.value).lower()
+
+
+def test_pivot_config_accepts_valid_remote_names() -> None:
+    """PivotConfig Pydantic validator accepts valid remote names."""
+    cfg = config.PivotConfig(remotes={"my-remote": "s3://bucket", "my_remote": "s3://bucket2"})
+    assert cfg.remotes == {"my-remote": "s3://bucket", "my_remote": "s3://bucket2"}
 
 
 # --- validate_config_value tests ---
@@ -218,6 +232,26 @@ def test_validate_remotes_rejects_invalid_url() -> None:
 def test_validate_remotes_rejects_http_url() -> None:
     with pytest.raises(exceptions.ConfigValidationError):
         config.validate_config_value("remotes.origin", "http://example.com")
+
+
+def test_validate_remotes_rejects_invalid_remote_name_with_dot() -> None:
+    # A dot in the remote name creates a 3-part key, which is invalid
+    with pytest.raises(exceptions.ConfigValidationError):
+        config.validate_config_value("remotes.has.dot", "s3://bucket")
+
+
+def test_validate_remotes_rejects_invalid_remote_name_with_space() -> None:
+    with pytest.raises(exceptions.ConfigValidationError) as exc_info:
+        config.validate_config_value("remotes.has space", "s3://bucket")
+    assert "invalid remote name" in str(exc_info.value).lower()
+
+
+def test_validate_remotes_accepts_valid_remote_names() -> None:
+    # alphanumeric, hyphens, underscores are valid
+    assert config.validate_config_value("remotes.origin", "s3://bucket") == "s3://bucket"
+    assert config.validate_config_value("remotes.my-remote", "s3://bucket") == "s3://bucket"
+    assert config.validate_config_value("remotes.my_remote", "s3://bucket") == "s3://bucket"
+    assert config.validate_config_value("remotes.Remote123", "s3://bucket") == "s3://bucket"
 
 
 def test_validate_default_remote_accepts_string() -> None:


### PR DESCRIPTION
## Summary

Add tab completion for config keys in `pivot config get`, `pivot config set`, and `pivot config unset` commands.

- Complete static config keys with descriptions (cache.dir, core.max_workers, etc.)
- Dynamically discover remote names from global and local config files
- Add remote name validation (alphanumeric, hyphens, underscores only)
- Consolidate `CONFIG_KEY_DESCRIPTIONS` as single source of truth in models.py
- Add Pydantic validation for remote names in `PivotConfig`

## Test plan

- [x] All existing tests pass (2434 passed)
- [x] New tests for config key completion
- [x] New tests for remote name validation

Closes #173

🤖 Generated with [Claude Code](https://claude.ai/code)