### PR TITLE
fix(cli): allow verify --allow-missing when dep files don't exist

### DIFF
--- a/src/pivot/cli/helpers.py
+++ b/src/pivot/cli/helpers.py
@@ -52,8 +52,7 @@ def validate_stages_exist(stages: list[str] | None) -> None:
     """Validate that specified stages exist in the registry."""
     if not stages:
         return
-    graph = registry.REGISTRY.build_dag(validate=True)
-    registered = set(graph.nodes())
+    registered = set(registry.REGISTRY.list_stages())
     unknown = [s for s in stages if s not in registered]
     if unknown:
         raise exceptions.StageNotFoundError(unknown, available_stages=list(registered))

--- a/src/pivot/cli/verify.py
+++ b/src/pivot/cli/verify.py
@@ -242,7 +242,11 @@ def verify(
     cache_dir = config.get_cache_dir()
 
     # Get pipeline status (uses default state directory internally)
-    pipeline_status, _ = status_mod.get_pipeline_status(stages_list, single_stage=False)
+    # When allow_missing is set, skip DAG validation so missing dependency files
+    # don't cause DependencyNotFoundError before we can check the remote
+    pipeline_status, _ = status_mod.get_pipeline_status(
+        stages_list, single_stage=False, validate=not allow_missing
+    )
 
     if not pipeline_status:
         raise click.ClickException("No stages to verify.")

--- a/src/pivot/status.py
+++ b/src/pivot/status.py
@@ -164,10 +164,18 @@ def _compute_explanations_with_upstream(
 def get_pipeline_status(
     stages: list[str] | None,
     single_stage: bool,
+    validate: bool = True,
 ) -> tuple[list[PipelineStatusInfo], DiGraph[str]]:
-    """Get status for all stages, tracking upstream staleness."""
+    """Get status for all stages, tracking upstream staleness.
+
+    Args:
+        stages: Stage names to check, or None for all stages.
+        single_stage: If True, check only specified stages without dependencies.
+        validate: If True, validate dependency files exist during DAG building.
+            Set to False with --allow-missing to skip validation.
+    """
     with metrics.timed("status.get_pipeline_status"):
-        graph = registry.REGISTRY.build_dag(validate=True)
+        graph = registry.REGISTRY.build_dag(validate=validate)
         execution_order = dag.get_execution_order(graph, stages, single_stage=single_stage)
 
         if not execution_order:


### PR DESCRIPTION
## Summary
- Skip DAG validation when `--allow-missing` is set so `DependencyNotFoundError` isn't raised before the allow-missing logic can check the remote
- Adds `validate` parameter to `get_pipeline_status()` and passes `validate=not allow_missing` from verify command
- Fixes CI use case where dep files may not exist yet during verification

## Test plan
- [x] All existing verify tests pass
- [x] New test `test_verify_allow_missing_without_prior_run` verifies the fix
- [x] Quality checks pass (ruff format, ruff check, basedpyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)