### PR TITLE
fix(fingerprint): resolve symlinks in stdlib path detection

### DIFF
--- a/tests/fingerprint/test_fingerprint.py
+++ b/tests/fingerprint/test_fingerprint.py
@@ -523,6 +523,22 @@ def test_is_user_code_non_callable():
         pass  # Acceptable to raise error
 
 
+def test_is_user_code_stdlib_via_symlink() -> None:
+    """Should identify stdlib as non-user code even when sys.prefix is a symlink.
+
+    On homebrew macOS, sys.base_prefix is a symlink:
+    - sys.base_prefix = /opt/homebrew/opt/python@3.13/... (symlink)
+    - Actual stdlib at /opt/homebrew/Cellar/python@3.13/... (resolved)
+
+    The _is_stdlib_path check must resolve symlinks to correctly identify stdlib.
+    """
+    import math
+
+    # math module should be identified as NOT user code
+    assert fingerprint.is_user_code(math) is False
+    assert fingerprint.is_user_code(math.ceil) is False
+
+
 # --- extract_module_attr_usage tests ---
 
 


### PR DESCRIPTION
## Summary
- Fix `_is_stdlib_path()` to resolve symlinks before comparing paths
- On homebrew macOS, `sys.prefix`/`sys.base_prefix` are symlinks while `module.__file__` paths are resolved
- This caused stdlib modules (math, collections, hashlib, bisect) to be incorrectly classified as user code, leading to non-deterministic fingerprints and unnecessary pipeline re-runs

## Test Plan
- [x] Added `test_is_user_code_stdlib_via_symlink` - verifies stdlib detection on current system
- [x] Added `test_is_stdlib_path_resolves_symlinks` - explicit symlink scenario with mocked paths
- [x] All fingerprint tests pass (182 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)