### PR TITLE
feat(cli): replace --display flag with --tui (plain by default)

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -64,7 +64,7 @@ pivot run [STAGES...] [OPTIONS]
 | `--force` / `-f` | Force re-run of stages, ignoring cache (in --watch mode, first run only) |
 | `--watch` / `-w` | Watch for file changes and re-run affected stages |
 | `--debounce MS` | Debounce delay in milliseconds (default: 300) |
-| `--display [tui\|plain]` | Display mode: tui (interactive) or plain (streaming text) |
+| `--tui` | Use interactive TUI display (default: plain text) |
 | `--json` | Output results as JSON |
 | `--tui-log PATH` | Write TUI messages to JSONL file for monitoring |
 | `--no-commit` | Defer lock files to pending dir for faster iteration |

--- a/docs/design/watch-engine.md
+++ b/docs/design/watch-engine.md
@@ -174,14 +174,11 @@ Filter all registered stage outputs from watcher to prevent infinite loops.
 ## CLI Usage
 
 ```bash
-# Basic watch mode
+# Plain text output (default)
 pivot run --watch
 
-# With TUI (default when TTY)
-pivot run --watch --display tui
-
-# Plain text output
-pivot run --watch --display plain
+# With TUI
+pivot run --watch --tui
 ```
 
 ## Performance Targets

--- a/docs/tutorial/watch.md
+++ b/docs/tutorial/watch.md
@@ -26,11 +26,11 @@ Pivot will:
 
 ## The TUI
 
-When running in a terminal, watch mode shows an interactive TUI with a two-panel layout:
+For an interactive interface, add the `--tui` flag. This shows a two-panel layout:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  pivot run --watch                                                   │
+│  pivot run --watch --tui                                             │
 ├─────────────────────────────────────────────────────────────────────┤
 │  Stages (2) $2                         │  train $ LIVE              │
 │  ─────────────────────────────────────┼──────────────────────────────│
@@ -123,12 +123,22 @@ Default is 300ms.
 
 > **Note:** Debounce is currently handled by the underlying file watcher (watchfiles). Custom debounce values may not take effect in all situations.
 
-## Plain Text Mode
+## Display Modes
 
