### PR TITLE
fix(cli): checkout --only-missing restores directories with missing files

### DIFF
--- a/src/pivot/cli/checkout.py
+++ b/src/pivot/cli/checkout.py
@@ -74,7 +74,12 @@ def _restore_path_sync(
                     + "Use --force to overwrite or --only-missing to skip existing files."
                 )
             case CheckoutBehavior.SKIP_EXISTING:
-                return ("skipped", path.name)
+                # For directories with manifests, don't skip - files inside may be missing.
+                # Let restore_from_cache() handle it (does full directory restoration).
+                # DirHash has "manifest" key, FileHash does not.
+                is_directory = output_hash is not None and "manifest" in output_hash
+                if not is_directory:
+                    return ("skipped", path.name)
             case CheckoutBehavior.FORCE:
                 cache.remove_output(path)
             case _:  # pyright: ignore[reportUnnecessaryComparison] - defensive for future enum values

--- a/src/pivot/cli/run.py
+++ b/src/pivot/cli/run.py
@@ -233,7 +233,7 @@ def _run_with_tui(
 def _run_watch_with_tui(
     stages_list: list[str] | None,
     single_stage: bool,
-    debounce: int,  # noqa: ARG001 - debounce not yet used by FilesystemSource
+    debounce: int,
     force: bool = False,
     tui_log: pathlib.Path | None = None,
     no_commit: bool = False,  # noqa: ARG001 - not yet supported in Engine watch mode
@@ -243,11 +243,11 @@ def _run_watch_with_tui(
 ) -> None:
     """Run watch mode with TUI display.
 
-    Note: Several parameters (debounce, no_commit, no_cache) are
+    Note: Several parameters (no_commit, no_cache) are
     retained for CLI signature compatibility but not currently used by Engine watch mode.
     """
     # Suppress unused parameter warnings - retained for CLI compatibility
-    _ = debounce, no_commit, no_cache
+    _ = no_commit, no_cache
 
     import queue as thread_queue
     import uuid
@@ -285,7 +285,7 @@ def _run_watch_with_tui(
         watch_paths = engine_graph.get_watch_paths(bipartite_graph)
 
         # Add FilesystemSource for watching file changes
-        filesystem_source = sources.FilesystemSource(watch_paths)
+        filesystem_source = sources.FilesystemSource(watch_paths, debounce=debounce)
         eng.add_source(filesystem_source)
 
         # Add OneShotSource for initial run if force is set
@@ -516,7 +516,7 @@ def run(
                 watch_paths = engine_graph.get_watch_paths(bipartite_graph)
 
                 # Add FilesystemSource for watching file changes
-                filesystem_source = sources.FilesystemSource(watch_paths)
+                filesystem_source = sources.FilesystemSource(watch_paths, debounce=debounce)
                 eng.add_source(filesystem_source)
 
                 # Add OneShotSource for initial run if force is set

--- a/src/pivot/engine/engine.py
+++ b/src/pivot/engine/engine.py
@@ -832,8 +832,14 @@ class Engine:
 
         added = list(new_stages - old_stage_names)
         removed = list(old_stage_names - new_stages)
-        # TODO: detect modified stages by comparing fingerprints
+
+        # Detect modified stages by comparing fingerprints
         modified = list[str]()
+        for stage_name in old_stage_names & new_stages:
+            old_info = old_stages[stage_name]
+            new_info = registry.REGISTRY.get(stage_name)
+            if old_info["fingerprint"] != new_info["fingerprint"]:
+                modified.append(stage_name)
 
         self.emit(
             PipelineReloaded(


### PR DESCRIPTION
## Summary

- **Fix #274:** `pivot checkout --only-missing` now correctly restores missing files inside directories that exist on disk, rather than skipping the entire directory
- **Fix #290:** Engine refactor follow-up items:
  - `PipelineReloaded` event now populates `stages_modified` by comparing fingerprints
  - `debounce` CLI parameter is now wired through to `FilesystemSource`
  - (Note: `no_commit`, `no_cache`, `single_stage` in watch mode remain blocked on architectural changes)
- **Fix #244:** Added Worker Execution section to CLAUDE.md documenting `WorkerStageInfo`, path derivation patterns, and nested parallelism gotchas

## Test plan

- [x] All 162 tests pass for modified modules
- [x] New test `test_checkout_only_missing_restores_directory_with_missing_file` verifies the bug fix
- [x] New test `test_engine_emit_reload_event_detects_modified_stages` verifies fingerprint comparison
- [x] New test `test_filesystem_source_debounce_parameter` verifies debounce wiring
- [x] All quality checks pass (ruff format, ruff check, basedpyright)

Closes #274, closes #290, closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)