### PR TITLE
fix(fingerprint): resolve stdlib paths for symlink-safe comparison

### DIFF
--- a/docs/plans/2026-01-30-symlink-fingerprint-fix-design.md
+++ b/docs/plans/2026-01-30-symlink-fingerprint-fix-design.md
@@ -1,0 +1,21 @@
+# Symlink Fingerprinting Fix Design
+
+## Problem
+
+On macOS with Homebrew Python (and similar setups where Python's installation path contains symlinks), stdlib modules are incorrectly classified as user code. This causes fingerprints to include stdlib functions that should be excluded.
+
+**Root cause:** In `_is_stdlib_path()`, the `module_file` parameter is fully resolved (symlinks followed), but `sys.prefix` and `sys.base_prefix` are used without resolution. When comparing paths, a resolved path won't match an unresolved parent containing symlinks.
+
+## Solution
+
+Add `_init_stdlib_paths()` function that:
+1. Resolves `sys.prefix` and `sys.base_prefix` for symlink-safe comparison
+2. Handles `OSError` gracefully (falls back to unresolved path)
+3. Deduplicates paths when not in a venv (`sys.prefix == sys.base_prefix`)
+4. Returns an immutable tuple for consistency with `_SITE_PACKAGE_PATHS`
+
+Update `_is_stdlib_path()` to use the cached `_STDLIB_PATHS` constant.
+
+## Testing
+
+Existing test coverage validates stdlib detection (`test_google_style.py:46`). All 106 fingerprint-related tests pass.


### PR DESCRIPTION
## Summary

On macOS with Homebrew Python (and similar setups where Python is installed via symlinks), stdlib modules were incorrectly classified as user code in fingerprinting. This caused fingerprints to include stdlib functions that should be excluded.

**Root cause:** `module_file` was resolved (symlinks followed), but `sys.prefix` and `sys.base_prefix` were used without resolution. Path comparison failed when one was resolved and the other wasn't.

**Fix:** Add `_init_stdlib_paths()` function that:
- Resolves `sys.prefix` and `sys.base_prefix` for consistent comparison
- Handles `OSError` gracefully with fallback to unresolved path
- Deduplicates when not in a venv (`sys.prefix == sys.base_prefix`)
- Returns immutable tuple for consistency with `_SITE_PACKAGE_PATHS`

## Test plan

- [x] All 106 fingerprint-related tests pass
- [x] `test_google_style.py` validates stdlib detection works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)