### PR TITLE
feat(cli): allow checkout to accept .pvt file paths

### DIFF
--- a/src/pivot/cli/checkout.py
+++ b/src/pivot/cli/checkout.py
@@ -123,6 +123,11 @@ def _checkout_target(
     if track.has_path_traversal(target):
         raise click.ClickException(f"Path traversal not allowed: {target}")
 
+    # Convert .pvt file paths to their corresponding data paths
+    target_path = pathlib.Path(target)
+    if target_path.suffix == ".pvt":
+        target = str(track.get_data_path(target_path))
+
     # Use normalized path (preserve symlinks) to match keys in tracked_files/stage_outputs
     abs_path = project.normalize_path(target)
     abs_path_str = str(abs_path)


### PR DESCRIPTION
## Summary
- `pivot checkout` now accepts `.pvt` manifest file paths in addition to data file paths and stage names
- When given a `.pvt` path (e.g., `data.csv.pvt`), it restores the corresponding data file (`data.csv`)
- Uses pathlib's suffix check to handle edge cases like dotfiles correctly

## Test plan
- [x] New test `test_checkout_accepts_pvt_file_path` verifies the behavior
- [x] All existing checkout tests pass (16 total)
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)