### PR TITLE
feat(engine): show modified stages in TUI on pipeline reload

### DIFF
--- a/src/pivot/engine/engine.py
+++ b/src/pivot/engine/engine.py
@@ -830,12 +830,12 @@ class Engine:
         new_stages = set(registry.REGISTRY.list_stages())
         old_stage_names = set(old_stages.keys())
 
-        added = list(new_stages - old_stage_names)
-        removed = list(old_stage_names - new_stages)
+        added = sorted(new_stages - old_stage_names)
+        removed = sorted(old_stage_names - new_stages)
 
         # Detect modified stages by comparing fingerprints
         modified = list[str]()
-        for stage_name in old_stage_names & new_stages:
+        for stage_name in sorted(old_stage_names & new_stages):
             old_info = old_stages[stage_name]
             new_info = registry.REGISTRY.get(stage_name)
             if old_info["fingerprint"] != new_info["fingerprint"]:

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -73,7 +73,33 @@ __all__ = [
     "ExecutorComplete",
     "run_with_tui",
     "run_watch_tui",
+    "format_reload_summary",
 ]
+
+
+def format_reload_summary(
+    stages_added: list[str],
+    stages_removed: list[str],
+    stages_modified: list[str],
+) -> str | None:
+    """Format a summary message for pipeline reload changes.
+
+    Returns None if there are no changes to report.
+    """
+    parts = list[str]()
+
+    if stages_added:
+        parts.append(f"{len(stages_added)} added")
+    if stages_removed:
+        parts.append(f"{len(stages_removed)} removed")
+    if stages_modified:
+        parts.append(f"{len(stages_modified)} modified")
+
+    if not parts:
+        return None
+
+    return f"Reloaded: {', '.join(parts)}"
+
 
 if TYPE_CHECKING:
     import multiprocessing as mp
@@ -638,6 +664,15 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
         self._recompute_selection_idx()
         self._rebuild_stage_list()
         self._update_detail_panel()
+
+        # Show notification with reload summary
+        summary = format_reload_summary(
+            stages_added=msg["stages_added"],
+            stages_removed=msg["stages_removed"],
+            stages_modified=msg["stages_modified"],
+        )
+        if summary:
+            self.notify(summary)
 
     def on_executor_complete(self, event: ExecutorComplete) -> None:  # pragma: no cover
         """Handle executor completion (run mode only)."""

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -540,6 +540,9 @@ class TuiReloadMessage(TypedDict):
 
     type: Literal[TuiMessageType.RELOAD]
     stages: list[str]
+    stages_added: list[str]
+    stages_removed: list[str]
+    stages_modified: list[str]
 
 
 TuiMessage = TuiLogMessage | TuiStatusMessage | TuiWatchMessage | TuiReloadMessage | None


### PR DESCRIPTION
## Summary

Implements issue #289: detect and display modified stages when pipeline code changes in watch mode.

- Add `stages_added`, `stages_removed`, `stages_modified` fields to `TuiReloadMessage`
- Update `WatchSink` to pass stage change info from `PipelineReloaded` event to TUI
- Add `format_reload_summary()` helper for building notification message
- Show "Reloaded: N added, M removed, K modified" notification in TUI when stages change

## Test plan

- [x] Unit tests for `format_reload_summary()` with various combinations
- [x] Unit test for `WatchSink` passing stage changes to `TuiReloadMessage`
- [x] End-to-end test verifying fingerprint changes emit `stages_modified`
- [x] All 194 related tests pass
- [x] Type checker passes (0 errors, 0 warnings)

Closes #289

🤖 Generated with [Claude Code](https://claude.ai/code)