-For CI logs or non-TTY environments:
+### Plain Text (Default)
+
+Watch mode outputs plain text by default:
 
 ```bash
-pivot run --watch --display plain
+pivot run --watch
+```
+
+### Interactive TUI
+
+For the interactive TUI with the two-panel layout described above, use the `--tui` flag:
+
+```bash
+pivot run --watch --tui
 ```
 
 ## Best Practices

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -57,7 +57,6 @@ from pivot.tui.widgets import (
 )
 from pivot.tui.widgets import status as status_utils
 from pivot.types import (
-    DisplayMode,
     StageStatus,
     TuiLogMessage,
     TuiMessageType,
@@ -74,7 +73,6 @@ __all__ = [
     "ExecutorComplete",
     "run_with_tui",
     "run_watch_tui",
-    "should_use_tui",
 ]
 
 if TYPE_CHECKING:
@@ -1342,12 +1340,3 @@ def run_watch_tui(
         serve=serve,
     )
     app.run()
-
-
-def should_use_tui(display_mode: DisplayMode | None) -> bool:
-    """Determine if TUI should be used based on display mode and TTY."""
-    if display_mode == DisplayMode.TUI:
-        return True
-    if display_mode == DisplayMode.PLAIN:
-        return False
-    return sys.stdout.isatty()

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -480,13 +480,6 @@ class DataDiffResult(TypedDict):
 #
 
 
-class DisplayMode(enum.StrEnum):
-    """Display mode for pivot run output."""
-
-    TUI = "tui"
-    PLAIN = "plain"
-
-
 class TuiMessageType(enum.StrEnum):
     """Type of TUI message."""
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -101,3 +101,131 @@ def test_run_allow_missing_requires_dry_run(
         assert result.exit_code != 0
         assert "--allow-missing" in result.output
         assert "--dry-run" in result.output
+
+
+# =============================================================================
+# --tui and --json Flag Tests
+# =============================================================================
+
+
+def test_run_tui_and_json_mutually_exclusive(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """--tui and --json are mutually exclusive."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+
+        result = runner.invoke(cli.cli, ["run", "--tui", "--json"])
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+
+def test_run_tui_log_requires_tui(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """--tui-log requires --tui flag."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        register_test_stage(_helper_process, name="process")
+        pathlib.Path("input.txt").write_text("data")
+
+        result = runner.invoke(cli.cli, ["run", "--tui-log", "log.jsonl"])
+
+        assert result.exit_code != 0
+        assert "--tui-log requires --tui" in result.output
+
+
+def test_run_serve_requires_tui(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """--serve requires --tui flag in watch mode."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        register_test_stage(_helper_process, name="process")
+        pathlib.Path("input.txt").write_text("data")
+
+        result = runner.invoke(cli.cli, ["run", "--watch", "--serve"])
+
+        assert result.exit_code != 0
+        assert "--serve requires --tui" in result.output
+
+
+def test_run_help_includes_tui_flag(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """--tui flag appears in help text."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+
+        result = runner.invoke(cli.cli, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "--tui" in result.output
+        # Help text is case-sensitive for "TUI"
+        assert "TUI display" in result.output
+
+
+def test_run_json_flag_accepted(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """--json flag should work without --tui (plain is now default)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        pathlib.Path("input.txt").write_text("data")
+        register_test_stage(_helper_process, name="process")
+
+        result = runner.invoke(cli.cli, ["run", "--json"])
+
+        assert result.exit_code == 0
+        # JSONL output should start with schema version
+        assert '"type": "schema_version"' in result.output
+
+
+def test_run_uses_plain_mode_by_default(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Plain text output is the default (no --tui flag needed)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        pathlib.Path("input.txt").write_text("data")
+        register_test_stage(_helper_process, name="process")
+
+        # Run without any display flags
+        result = runner.invoke(cli.cli, ["run"])
+
+        assert result.exit_code == 0
+        # Plain mode shows stage status in simple text format
+        # (not JSONL format which has "type":)
+        assert '"type":' not in result.output
+        # Should contain stage name in output
+        assert "process" in result.output.lower()
+
+
+def test_run_serve_requires_watch(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+    """--serve requires --watch mode."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        pathlib.Path("input.txt").write_text("data")
+        register_test_stage(_helper_process, name="process")
+
+        result = runner.invoke(cli.cli, ["run", "--serve"])
+
+        assert result.exit_code != 0
+        assert "--serve requires --watch" in result.output
+
+
+def test_run_tui_with_tui_log_validation_passes(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """--tui --tui-log passes validation (log path is writable)."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        pathlib.Path("input.txt").write_text("data")
+        register_test_stage(_helper_process, name="process")
+
+        log_path = tmp_path / "tui.jsonl"
+
+        # This will attempt to run TUI which fails in non-TTY test environment,
+        # but it should NOT fail on validation errors about --tui-log
+        result = runner.invoke(cli.cli, ["run", "--tui", "--tui-log", str(log_path)])
+
+        # Should NOT have validation errors
+        assert "--tui-log requires --tui" not in result.output
+        assert "Cannot write to" not in result.output
+        # The log file should have been created during validation (touch())
+        assert log_path.exists()


### PR DESCRIPTION
## Summary

Replaces the `--display [tui|plain]` flag with separate `--tui` and `--json` flags. Plain text output becomes the default.

**New behavior:**
| Command | Output |
|---------|--------|
| `pivot run` | Plain text (new default) |
| `pivot run --tui` | Interactive TUI |
| `pivot run --json` | JSONL streaming |
| `pivot run --tui --json` | Error: mutually exclusive |

**Flag constraints:**
- `--tui` and `--json` are mutually exclusive
- `--tui-log` requires `--tui`
- `--serve` requires `--tui`

## Changes

- Remove `--display` option from CLI
- Add `--tui` boolean flag
- Remove `DisplayMode` enum and `should_use_tui()` function
- Update documentation and tests

Closes #297

## Test Plan

- [x] All 2713 tests pass
- [x] Type checking passes (basedpyright)
- [x] Linting passes (ruff)