### PR TITLE
feat(pipeline): add Pipeline class for programmatic pipeline management

### DIFF
--- a/docs/plans/2026-01-31-pipeline-class.md
+++ b/docs/plans/2026-01-31-pipeline-class.md
@@ -1,0 +1,1280 @@
+# Pipeline Class Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace global `REGISTRY` with a `Pipeline` class that supports multiple isolated pipelines with separate state tracking but shared cache.
+
+**Architecture:** Each `Pipeline` has its own internal registry, state directory (for lock files and state.db), and home directory (for resolving relative paths). Pipelines share a project-wide cache. When Pipeline A includes Pipeline B, B's stages use B's state directory, enabling seamless composition.
+
+**Tech Stack:** Python 3.13+, pytest, pydantic
+
+---
+
+## Background
+
+### Current State
+- Global `REGISTRY` singleton in `src/pivot/registry.py`
+- All stages share one `state_dir` (`.pivot/`)
+- `state_dir` determined at engine runtime in `_orchestrate_execution()`
+- `RegistryStageInfo` has no concept of "owner" or "home directory"
+
+### Target State
+- `Pipeline` class with internal registry
+- Each stage carries its `state_dir` (set at registration time)
+- `project_root` remains runtime-determined for shared cache
+- `pivot.yaml` creates implicit Pipeline (name from YAML or parent directory)
+- Global `REGISTRY` removed (breaking change)
+
+### Key Design Decisions
+1. `state_dir` is per-stage (stored in `RegistryStageInfo`), set at registration
+2. `project_root` is project-wide (determined at runtime), used for shared cache
+3. Pipeline home directory inferred from caller's `__file__`, overridable with `root=`
+4. Stage names are isolated per pipeline (two pipelines can both have "train")
+5. When Pipeline A includes Pipeline B, B's stages still use B's state_dir
+
+---
+
+## Task 1: Add `state_dir` Field to RegistryStageInfo
+
+**Files:**
+- Modify: `src/pivot/registry.py:57-93` (RegistryStageInfo TypedDict)
+- Test: `tests/config/test_registry.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/config/test_registry.py`:
+
+```python
+def test_registry_stage_info_has_state_dir() -> None:
+    """RegistryStageInfo should include state_dir field."""
+    reg = StageRegistry()
+
+    def my_stage() -> None:
+        pass
+
+    state_dir = pathlib.Path("/tmp/test_pipeline/.pivot")
+    reg.register(my_stage, name="my_stage", state_dir=state_dir)
+
+    info = reg.get("my_stage")
+    assert info["state_dir"] == state_dir
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/config/test_registry.py::test_registry_stage_info_has_state_dir -v`
+Expected: FAIL with TypeError (unexpected keyword argument 'state_dir')
+
+**Step 3: Add state_dir to RegistryStageInfo**
+
+In `src/pivot/registry.py`, add to `RegistryStageInfo` TypedDict (around line 93):
+
+```python
+class RegistryStageInfo(TypedDict):
+    # ... existing fields ...
+    params_arg_name: str | None
+    state_dir: pathlib.Path | None  # Pipeline's state directory, None uses default
+```
+
+**Step 4: Update StageRegistry.register() to accept state_dir**
+
+In `src/pivot/registry.py`, update the `register` method signature and body to accept and store `state_dir`:
+
+```python
+def register(
+    self,
+    func: Callable[..., Any],
+    *,
+    name: str | None = None,
+    params: ParamsArg = None,
+    mutex: list[str] | None = None,
+    variant: str | None = None,
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+    out_path_overrides: Mapping[str, OutOverrideInput] | None = None,
+    state_dir: pathlib.Path | None = None,  # Add this parameter
+) -> None:
+```
+
+And in the RegistryStageInfo construction:
+
+```python
+stage_info = RegistryStageInfo(
+    # ... existing fields ...
+    params_arg_name=params_arg_name,
+    state_dir=state_dir,
+)
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/config/test_registry.py::test_registry_stage_info_has_state_dir -v`
+Expected: PASS
+
+**Step 6: Run full test suite to check for regressions**
+
+Run: `uv run pytest tests/config/test_registry.py -v`
+Expected: All tests pass (existing tests pass None for state_dir)
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat(registry): add state_dir field to RegistryStageInfo
+
+Stages can now carry their own state directory, enabling per-pipeline
+state isolation. When state_dir is None, the default behavior applies.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Update Worker to Use Stage's state_dir
+
+**Files:**
+- Modify: `src/pivot/executor/core.py:287-318` (prepare_worker_info)
+- Modify: `src/pivot/engine/engine.py:1338` (where prepare_worker_info is called)
+- Test: `tests/execution/test_executor_worker.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/execution/test_executor_worker.py`:
+
+```python
+def test_prepare_worker_info_uses_stage_state_dir(
+    set_project_root: pathlib.Path,
+) -> None:
+    """prepare_worker_info should use stage's state_dir when set."""
+    from pivot.executor import core as executor_core
+    from pivot import registry, outputs, loaders
+
+    class _Output(TypedDict):
+        result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+    def _stage_with_state_dir() -> _Output:
+        return {"result": pathlib.Path("result.txt")}
+
+    custom_state_dir = set_project_root / "custom_pipeline" / ".pivot"
+    registry.REGISTRY.register(
+        _stage_with_state_dir,
+        name="stage_with_custom_state",
+        state_dir=custom_state_dir,
+    )
+
+    stage_info = registry.REGISTRY.get("stage_with_custom_state")
+    worker_info = executor_core.prepare_worker_info(
+        stage_info=stage_info,
+        overrides={},
+        checkout_modes=[],
+        run_id="test-run",
+        force=False,
+        no_commit=False,
+        no_cache=False,
+        project_root=set_project_root,
+        default_state_dir=set_project_root / ".pivot",  # Fallback
+    )
+
+    assert worker_info["state_dir"] == custom_state_dir
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/execution/test_executor_worker.py::test_prepare_worker_info_uses_stage_state_dir -v`
+Expected: FAIL (prepare_worker_info doesn't have default_state_dir param or doesn't check stage_info)
+
+**Step 3: Update prepare_worker_info signature**
+
+In `src/pivot/executor/core.py`, update `prepare_worker_info`:
+
+```python
+def prepare_worker_info(
+    stage_info: registry.RegistryStageInfo,
+    overrides: parameters.ParamsOverrides,
+    checkout_modes: list[cache.CheckoutMode],
+    run_id: str,
+    force: bool,
+    no_commit: bool,
+    no_cache: bool,
+    project_root: pathlib.Path,
+    default_state_dir: pathlib.Path,  # Renamed from state_dir
+) -> worker.WorkerStageInfo:
+    """Prepare worker info for stage execution.
+
+    Uses stage's state_dir if set, otherwise falls back to default_state_dir.
+    """
+    # Use stage's state_dir if set, otherwise use default
+    state_dir = stage_info["state_dir"] or default_state_dir
+
+    return worker.WorkerStageInfo(
+        # ... existing fields ...
+        state_dir=state_dir,
+        # ...
+    )
+```
+
+**Step 4: Update engine.py call sites**
+
+In `src/pivot/engine/engine.py`, update calls to `prepare_worker_info` to pass `default_state_dir`:
+
+```python
+worker_info = executor_core.prepare_worker_info(
+    stage_info=stage_info,
+    overrides=overrides,
+    checkout_modes=checkout_modes,
+    run_id=run_id,
+    force=force,
+    no_commit=no_commit,
+    no_cache=no_cache,
+    project_root=project_root,
+    default_state_dir=state_dir,  # Renamed parameter
+)
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/execution/test_executor_worker.py::test_prepare_worker_info_uses_stage_state_dir -v`
+Expected: PASS
+
+**Step 6: Run broader test suite**
+
+Run: `uv run pytest tests/execution/ tests/engine/ -v`
+Expected: All tests pass
+
+**Step 7: Commit**
+
+```bash
+jj describe -m "feat(executor): use stage's state_dir when preparing worker info
+
+prepare_worker_info now checks stage_info['state_dir'] and uses it if set,
+falling back to default_state_dir otherwise. This enables per-pipeline
+state isolation.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Create Pipeline Class (Core Structure)
+
+**Files:**
+- Create: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1: Create test file and write failing test**
+
+Create `tests/pipeline/test_pipeline.py`:
+
+```python
+from __future__ import annotations
+
+import inspect
+import pathlib
+from typing import Annotated, TypedDict
+
+import pytest
+
+from pivot import loaders, outputs
+
+
+class _SimpleOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _simple_stage() -> _SimpleOutput:
+    pathlib.Path("result.txt").write_text("done")
+    return {"result": pathlib.Path("result.txt")}
+
+
+def test_pipeline_creation_with_name() -> None:
+    """Pipeline should be creatable with a name."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    p = Pipeline("my_pipeline")
+
+    assert p.name == "my_pipeline"
+
+
+def test_pipeline_infers_root_from_caller() -> None:
+    """Pipeline should infer root directory from caller's __file__."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    p = Pipeline("test")
+
+    # Should be the directory containing this test file
+    expected = pathlib.Path(__file__).parent
+    assert p.root == expected
+
+
+def test_pipeline_accepts_explicit_root() -> None:
+    """Pipeline should accept explicit root override."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    custom_root = pathlib.Path("/custom/path")
+    p = Pipeline("test", root=custom_root)
+
+    assert p.root == custom_root
+
+
+def test_pipeline_state_dir_derived_from_root() -> None:
+    """Pipeline state_dir should be root/.pivot."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    custom_root = pathlib.Path("/custom/path")
+    p = Pipeline("test", root=custom_root)
+
+    assert p.state_dir == custom_root / ".pivot"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py -v`
+Expected: FAIL with ModuleNotFoundError (pivot.pipeline.pipeline doesn't exist)
+
+**Step 3: Create Pipeline class**
+
+Create `src/pivot/pipeline/pipeline.py`:
+
+```python
+from __future__ import annotations
+
+import inspect
+import pathlib
+
+
+class Pipeline:
+    """A pipeline with its own stage registry and state directory.
+
+    Each pipeline maintains isolated state (lock files, state.db) while
+    sharing the project-wide cache.
+
+    Args:
+        name: Pipeline identifier for logging and display.
+        root: Home directory for this pipeline. Defaults to the directory
+            containing the file where Pipeline() is called.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        root: pathlib.Path | None = None,
+    ) -> None:
+        self._name = name
+
+        if root is not None:
+            self._root = root
+        else:
+            # Infer from caller's __file__
+            frame = inspect.currentframe()
+            if frame is None or frame.f_back is None:
+                raise RuntimeError("Cannot determine caller frame")
+            caller_file = frame.f_back.f_globals.get("__file__")
+            if caller_file is None:
+                raise RuntimeError("Cannot determine caller's __file__")
+            self._root = pathlib.Path(caller_file).parent
+
+    @property
+    def name(self) -> str:
+        """Pipeline name."""
+        return self._name
+
+    @property
+    def root(self) -> pathlib.Path:
+        """Pipeline root directory."""
+        return self._root
+
+    @property
+    def state_dir(self) -> pathlib.Path:
+        """State directory for this pipeline's lock files and state.db."""
+        return self._root / ".pivot"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add Pipeline class with name and root
+
+Pipeline class provides isolated state directories for multi-pipeline
+support. Root is inferred from caller's __file__ or can be explicitly set.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add Pipeline.register() Method
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1: Write failing test**
+
+Add to `tests/pipeline/test_pipeline.py`:
+
+```python
+def test_pipeline_register_stage(tmp_path: pathlib.Path) -> None:
+    """Pipeline.register should register a stage with the pipeline's state_dir."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    p = Pipeline("test", root=tmp_path)
+    p.register(_simple_stage, name="my_stage")
+
+    assert "my_stage" in p.list_stages()
+    info = p.get("my_stage")
+    assert info["state_dir"] == tmp_path / ".pivot"
+
+
+def test_pipeline_stages_isolated(tmp_path: pathlib.Path) -> None:
+    """Two pipelines can have stages with the same name."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    p1 = Pipeline("pipeline1", root=tmp_path / "p1")
+    p2 = Pipeline("pipeline2", root=tmp_path / "p2")
+
+    p1.register(_simple_stage, name="train")
+    p2.register(_simple_stage, name="train")
+
+    assert "train" in p1.list_stages()
+    assert "train" in p2.list_stages()
+
+    # Each has its own state_dir
+    assert p1.get("train")["state_dir"] == tmp_path / "p1" / ".pivot"
+    assert p2.get("train")["state_dir"] == tmp_path / "p2" / ".pivot"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_register_stage -v`
+Expected: FAIL (Pipeline has no register method)
+
+**Step 3: Add register, list_stages, and get methods**
+
+Update `src/pivot/pipeline/pipeline.py`:
+
+```python
+from __future__ import annotations
+
+import inspect
+import pathlib
+from typing import TYPE_CHECKING, Any
+
+from pivot import registry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from pivot import outputs, stage_def
+
+
+class Pipeline:
+    """A pipeline with its own stage registry and state directory."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        root: pathlib.Path | None = None,
+    ) -> None:
+        self._name = name
+
+        if root is not None:
+            self._root = root
+        else:
+            frame = inspect.currentframe()
+            if frame is None or frame.f_back is None:
+                raise RuntimeError("Cannot determine caller frame")
+            caller_file = frame.f_back.f_globals.get("__file__")
+            if caller_file is None:
+                raise RuntimeError("Cannot determine caller's __file__")
+            self._root = pathlib.Path(caller_file).parent
+
+        self._registry = registry.StageRegistry()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def root(self) -> pathlib.Path:
+        return self._root
+
+    @property
+    def state_dir(self) -> pathlib.Path:
+        return self._root / ".pivot"
+
+    def register(
+        self,
+        func: Callable[..., Any],
+        *,
+        name: str | None = None,
+        params: registry.ParamsArg = None,
+        mutex: list[str] | None = None,
+        variant: str | None = None,
+        dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+        out_path_overrides: Mapping[str, registry.OutOverrideInput] | None = None,
+    ) -> None:
+        """Register a stage with this pipeline.
+
+        The stage will use this pipeline's state_dir for lock files and state.db.
+        """
+        self._registry.register(
+            func=func,
+            name=name,
+            params=params,
+            mutex=mutex,
+            variant=variant,
+            dep_path_overrides=dep_path_overrides,
+            out_path_overrides=out_path_overrides,
+            state_dir=self.state_dir,
+        )
+
+    def list_stages(self) -> list[str]:
+        """List all registered stage names."""
+        return self._registry.list_stages()
+
+    def get(self, name: str) -> registry.RegistryStageInfo:
+        """Get stage info by name."""
+        return self._registry.get(name)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add register, list_stages, and get methods
+
+Pipeline now wraps StageRegistry and automatically sets state_dir on
+registered stages. Each pipeline maintains isolated state.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add Pipeline Discovery
+
+**Files:**
+- Modify: `src/pivot/discovery.py`
+- Test: `tests/core/test_discovery.py`
+
+**Step 1: Write failing test**
+
+Add to `tests/core/test_discovery.py`:
+
+```python
+def test_discover_pipeline_from_pipeline_py(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """discover_pipeline should find Pipeline instance in pipeline.py."""
+    from pivot import discovery
+    from pivot.pipeline.pipeline import Pipeline
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+
+    # Create pipeline.py that defines a Pipeline
+    pipeline_code = '''
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test_pipeline")
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="my_stage")
+'''
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.discover_pipeline(tmp_path)
+
+    assert result is not None
+    assert result.name == "test_pipeline"
+    assert "my_stage" in result.list_stages()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_discovery.py::test_discover_pipeline_from_pipeline_py -v`
+Expected: FAIL (discover_pipeline doesn't exist)
+
+**Step 3: Add discover_pipeline function**
+
+Update `src/pivot/discovery.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+import runpy
+from typing import TYPE_CHECKING
+
+from pivot import fingerprint, metrics, project, registry
+from pivot.pipeline import yaml as pipeline_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pivot.pipeline.pipeline import Pipeline
+
+logger = logging.getLogger(__name__)
+
+PIVOT_YAML_NAMES = ("pivot.yaml", "pivot.yml")
+PIPELINE_PY_NAME = "pipeline.py"
+
+
+def discover_pipeline(project_root: Path | None = None) -> Pipeline | None:
+    """Discover and return Pipeline from pivot.yaml or pipeline.py.
+
+    Looks in project root for:
+    1. pivot.yaml (or pivot.yml) - creates implicit Pipeline
+    2. pipeline.py - looks for `pipeline` variable (Pipeline instance)
+
+    Args:
+        project_root: Override project root (default: auto-detect)
+
+    Returns:
+        Pipeline instance, or None if nothing found
+
+    Raises:
+        DiscoveryError: If discovery fails, or if both config types exist
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    with metrics.timed("discovery.total"):
+        root = project_root or project.get_project_root()
+
+        # Check which files exist upfront
+        yaml_path = None
+        for yaml_name in PIVOT_YAML_NAMES:
+            candidate = root / yaml_name
+            if candidate.exists():
+                yaml_path = candidate
+                break
+
+        pipeline_path = root / PIPELINE_PY_NAME
+        pipeline_exists = pipeline_path.exists()
+
+        # Error if both exist
+        if yaml_path and pipeline_exists:
+            raise DiscoveryError(
+                f"Found both {yaml_path.name} and {PIPELINE_PY_NAME} in {root}. "
+                "Remove one to resolve ambiguity."
+            )
+
+        # Load from yaml if found
+        if yaml_path:
+            logger.info(f"Discovered {yaml_path}")
+            try:
+                return pipeline_config.load_pipeline_from_yaml(yaml_path)
+            except pipeline_config.PipelineConfigError as e:
+                raise DiscoveryError(f"Failed to load {yaml_path}: {e}") from e
+
+        # Try pipeline.py
+        if pipeline_exists:
+            logger.info(f"Discovered {pipeline_path}")
+            try:
+                return _load_pipeline_from_module(pipeline_path)
+            except SystemExit as e:
+                raise DiscoveryError(
+                    f"Pipeline {pipeline_path} called sys.exit({e.code})"
+                ) from e
+            except Exception as e:
+                raise DiscoveryError(f"Failed to load {pipeline_path}: {e}") from e
+            finally:
+                fingerprint.flush_ast_hash_cache()
+
+        return None
+
+
+def _load_pipeline_from_module(path: Path) -> Pipeline:
+    """Load Pipeline instance from a pipeline.py file."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    module_dict = runpy.run_path(str(path), run_name="_pivot_pipeline")
+
+    # Look for 'pipeline' variable
+    pipeline = module_dict.get("pipeline")
+    if pipeline is None:
+        raise DiscoveryError(
+            f"{path} does not define a 'pipeline' variable. "
+            "Expected: pipeline = Pipeline('name')"
+        )
+
+    if not isinstance(pipeline, Pipeline):
+        raise DiscoveryError(
+            f"{path} defines 'pipeline' but it's not a Pipeline instance "
+            f"(got {type(pipeline).__name__})"
+        )
+
+    return pipeline
+
+
+# Keep legacy function for backwards compatibility during transition
+def discover_and_register(project_root: Path | None = None) -> str | None:
+    """Legacy: Discover and register pipeline into global REGISTRY.
+
+    DEPRECATED: Use discover_pipeline() instead.
+    """
+    # ... existing implementation ...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_discovery.py::test_discover_pipeline_from_pipeline_py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(discovery): add discover_pipeline returning Pipeline instance
+
+New discover_pipeline() function returns Pipeline directly instead of
+registering into global REGISTRY. Legacy discover_and_register() preserved
+for backwards compatibility.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Update pivot.yaml to Create Pipeline
+
+**Files:**
+- Modify: `src/pivot/pipeline/yaml.py`
+- Test: `tests/core/test_pipeline_config.py`
+
+**Step 1: Write failing test**
+
+Add to `tests/core/test_pipeline_config.py`:
+
+```python
+def test_load_pipeline_from_yaml_creates_pipeline(tmp_path: pathlib.Path) -> None:
+    """load_pipeline_from_yaml should return a Pipeline instance."""
+    from pivot.pipeline import yaml as pipeline_yaml
+    from pivot.pipeline.pipeline import Pipeline
+
+    yaml_content = """
+stages:
+  process:
+    python: tests.helpers._simple_stage
+"""
+    yaml_path = tmp_path / "pivot.yaml"
+    yaml_path.write_text(yaml_content)
+
+    result = pipeline_yaml.load_pipeline_from_yaml(yaml_path)
+
+    assert isinstance(result, Pipeline)
+    assert result.root == tmp_path
+
+
+def test_load_pipeline_from_yaml_uses_pipeline_name(tmp_path: pathlib.Path) -> None:
+    """load_pipeline_from_yaml should use 'pipeline' field for name if present."""
+    from pivot.pipeline import yaml as pipeline_yaml
+
+    yaml_content = """
+pipeline: my_custom_name
+stages:
+  process:
+    python: tests.helpers._simple_stage
+"""
+    yaml_path = tmp_path / "pivot.yaml"
+    yaml_path.write_text(yaml_content)
+
+    result = pipeline_yaml.load_pipeline_from_yaml(yaml_path)
+
+    assert result.name == "my_custom_name"
+
+
+def test_load_pipeline_from_yaml_defaults_to_directory_name(tmp_path: pathlib.Path) -> None:
+    """load_pipeline_from_yaml should default name to parent directory."""
+    from pivot.pipeline import yaml as pipeline_yaml
+
+    yaml_content = """
+stages:
+  process:
+    python: tests.helpers._simple_stage
+"""
+    subdir = tmp_path / "my_project"
+    subdir.mkdir()
+    yaml_path = subdir / "pivot.yaml"
+    yaml_path.write_text(yaml_content)
+
+    result = pipeline_yaml.load_pipeline_from_yaml(yaml_path)
+
+    assert result.name == "my_project"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_pipeline_config.py::test_load_pipeline_from_yaml_creates_pipeline -v`
+Expected: FAIL (load_pipeline_from_yaml doesn't exist)
+
+**Step 3: Add load_pipeline_from_yaml and update PipelineConfig**
+
+Update `src/pivot/pipeline/yaml.py`:
+
+```python
+class PipelineConfig(pydantic.BaseModel):
+    """Top-level pivot.yaml configuration."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    pipeline: str | None = None  # Add optional pipeline name
+    stages: dict[str, StageConfig]
+    vars: list[str] = []
+
+
+def load_pipeline_from_yaml(pipeline_file: Path) -> Pipeline:
+    """Load pivot.yaml and return a Pipeline instance.
+
+    The pipeline name comes from:
+    1. 'pipeline' field in YAML if present
+    2. Otherwise, parent directory name
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    config = load_pipeline_file(pipeline_file)
+    pipeline_dir = pipeline_file.parent
+
+    # Determine pipeline name
+    name = config.pipeline or pipeline_dir.name
+
+    # Create Pipeline with explicit root
+    p = Pipeline(name, root=pipeline_dir)
+
+    # Register all stages
+    for stage_name, stage_config in config.stages.items():
+        expanded = _expand_stage(stage_name, stage_config, pipeline_dir, config.vars)
+        for stage in expanded:
+            p.register(
+                func=stage.func,
+                name=stage.name,
+                params=stage.params,
+                mutex=stage.mutex,
+                variant=stage.variant,
+                dep_path_overrides=stage.dep_path_overrides,
+                out_path_overrides=stage.out_path_overrides,
+            )
+
+    return p
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_pipeline_config.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(yaml): add load_pipeline_from_yaml returning Pipeline
+
+pivot.yaml now creates a Pipeline instance with stages registered.
+Pipeline name comes from 'pipeline' field or defaults to directory name.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Update Engine to Accept Pipeline
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py`
+- Test: `tests/engine/test_engine.py`
+
+**Step 1: Write failing test**
+
+Add to `tests/engine/test_engine.py`:
+
+```python
+def test_engine_accepts_pipeline(tmp_path: pathlib.Path) -> None:
+    """Engine should accept a Pipeline instance."""
+    from pivot.engine.engine import Engine
+    from pivot.pipeline.pipeline import Pipeline
+
+    p = Pipeline("test", root=tmp_path)
+
+    def _stage() -> None:
+        pass
+
+    p.register(_stage, name="my_stage")
+
+    with Engine(pipeline=p) as engine:
+        assert "my_stage" in engine._graph.nodes()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_engine.py::test_engine_accepts_pipeline -v`
+Expected: FAIL (Engine doesn't accept pipeline parameter)
+
+**Step 3: Update Engine.__init__ to accept Pipeline**
+
+In `src/pivot/engine/engine.py`, update the `Engine` class:
+
+```python
+class Engine:
+    """Pipeline execution engine."""
+
+    def __init__(
+        self,
+        *,
+        pipeline: Pipeline | None = None,
+        # ... existing parameters ...
+    ) -> None:
+        self._pipeline = pipeline
+        # ... rest of __init__ ...
+
+    def _build_graph(self) -> DiGraph:
+        """Build execution graph from registered stages."""
+        if self._pipeline is not None:
+            all_stages = {
+                name: self._pipeline.get(name)
+                for name in self._pipeline.list_stages()
+            }
+        else:
+            # Legacy: use global REGISTRY
+            all_stages = {
+                name: registry.REGISTRY.get(name)
+                for name in registry.REGISTRY.list_stages()
+            }
+        return engine_graph.build_graph(all_stages)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_engine.py::test_engine_accepts_pipeline -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(engine): accept Pipeline instance
+
+Engine can now receive a Pipeline directly instead of reading from
+global REGISTRY. Legacy behavior (reading REGISTRY) preserved when
+pipeline=None.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Update CLI to Use discover_pipeline
+
+**Files:**
+- Modify: `src/pivot/cli/run.py`
+- Test: `tests/cli/test_run.py`
+
+**Step 1: Write failing test**
+
+Add to `tests/cli/test_run.py`:
+
+```python
+def test_cli_run_discovers_pipeline(
+    tmp_path: pathlib.Path,
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """pivot run should discover and use Pipeline from pipeline.py."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+
+    # Create pipeline.py
+    pipeline_code = '''
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test")
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="my_stage")
+'''
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+    (tmp_path / ".pivot").mkdir()
+
+    result = runner.invoke(cli, ["run", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "my_stage" in result.output
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/cli/test_run.py::test_cli_run_discovers_pipeline -v`
+Expected: FAIL (CLI still uses global REGISTRY)
+
+**Step 3: Update CLI run command**
+
+In `src/pivot/cli/run.py`, update to use `discover_pipeline`:
+
+```python
+@cli.command()
+def run(...):
+    """Run pipeline stages."""
+    from pivot import discovery
+
+    # Discover pipeline
+    pipeline = discovery.discover_pipeline()
+    if pipeline is None:
+        raise click.ClickException("No pipeline found (pivot.yaml or pipeline.py)")
+
+    # Create engine with pipeline
+    with Engine(pipeline=pipeline, ...) as engine:
+        # ... rest of run logic ...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/cli/test_run.py::test_cli_run_discovers_pipeline -v`
+Expected: PASS
+
+**Step 5: Run full CLI test suite**
+
+Run: `uv run pytest tests/cli/test_run.py -v`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat(cli): use discover_pipeline in run command
+
+CLI now discovers Pipeline instance and passes it to Engine, instead
+of relying on global REGISTRY side effects.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Remove Global REGISTRY Usage (Breaking Change)
+
+**Files:**
+- Modify: `src/pivot/registry.py` (remove REGISTRY singleton)
+- Modify: Multiple files that import REGISTRY
+- Test: Ensure all tests pass without global REGISTRY
+
+**Step 1: Identify all REGISTRY imports**
+
+Run: `uv run rg "from pivot.registry import REGISTRY|from pivot import.*registry.*REGISTRY" --files-with-matches`
+
+**Step 2: Update each file to use Pipeline instead**
+
+This is a larger refactoring task. For each file:
+1. Remove REGISTRY import
+2. Accept Pipeline as parameter or use discover_pipeline()
+
+**Step 3: Mark REGISTRY as deprecated (optional intermediate step)**
+
+```python
+# In src/pivot/registry.py
+import warnings
+
+class _DeprecatedRegistry(StageRegistry):
+    def register(self, *args, **kwargs):
+        warnings.warn(
+            "REGISTRY is deprecated. Use Pipeline().register() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().register(*args, **kwargs)
+
+REGISTRY = _DeprecatedRegistry()
+```
+
+**Step 4: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All tests pass (may show deprecation warnings)
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "refactor!: deprecate global REGISTRY
+
+BREAKING CHANGE: Global REGISTRY is deprecated. Use Pipeline class instead.
+All internal usage updated to use Pipeline. REGISTRY kept for backwards
+compatibility with deprecation warning.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Integration Test - Multi-Pipeline Execution
+
+**Files:**
+- Test: `tests/integration/test_multi_pipeline.py`
+
+**Step 1: Write integration test**
+
+Create `tests/integration/test_multi_pipeline.py`:
+
+```python
+from __future__ import annotations
+
+import pathlib
+from typing import Annotated, TypedDict
+
+import pytest
+
+from pivot import loaders, outputs
+from pivot.engine.engine import Engine
+from pivot.pipeline.pipeline import Pipeline
+
+
+class _DataOutput(TypedDict):
+    data: Annotated[pathlib.Path, outputs.Out("data.csv", loaders.PathOnly())]
+
+
+def _produce_data() -> _DataOutput:
+    pathlib.Path("data.csv").write_text("id,value\n1,10\n")
+    return {"data": pathlib.Path("data.csv")}
+
+
+class _ResultOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _consume_data(
+    data: Annotated[pathlib.Path, outputs.Dep("data.csv", loaders.PathOnly())],
+) -> _ResultOutput:
+    pathlib.Path("result.txt").write_text("processed")
+    return {"result": pathlib.Path("result.txt")}
+
+
+def test_two_pipelines_isolated_state(tmp_path: pathlib.Path) -> None:
+    """Two pipelines should have isolated state directories."""
+    # Create two pipeline directories
+    p1_dir = tmp_path / "pipeline1"
+    p2_dir = tmp_path / "pipeline2"
+    p1_dir.mkdir()
+    p2_dir.mkdir()
+
+    # Create pipelines
+    p1 = Pipeline("producer", root=p1_dir)
+    p2 = Pipeline("consumer", root=p2_dir)
+
+    p1.register(_produce_data, name="produce")
+    p2.register(_consume_data, name="consume")
+
+    # Verify isolated state_dirs
+    assert p1.get("produce")["state_dir"] == p1_dir / ".pivot"
+    assert p2.get("consume")["state_dir"] == p2_dir / ".pivot"
+
+    # Run pipeline 1
+    with Engine(pipeline=p1) as engine:
+        engine.run_once()
+
+    # Verify state files created in p1's state_dir
+    assert (p1_dir / ".pivot" / "stages" / "produce.lock").exists()
+    assert not (p2_dir / ".pivot" / "stages" / "produce.lock").exists()
+
+
+def test_same_stage_name_different_pipelines(tmp_path: pathlib.Path) -> None:
+    """Two pipelines can have stages with the same name."""
+    p1 = Pipeline("pipeline1", root=tmp_path / "p1")
+    p2 = Pipeline("pipeline2", root=tmp_path / "p2")
+
+    def _train_v1() -> None:
+        pass
+
+    def _train_v2() -> None:
+        pass
+
+    # Both register "train" - should not conflict
+    p1.register(_train_v1, name="train")
+    p2.register(_train_v2, name="train")
+
+    assert p1.get("train")["func"] == _train_v1
+    assert p2.get("train")["func"] == _train_v2
+```
+
+**Step 2: Run integration tests**
+
+Run: `uv run pytest tests/integration/test_multi_pipeline.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "test: add integration tests for multi-pipeline isolation
+
+Tests verify that two pipelines maintain isolated state directories
+and can have stages with the same name without conflict.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Final Verification and Quality Checks
+
+**Step 1: Run type checker**
+
+Run: `uv run basedpyright .`
+Expected: No errors or warnings
+
+**Step 2: Run linter**
+
+Run: `uv run ruff check .`
+Expected: No errors
+
+**Step 3: Run formatter**
+
+Run: `uv run ruff format .`
+Expected: Files formatted
+
+**Step 4: Run full test suite with coverage**
+
+Run: `uv run pytest tests/ -v --cov=pivot --cov-report=term-missing`
+Expected: All tests pass, coverage >= 90%
+
+**Step 5: Final commit**
+
+```bash
+jj describe -m "feat(pipeline): complete Pipeline class implementation
+
+Adds Pipeline class for multi-pipeline support with:
+- Isolated state directories per pipeline
+- Shared project-wide cache
+- Per-stage state_dir in RegistryStageInfo
+- Updated discovery to return Pipeline instances
+- Updated Engine to accept Pipeline
+- Updated CLI to use discover_pipeline
+
+BREAKING CHANGE: Global REGISTRY is deprecated in favor of Pipeline class.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Add state_dir to RegistryStageInfo | registry.py |
+| 2 | Update worker to use stage's state_dir | core.py, engine.py |
+| 3 | Create Pipeline class core | pipeline/pipeline.py |
+| 4 | Add Pipeline.register() | pipeline/pipeline.py |
+| 5 | Add Pipeline discovery | discovery.py |
+| 6 | Update pivot.yaml to create Pipeline | pipeline/yaml.py |
+| 7 | Update Engine to accept Pipeline | engine/engine.py |
+| 8 | Update CLI to use discover_pipeline | cli/run.py |
+| 9 | Deprecate global REGISTRY | registry.py, multiple |
+| 10 | Integration tests | test_multi_pipeline.py |
+| 11 | Final verification | - |
+
+## Deferred Work (Post-MVP)
+
+- Pipeline composition (Pipeline A includes Pipeline B)
+- Cross-pipeline dependency validation
+- Shared cache directory discovery (walk up to find `.pivot/`)
+- `PIVOT_PROJECT_ROOT` environment variable override

--- a/src/pivot/__init__.py
+++ b/src/pivot/__init__.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 __version__ = "0.1.0-dev"
 
 # Public API - only exports that users need when writing pipelines
-# Internal modules like REGISTRY, BaseOut, and show.* are accessible
-# via their full paths (e.g., pivot.registry.REGISTRY) for advanced use
+# Internal modules like BaseOut and show.* are accessible via their full paths
 
 if TYPE_CHECKING:
     from pivot import loaders as loaders

--- a/src/pivot/cli/CLAUDE.md
+++ b/src/pivot/cli/CLAUDE.md
@@ -16,8 +16,8 @@ from pivot.cli import decorators as cli_decorators
 @cli_decorators.pivot_command()
 def list_cmd() -> None:
     """List registered stages."""
-    # Registry is guaranteed to be populated here
-    stages = registry.REGISTRY.list_stages()
+    # Pipeline is guaranteed to be in context here
+    stages = cli_helpers.list_stages()
     ...
 
 # Command that doesn't need the registry

--- a/src/pivot/cli/checkout.py
+++ b/src/pivot/cli/checkout.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 
 import click
 
-from pivot import config, project, registry
+from pivot import config, project
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
 from pivot.cli import helpers as cli_helpers
@@ -36,7 +36,7 @@ def _get_stage_output_info(state_dir: pathlib.Path) -> dict[str, OutputHash]:
     """Get output hash info from lock files for all stages."""
     outputs = dict[str, OutputHash]()
 
-    for stage_name in registry.REGISTRY.list_stages():
+    for stage_name in cli_helpers.list_stages():
         stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
         lock_data = stage_lock.read()
         if lock_data and "output_hashes" in lock_data:

--- a/src/pivot/cli/completion.py
+++ b/src/pivot/cli/completion.py
@@ -126,12 +126,13 @@ def _get_stages_fast() -> list[str] | None:
 
 def _get_stages_full() -> list[str]:
     """Fallback: get stage names via full discovery (~500ms)."""
-    from pivot import discovery, registry
+    from pivot import discovery
 
-    if not discovery.has_registered_stages():
-        discovery.discover_and_register()
+    pipeline = discovery.discover_pipeline()
+    if pipeline is None:
+        return []
 
-    return registry.REGISTRY.list_stages()
+    return pipeline.list_stages()
 
 
 def _find_project_root_fast() -> pathlib.Path | None:

--- a/src/pivot/cli/dag.py
+++ b/src/pivot/cli/dag.py
@@ -5,8 +5,9 @@ import logging
 import click
 import networkx as nx
 
-from pivot import dag, project, registry
+from pivot import dag, project
 from pivot.cli import decorators as cli_decorators
+from pivot.cli import helpers as cli_helpers
 from pivot.cli import targets as cli_targets
 from pivot.engine import graph as engine_graph
 from pivot.engine import types as engine_types
@@ -26,7 +27,7 @@ def _resolve_targets_to_stages(
     Returns:
         Tuple of (resolved stage names, unresolved targets).
     """
-    registered_stages = set(registry.REGISTRY.list_stages())
+    registered_stages = set(cli_helpers.list_stages())
     result = set[str]()
     unresolved = list[str]()
 
@@ -100,8 +101,8 @@ def dag_cmd(
     TARGETS can be stage names or artifact paths. Stage names take precedence
     when a name matches both a stage and a file path.
     """
-    # Build bipartite graph from registry
-    all_stages = {name: registry.REGISTRY.get(name) for name in registry.REGISTRY.list_stages()}
+    # Build bipartite graph from pipeline
+    all_stages = cli_helpers.get_all_stages()
     bipartite_graph = engine_graph.build_graph(all_stages)
 
     # Filter to subgraph if targets provided

--- a/src/pivot/cli/list.py
+++ b/src/pivot/cli/list.py
@@ -5,7 +5,6 @@ from typing import TypedDict
 
 import click
 
-from pivot import registry
 from pivot.cli import decorators as cli_decorators
 from pivot.cli import helpers as cli_helpers
 
@@ -31,7 +30,7 @@ def _get_output_sources(stage_list: list[str]) -> dict[str, str]:
     return {
         out_path: name
         for name in stage_list
-        for out_path in registry.REGISTRY.get(name)["outs_paths"]
+        for out_path in cli_helpers.get_stage(name)["outs_paths"]
     }
 
 
@@ -44,7 +43,7 @@ def list_cmd(ctx: click.Context, as_json: bool, show_deps: bool) -> None:
     cli_ctx = cli_helpers.get_cli_context(ctx)
     verbose = cli_ctx["verbose"]
     quiet = cli_ctx["quiet"]
-    stage_list = registry.REGISTRY.list_stages()
+    stage_list = cli_helpers.list_stages()
 
     if not stage_list:
         if as_json:
@@ -58,7 +57,7 @@ def list_cmd(ctx: click.Context, as_json: bool, show_deps: bool) -> None:
         stages = [
             StageJsonOutput(
                 name=name,
-                deps=(info := registry.REGISTRY.get(name))["deps_paths"],
+                deps=(info := cli_helpers.get_stage(name))["deps_paths"],
                 outs=info["outs_paths"],
                 mutex=info["mutex"],
                 variant=info["variant"],
@@ -77,7 +76,7 @@ def list_cmd(ctx: click.Context, as_json: bool, show_deps: bool) -> None:
 
     click.echo(f"Registered stages ({len(stage_list)}):")
     for name in stage_list:
-        info = registry.REGISTRY.get(name)
+        info = cli_helpers.get_stage(name)
         deps = info["deps_paths"]
         outs = info["outs_paths"]
         click.echo(f"  {name}")

--- a/src/pivot/cli/params.py
+++ b/src/pivot/cli/params.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import click
 
-from pivot import config, exceptions, registry
+from pivot import config, exceptions
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
+from pivot.cli import helpers as cli_helpers
 from pivot.show import params as params_mod
 from pivot.types import OutputFormat
 
@@ -39,7 +40,7 @@ def params_show(
     result = params_mod.collect_params_from_stages(stages_list)
 
     if result["unknown_stages"]:
-        available = registry.REGISTRY.list_stages()
+        available = cli_helpers.list_stages()
         raise exceptions.StageNotFoundError(result["unknown_stages"], available_stages=available)
 
     output = params_mod.format_params_table(result["params"], output_format, precision)
@@ -73,7 +74,7 @@ def params_diff(
     workspace_result = params_mod.collect_params_from_stages(stages_list)
 
     if workspace_result["unknown_stages"]:
-        available = registry.REGISTRY.list_stages()
+        available = cli_helpers.list_stages()
         raise exceptions.StageNotFoundError(
             workspace_result["unknown_stages"], available_stages=available
         )

--- a/src/pivot/cli/status.py
+++ b/src/pivot/cli/status.py
@@ -6,7 +6,7 @@ import sys
 import click
 import tqdm
 
-from pivot import config, exceptions, project, registry
+from pivot import config, exceptions, project
 from pivot import status as status_mod
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
@@ -72,16 +72,16 @@ def status(
 
     if show_stages:
         # Build bipartite graph for consistent execution order with Engine
-        all_stages = {name: registry.REGISTRY.get(name) for name in registry.REGISTRY.list_stages()}
+        all_stages = cli_helpers.get_all_stages()
         graph = engine_graph.build_graph(all_stages)
 
         if explain:
             pipeline_explanations = status_mod.get_pipeline_explanations(
-                stages_list, single_stage=False, graph=graph
+                stages_list, single_stage=False, all_stages=all_stages, graph=graph
             )
         else:
             pipeline_status, _ = status_mod.get_pipeline_status(
-                stages_list, single_stage=False, graph=graph
+                stages_list, single_stage=False, all_stages=all_stages, graph=graph
             )
 
     if show_tracked:

--- a/src/pivot/cli/targets.py
+++ b/src/pivot/cli/targets.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import click
 
-from pivot import outputs, project, registry
+from pivot import outputs, project
+from pivot.cli import helpers as cli_helpers
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -50,7 +51,7 @@ def _classify_targets(
     proj_root: Path,
 ) -> list[ResolvedTarget]:
     """Classify each target as stage, file, both, or neither."""
-    registered_stages = set(registry.REGISTRY.list_stages())
+    registered_stages = set(cli_helpers.list_stages())
     results = list[ResolvedTarget]()
 
     for target in targets:
@@ -90,7 +91,7 @@ def resolve_output_paths(
 
     for item in _classify_targets(targets, proj_root):
         if item["is_stage"]:
-            info = registry.REGISTRY.get(item["target"])
+            info = cli_helpers.get_stage(item["target"])
             for out in info["outs"]:
                 if isinstance(out, output_type):
                     # Registry always stores single-file outputs (multi-file are expanded)
@@ -121,7 +122,7 @@ def resolve_plot_infos(
 
     for item in _classify_targets(targets, proj_root):
         if item["is_stage"]:
-            info = registry.REGISTRY.get(item["target"])
+            info = cli_helpers.get_stage(item["target"])
             for out in info["outs"]:
                 if isinstance(out, outputs.Plot):
                     # Registry always stores single-file outputs (multi-file are expanded)

--- a/src/pivot/cli/track.py
+++ b/src/pivot/cli/track.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 
 import click
 
-from pivot import config, project, registry
+from pivot import config, project
 from pivot.cli import decorators as cli_decorators
 from pivot.cli import helpers as cli_helpers
 from pivot.storage import cache
@@ -50,8 +50,8 @@ def _get_all_stage_outputs() -> dict[str, pathlib.Path]:
         This provides clear error messages showing ALL issues at once.
     """
     outputs_normalized = set[str]()
-    for stage_name in registry.REGISTRY.list_stages():
-        info = registry.REGISTRY.get(stage_name)
+    for stage_name in cli_helpers.list_stages():
+        info = cli_helpers.get_stage(stage_name)
         outputs_normalized.update(info.get("outs_paths", []))
 
     # Pre-resolve all stage outputs with explicit error handling

--- a/src/pivot/cli/verify.py
+++ b/src/pivot/cli/verify.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 import click
 
-from pivot import config, exceptions, registry
+from pivot import config, exceptions
 from pivot import status as status_mod
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
@@ -233,7 +233,7 @@ def verify(
     cli_helpers.validate_stages_exist(stages_list)
 
     # Check if any stages are registered
-    all_stages = registry.REGISTRY.list_stages()
+    all_stages = cli_helpers.get_all_stages()
     if not all_stages:
         raise click.ClickException("No stages registered. Nothing to verify.")
 
@@ -245,7 +245,11 @@ def verify(
     # When allow_missing is set, skip DAG validation so missing dependency files
     # don't cause DependencyNotFoundError before we can check the remote
     pipeline_status, _ = status_mod.get_pipeline_status(
-        stages_list, single_stage=False, validate=not allow_missing, allow_missing=allow_missing
+        stages_list,
+        single_stage=False,
+        all_stages=all_stages,
+        validate=not allow_missing,
+        allow_missing=allow_missing,
     )
 
     if not pipeline_status:

--- a/src/pivot/discovery.py
+++ b/src/pivot/discovery.py
@@ -4,11 +4,13 @@ import logging
 import runpy
 from typing import TYPE_CHECKING
 
-from pivot import fingerprint, metrics, project, registry
+from pivot import fingerprint, metrics, project
 from pivot.pipeline import yaml as pipeline_config
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pivot.pipeline.pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -20,21 +22,21 @@ class DiscoveryError(Exception):
     """Error during pipeline discovery."""
 
 
-def discover_and_register(project_root: Path | None = None) -> str | None:
-    """Discover and register pipeline from pivot.yaml or pipeline.py.
+def discover_pipeline(project_root: Path | None = None) -> Pipeline | None:
+    """Discover and return Pipeline from pivot.yaml or pipeline.py.
 
     Looks in project root for:
-    1. pivot.yaml (or pivot.yml) - uses pipeline_config to register
-    2. pipeline.py - imports module which should register stages
+    1. pivot.yaml (or pivot.yml) - creates implicit Pipeline
+    2. pipeline.py - looks for `pipeline` variable (Pipeline instance)
 
     Args:
         project_root: Override project root (default: auto-detect)
 
     Returns:
-        Path to the discovered file, or None if nothing found
+        Pipeline instance, or None if nothing found
 
     Raises:
-        DiscoveryError: If discovery or registration fails, or if both config types exist
+        DiscoveryError: If discovery fails, or if both config types exist
     """
     with metrics.timed("discovery.total"):
         root = project_root or project.get_project_root()
@@ -56,12 +58,11 @@ def discover_and_register(project_root: Path | None = None) -> str | None:
                 f"Found both {yaml_path.name} and {PIPELINE_PY_NAME} in {root}. Remove one to resolve ambiguity."
             )
 
-        # Register from yaml if found
+        # Load from yaml if found
         if yaml_path:
             logger.info(f"Discovered {yaml_path}")
             try:
-                pipeline_config.register_from_pipeline_file(yaml_path)
-                return str(yaml_path)
+                return pipeline_config.load_pipeline_from_yaml(yaml_path)
             except pipeline_config.PipelineConfigError as e:
                 raise DiscoveryError(f"Failed to load {yaml_path}: {e}") from e
 
@@ -69,24 +70,48 @@ def discover_and_register(project_root: Path | None = None) -> str | None:
         if pipeline_exists:
             logger.info(f"Discovered {pipeline_path}")
             try:
-                _import_pipeline_module(pipeline_path)
-                return str(pipeline_path)
+                return _load_pipeline_from_module(pipeline_path)
             except SystemExit as e:
                 raise DiscoveryError(f"Pipeline {pipeline_path} called sys.exit({e.code})") from e
+            except DiscoveryError:
+                # Re-raise DiscoveryError without wrapping
+                raise
             except Exception as e:
                 raise DiscoveryError(f"Failed to load {pipeline_path}: {e}") from e
             finally:
-                # Flush pending AST hash writes even if registration failed partway
                 fingerprint.flush_ast_hash_cache()
 
         return None
 
 
-def has_registered_stages() -> bool:
-    """Check if any stages are registered."""
-    return len(registry.REGISTRY.list_stages()) > 0
+def _load_pipeline_from_module(path: Path) -> Pipeline | None:
+    """Load Pipeline instance from a pipeline.py file.
 
+    Returns None if the file doesn't define a 'pipeline' variable.
+    Raises DiscoveryError if:
+    - 'pipeline' variable exists but isn't a Pipeline instance
+    - A Pipeline instance exists under a different variable name (likely typo)
+    """
+    from pivot.pipeline.pipeline import Pipeline
 
-def _import_pipeline_module(path: Path) -> None:
-    """Execute a pipeline.py file, registering its stages."""
-    runpy.run_path(str(path), run_name="_pivot_pipeline")
+    module_dict = runpy.run_path(str(path), run_name="_pivot_pipeline")
+
+    # Look for 'pipeline' variable
+    pipeline = module_dict.get("pipeline")
+    if pipeline is not None:
+        if not isinstance(pipeline, Pipeline):
+            raise DiscoveryError(
+                f"{path} defines 'pipeline' but it's not a Pipeline instance (got {type(pipeline).__name__})"
+            )
+        return pipeline
+
+    # No 'pipeline' variable - check if there's a Pipeline under a different name
+    # This catches cases where user creates a Pipeline but forgets to name it 'pipeline'
+    for name, value in module_dict.items():
+        if isinstance(value, Pipeline):
+            raise DiscoveryError(
+                f"{path} does not define a 'pipeline' variable. Found Pipeline instance named '{name}' - rename it to 'pipeline'."
+            )
+
+    # No Pipeline found anywhere
+    return None

--- a/src/pivot/engine/sinks.py
+++ b/src/pivot/engine/sinks.py
@@ -266,16 +266,10 @@ class WatchSink:
             with contextlib.suppress(queue.Full):
                 self._queue.put_nowait(restart_msg)
 
-            # Import registry here to avoid circular import
-            from pivot import registry
-
             # Send reload notification with stage list and changes
-            # Use blocking put with timeout for reload_msg - more important than restart_msg,
-            # but still acceptable to drop if queue stays full for 1s (unlikely in practice)
-            new_stages = list(registry.REGISTRY.list_stages())
             reload_msg = TuiReloadMessage(
                 type=TuiMessageType.RELOAD,
-                stages=new_stages,
+                stages=event["stages"],
                 stages_added=event["stages_added"],
                 stages_removed=event["stages_removed"],
                 stages_modified=event["stages_modified"],

--- a/src/pivot/exceptions.py
+++ b/src/pivot/exceptions.py
@@ -372,3 +372,11 @@ class AlreadyInitializedError(InitError):
     @override
     def get_suggestion(self) -> str:
         return "Use --force to reinitialize"
+
+
+class PipelineNotFoundError(PivotError):
+    """Raised when no pipeline is found (no pivot.yaml or pipeline.py)."""
+
+    @override
+    def get_suggestion(self) -> str:
+        return "Create pivot.yaml or pipeline.py to define your pipeline"

--- a/src/pivot/pipeline/__init__.py
+++ b/src/pivot/pipeline/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 from pivot.pipeline import yaml as yaml
+from pivot.pipeline.pipeline import Pipeline as Pipeline

--- a/src/pivot/pipeline/pipeline.py
+++ b/src/pivot/pipeline/pipeline.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+from typing import TYPE_CHECKING
+
+from pivot import outputs, registry
+from pivot.pipeline.yaml import PipelineConfigError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from networkx import DiGraph
+
+    from pivot.types import StageFunc
+
+# Pipeline name pattern: alphanumeric, underscore, hyphen (like stage names)
+_PIPELINE_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
+
+
+class Pipeline:
+    """A pipeline with its own stage registry and state directory.
+
+    Each pipeline maintains isolated state (lock files, state.db) while
+    sharing the project-wide cache.
+
+    Args:
+        name: Pipeline identifier for logging and display.
+        root: Home directory for this pipeline. Defaults to the directory
+            containing the file where Pipeline() is called.
+    """
+
+    _name: str
+    _root: pathlib.Path
+    _registry: registry.StageRegistry
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        root: pathlib.Path | None = None,
+    ) -> None:
+        # Validate pipeline name
+        if not name:
+            raise PipelineConfigError("Pipeline name cannot be empty")
+        if not _PIPELINE_NAME_PATTERN.match(name):
+            raise PipelineConfigError(
+                f"Invalid pipeline name '{name}'. Must start with a letter and contain only alphanumeric characters, underscores, or hyphens."
+            )
+
+        self._name = name
+        self._registry = registry.StageRegistry()
+
+        if root is not None:
+            self._root = root.resolve()
+        else:
+            # Infer from caller's __file__
+            frame = inspect.currentframe()
+            try:
+                if frame is None or frame.f_back is None:
+                    raise RuntimeError("Cannot determine caller frame")
+                caller_file = frame.f_back.f_globals.get("__file__")
+                if caller_file is None:
+                    raise RuntimeError(
+                        "Cannot determine caller's __file__. Provide an explicit root= argument when creating Pipeline from interactive code, exec(), or similar contexts."
+                    )
+                self._root = pathlib.Path(caller_file).resolve().parent
+            finally:
+                del frame
+
+    @property
+    def name(self) -> str:
+        """Pipeline name."""
+        return self._name
+
+    @property
+    def root(self) -> pathlib.Path:
+        """Pipeline root directory."""
+        return self._root
+
+    @property
+    def state_dir(self) -> pathlib.Path:
+        """State directory for this pipeline's lock files and state.db."""
+        return self._root / ".pivot"
+
+    def register(
+        self,
+        func: StageFunc,
+        *,
+        name: str | None = None,
+        params: registry.ParamsArg = None,
+        mutex: list[str] | None = None,
+        variant: str | None = None,
+        dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+        out_path_overrides: Mapping[str, registry.OutOverrideInput] | None = None,
+    ) -> None:
+        """Register a stage with this pipeline.
+
+        The stage will use this pipeline's state_dir for lock files and state.db.
+        """
+        self._registry.register(
+            func=func,
+            name=name,
+            params=params,
+            mutex=mutex,
+            variant=variant,
+            dep_path_overrides=dep_path_overrides,
+            out_path_overrides=out_path_overrides,
+            state_dir=self.state_dir,
+        )
+
+    def list_stages(self) -> list[str]:
+        """List all registered stage names."""
+        return self._registry.list_stages()
+
+    def get(self, name: str) -> registry.RegistryStageInfo:
+        """Get stage info by name."""
+        return self._registry.get(name)
+
+    def build_dag(self, validate: bool = True) -> DiGraph[str]:
+        """Build DAG from registered stages.
+
+        Args:
+            validate: If True, validate that all dependencies exist
+
+        Returns:
+            NetworkX DiGraph with stages as nodes and dependencies as edges
+
+        Raises:
+            CyclicGraphError: If graph contains cycles
+            DependencyNotFoundError: If dependency doesn't exist (when validate=True)
+        """
+        return self._registry.build_dag(validate=validate)
+
+    def snapshot(self) -> dict[str, registry.RegistryStageInfo]:
+        """Create a snapshot of current registry state for backup/restore."""
+        return self._registry.snapshot()
+
+    def invalidate_dag_cache(self) -> None:
+        """Invalidate cached DAG without clearing stages."""
+        self._registry.invalidate_dag_cache()
+
+    def restore(self, snapshot: dict[str, registry.RegistryStageInfo]) -> None:
+        """Restore registry state from a previous snapshot."""
+        self._registry.restore(snapshot)
+
+    def clear(self) -> None:
+        """Clear all registered stages (for testing)."""
+        self._registry.clear()

--- a/src/pivot/show/params.py
+++ b/src/pivot/show/params.py
@@ -44,19 +44,19 @@ def collect_params_from_stages(
 
     Returns CollectResult with params dict and list of unknown stage names.
     """
-    from pivot import registry
+    from pivot.cli import helpers as cli_helpers
 
     result = dict[str, StageParams]()
     unknown_stages = list[str]()
     overrides = parameters.load_params_yaml()
 
-    available_stages = set(registry.REGISTRY.list_stages())
+    available_stages = set(cli_helpers.list_stages())
     stage_list = list(stages) if stages else list(available_stages)
     for stage_name in stage_list:
         if stage_name not in available_stages:
             unknown_stages.append(stage_name)
             continue
-        stage_info = registry.REGISTRY.get(stage_name)
+        stage_info = cli_helpers.get_stage(stage_name)
         effective = parameters.get_effective_params(stage_info["params"], stage_name, overrides)
         if effective:
             result[stage_name] = cast("StageParams", effective)
@@ -78,11 +78,11 @@ def get_params_from_head(
 
     Returns HeadResult with params dict and git availability flag.
     """
-    from pivot import registry
+    from pivot.cli import helpers as cli_helpers
 
     result = dict[str, StageParams]()
 
-    stage_list = list(stages) if stages else registry.REGISTRY.list_stages()
+    stage_list = list(stages) if stages else cli_helpers.list_stages()
     if not stage_list:
         return HeadResult(params=result, git_available=True)
 

--- a/src/pivot/tui/diff_panels.py
+++ b/src/pivot/tui/diff_panels.py
@@ -21,7 +21,7 @@ import textual.css.query
 import textual.widgets
 
 from pivot import config, explain, outputs, parameters, project
-from pivot.registry import REGISTRY
+from pivot.cli import helpers as cli_helpers
 from pivot.show import data as data_mod
 from pivot.show import metrics as metrics_mod
 from pivot.show.metrics import MetricDiff
@@ -429,7 +429,7 @@ class InputDiffPanel(_SelectableExpandablePanel):
     def _load_stage_data(self, stage_name: str) -> None:  # pragma: no cover
         """Load and cache stage data."""
         try:
-            self._registry_info = REGISTRY.get(stage_name)
+            self._registry_info = cli_helpers.get_stage(stage_name)
         except KeyError:
             logger.debug("Stage %s not in registry", stage_name)
             return
@@ -688,7 +688,7 @@ class InputDiffPanel(_SelectableExpandablePanel):
         self._explanation = snapshot
         self._stage_name = snapshot["stage_name"]
         try:
-            self._registry_info = REGISTRY.get(snapshot["stage_name"])
+            self._registry_info = cli_helpers.get_stage(snapshot["stage_name"])
         except KeyError:
             self._registry_info = None
         self._code_by_key = {c["key"]: c for c in snapshot["code_changes"]}
@@ -740,7 +740,7 @@ class OutputDiffPanel(_SelectableExpandablePanel):
     def _load_stage_data(self, stage_name: str) -> None:  # pragma: no cover
         """Load and cache stage data."""
         try:
-            self._registry_info = REGISTRY.get(stage_name)
+            self._registry_info = cli_helpers.get_stage(stage_name)
         except KeyError:
             logger.debug("Stage %s not in registry", stage_name)
             return
@@ -1115,7 +1115,7 @@ class OutputDiffPanel(_SelectableExpandablePanel):
         self._stage_name = stage_name
         self._stage_status = status
         try:
-            self._registry_info = REGISTRY.get(stage_name)
+            self._registry_info = cli_helpers.get_stage(stage_name)
         except KeyError:
             self._registry_info = None
         self._output_by_path = {c["path"]: c for c in changes}

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -35,9 +35,9 @@ import textual.widget
 import textual.widgets
 
 from pivot import config, explain, parameters, project
+from pivot.cli import helpers as cli_helpers
 from pivot.executor import ExecutionSummary
 from pivot.executor import commit as commit_mod
-from pivot.registry import REGISTRY
 from pivot.storage import lock, project_lock
 from pivot.tui import agent_server, diff_panels
 from pivot.tui.diff_panels import InputDiffPanel, OutputDiffPanel
@@ -698,7 +698,7 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
         """Create a new history entry when stage starts executing."""
         input_snapshot = None
         try:
-            registry_info = REGISTRY.get(stage_name)
+            registry_info = cli_helpers.get_stage(stage_name)
             state_dir = config.get_state_dir()
             input_snapshot = explain.get_stage_explanation(
                 stage_name=stage_name,
@@ -754,7 +754,7 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
         else:
             output_snapshot: list[OutputChange] | None = None
             try:
-                registry_info = REGISTRY.get(stage_name)
+                registry_info = cli_helpers.get_stage(stage_name)
                 state_dir = config.get_state_dir()
                 stages_dir = lock.get_stages_dir(state_dir)
                 lock_data = lock.StageLock(stage_name, stages_dir).read()

--- a/tests/cli/test_cli_completion.py
+++ b/tests/cli/test_cli_completion.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
+    from pivot.pipeline.pipeline import Pipeline
+
 
 def _noop() -> None:
     """Module-level no-op function for stage registration in tests."""
@@ -220,8 +222,9 @@ def test_find_project_root_fast_returns_none_when_no_marker(
 # =============================================================================
 
 
-def test_get_stages_full_returns_registered_stages() -> None:
+def test_get_stages_full_returns_registered_stages(mock_discovery: Pipeline) -> None:
     """Returns stages from registry after registration."""
+    _ = mock_discovery
 
     # Register real stages (autouse fixture clears registry between tests)
     register_test_stage(_noop, name="stage1")
@@ -284,9 +287,13 @@ stages:
 
 
 def test_complete_stages_falls_back_to_registry(
-    mock_ctx: mock.MagicMock, mock_param: mock.MagicMock, mocker: MockerFixture
+    mock_discovery: Pipeline,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
+    mocker: MockerFixture,
 ) -> None:
     """Falls back to registry when fast path returns None (no YAML)."""
+    _ = mock_discovery
 
     # No YAML file, fast path returns None
     mocker.patch.object(completion, "_find_project_root_fast", return_value=None)

--- a/tests/cli/test_cli_export.py
+++ b/tests/cli/test_cli_export.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
     from click.testing import CliRunner
 
+    from pivot.pipeline.pipeline import Pipeline
+
 
 # =============================================================================
 # Module-level TypedDicts and Stage Functions for annotation-based registration
@@ -104,10 +106,12 @@ def test_export_help_shows_options(runner: CliRunner) -> None:
 
 
 def test_export_default_output_creates_dvc_yaml(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Export without args creates dvc.yaml in current directory."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_with_data_dep, name="preprocess")
@@ -121,10 +125,12 @@ def test_export_default_output_creates_dvc_yaml(
 
 
 def test_export_custom_output_path(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Export with --output writes to specified path."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_no_deps, name="preprocess")
@@ -137,10 +143,12 @@ def test_export_custom_output_path(
 
 
 def test_export_specific_stages_only(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Export with stage names exports only those stages."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_a_txt, name="preprocess")
@@ -160,10 +168,12 @@ def test_export_specific_stages_only(
 
 
 def test_export_generates_params_yaml(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Export generates params.yaml with Pydantic model defaults."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(
@@ -186,10 +196,12 @@ def test_export_generates_params_yaml(
 
 
 def test_export_unknown_stage_error(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Export with unknown stage name shows error."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_a_txt, name="preprocess")
@@ -202,10 +214,12 @@ def test_export_unknown_stage_error(
 
 
 def test_export_no_stages_error(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     tmp_path: Path,
 ) -> None:
     """Export with no registered stages shows error."""
+    _ = mock_discovery
     (tmp_path / ".git").mkdir()
 
     with contextlib.chdir(tmp_path):
@@ -216,10 +230,12 @@ def test_export_no_stages_error(
 
 
 def test_export_dvc_yaml_structure(
+    mock_discovery: Pipeline,
     runner: CliRunner,
     set_project_root: Path,
 ) -> None:
     """Exported dvc.yaml has correct structure with cmd, deps, outs."""
+    _ = mock_discovery
     (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_with_input_dep, name="preprocess")

--- a/tests/cli/test_cli_list.py
+++ b/tests/cli/test_cli_list.py
@@ -10,6 +10,8 @@ from pivot import cli, loaders, outputs
 if TYPE_CHECKING:
     import click.testing
 
+    from pivot.pipeline.pipeline import Pipeline
+
 
 # =============================================================================
 # Output TypedDicts for annotation-based stages
@@ -75,9 +77,12 @@ def _helper_consumer(
 
 
 def test_list_no_stages_explains_how_to_create(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
 ) -> None:
     """Empty pipeline shows help text for creating stages."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
 
@@ -89,8 +94,13 @@ def test_list_no_stages_explains_how_to_create(
         assert "pivot.yaml" in result.output
 
 
-def test_list_no_stages_json(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_list_no_stages_json(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+) -> None:
     """Returns {"stages": []} for JSON output with no stages."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
 
@@ -107,8 +117,11 @@ def test_list_no_stages_json(runner: click.testing.CliRunner, tmp_path: pathlib.
 # =============================================================================
 
 
-def test_list_with_stages_json(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_list_with_stages_json(
+    mock_discovery: Pipeline, runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
     """JSON output includes name, deps, outs, mutex, variant for all stages."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
         pathlib.Path("input.txt").write_text("data")
@@ -144,9 +157,10 @@ def test_list_with_stages_json(runner: click.testing.CliRunner, tmp_path: pathli
 
 
 def test_list_deps_shows_source_stage(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline, runner: click.testing.CliRunner, tmp_path: pathlib.Path
 ) -> None:
     """--deps shows source stage for dependencies that are outputs of other stages."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
         pathlib.Path("input.txt").write_text("data")

--- a/tests/cli/test_cli_plots.py
+++ b/tests/cli/test_cli_plots.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import pathlib
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,7 +9,11 @@ from conftest import GitRepo, init_git_repo
 from pivot import cli
 
 if TYPE_CHECKING:
+    import pathlib
+
     import click.testing
+
+    from pivot.pipeline.pipeline import Pipeline
 
 
 # =============================================================================
@@ -46,8 +49,11 @@ def test_plots_show_help(runner: click.testing.CliRunner) -> None:
     assert "--open" in result.output
 
 
-def test_plots_show_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_plots_show_no_plots(
+    mock_discovery: Pipeline, runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
     """plots show with no registered plots should report empty."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(cli.cli, ["plots", "show"])
         assert result.exit_code == 0
@@ -55,49 +61,59 @@ def test_plots_show_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.
 
 
 def test_plots_show_explicit_file_no_stages(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #62: plots show TARGET should work with explicit file when no stages registered."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        # Create a plot file
-        plot_file = pathlib.Path("results.png")
-        plot_file.write_bytes(b"fake png data")
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    # Create a plot file
+    plot_file = tmp_path / "results.png"
+    plot_file.write_bytes(b"fake png data")
 
-        # Should work even with no stages registered
-        result = runner.invoke(cli.cli, ["plots", "show", str(plot_file)])
+    # Should work even with no stages registered
+    result = runner.invoke(cli.cli, ["plots", "show", "results.png"])
 
-        # Should not fail with "stage not found" error
-        assert result.exit_code == 0
-        assert "Rendered 1 plot(s)" in result.output
+    # Should not fail with "stage not found" error
+    assert result.exit_code == 0
+    assert "Rendered 1 plot(s)" in result.output
 
 
 def test_plots_show_creates_html(
-    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """plots show creates HTML output file with explicit file target."""
-    plot_file = set_project_root / "plot.png"
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    plot_file = tmp_path / "plot.png"
     plot_file.write_bytes(b"fake png data")
 
-    with runner.isolated_filesystem(temp_dir=set_project_root):
-        result = runner.invoke(cli.cli, ["plots", "show", str(plot_file)])
-        assert result.exit_code == 0
-        assert "Rendered 1 plot(s)" in result.output
+    result = runner.invoke(cli.cli, ["plots", "show", "plot.png"])
+    assert result.exit_code == 0
+    assert "Rendered 1 plot(s)" in result.output
 
 
 def test_plots_show_custom_output_path(
-    runner: click.testing.CliRunner, set_project_root: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """plots show with custom output path."""
-    plot_file = set_project_root / "plot.png"
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    plot_file = tmp_path / "plot.png"
     plot_file.write_bytes(b"fake png data")
 
-    with runner.isolated_filesystem(temp_dir=set_project_root):
-        result = runner.invoke(
-            cli.cli, ["plots", "show", str(plot_file), "-o", "custom/output.html"]
-        )
-        assert result.exit_code == 0
-        assert "custom/output.html" in result.output
+    result = runner.invoke(cli.cli, ["plots", "show", "plot.png", "-o", "custom/output.html"])
+    assert result.exit_code == 0
+    assert "custom/output.html" in result.output
 
 
 # =============================================================================
@@ -114,8 +130,11 @@ def test_plots_diff_help(runner: click.testing.CliRunner) -> None:
     assert "--no-path" in result.output
 
 
-def test_plots_diff_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_plots_diff_no_plots(
+    mock_discovery: Pipeline, runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
     """plots diff with no registered plots should report empty."""
+    _ = mock_discovery
     with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(cli.cli, ["plots", "diff"])
         assert result.exit_code == 0
@@ -123,27 +142,36 @@ def test_plots_diff_no_plots(runner: click.testing.CliRunner, tmp_path: pathlib.
 
 
 def test_plots_diff_explicit_file_no_stages(
+    mock_discovery: Pipeline,
     runner: click.testing.CliRunner,
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #62: plots diff TARGET should work with explicit file when no stages registered."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        init_git_repo(pathlib.Path("."), monkeypatch)
-        # Create a plot file
-        plot_file = pathlib.Path("results.png")
-        plot_file.write_bytes(b"fake png data")
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    init_git_repo(tmp_path, monkeypatch)
+    # Create a plot file
+    plot_file = tmp_path / "results.png"
+    plot_file.write_bytes(b"fake png data")
 
-        # Should work even with no stages registered
-        result = runner.invoke(cli.cli, ["plots", "diff", str(plot_file)])
+    # Should work even with no stages registered
+    result = runner.invoke(cli.cli, ["plots", "diff", "results.png"])
 
-        # Should not fail with "stage not found" error
-        assert result.exit_code == 0
+    # Should not fail with "stage not found" error
+    assert result.exit_code == 0
 
 
-def test_plots_diff_json_format(runner: click.testing.CliRunner, git_repo: GitRepo) -> None:
+def test_plots_diff_json_format(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """plots diff --json returns valid JSON with explicit file target."""
+    _ = mock_discovery
     repo_path, commit = git_repo
+    monkeypatch.chdir(repo_path)
 
     plot_file = repo_path / "plot.png"
     plot_file.write_bytes(b"fake png data")
@@ -154,20 +182,26 @@ def test_plots_diff_json_format(runner: click.testing.CliRunner, git_repo: GitRe
     # Modify the plot file
     plot_file.write_bytes(b"modified png data")
 
-    with runner.isolated_filesystem(temp_dir=repo_path):
-        result = runner.invoke(cli.cli, ["plots", "diff", "--json", str(plot_file)])
-        assert result.exit_code == 0
-        # Output should be valid JSON
-        try:
-            parsed = json.loads(result.output)
-            assert isinstance(parsed, list)
-        except json.JSONDecodeError:
-            pytest.fail(f"Output is not valid JSON: {result.output}")
+    result = runner.invoke(cli.cli, ["plots", "diff", "--json", "plot.png"])
+    assert result.exit_code == 0
+    # Output should be valid JSON
+    try:
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+    except json.JSONDecodeError:
+        pytest.fail(f"Output is not valid JSON: {result.output}")
 
 
-def test_plots_diff_md_format(runner: click.testing.CliRunner, git_repo: GitRepo) -> None:
+def test_plots_diff_md_format(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """plots diff --md returns markdown table with explicit file target."""
+    _ = mock_discovery
     repo_path, commit = git_repo
+    monkeypatch.chdir(repo_path)
 
     plot_file = repo_path / "plot.png"
     plot_file.write_bytes(b"fake png data")
@@ -178,15 +212,21 @@ def test_plots_diff_md_format(runner: click.testing.CliRunner, git_repo: GitRepo
     # Modify the plot file
     plot_file.write_bytes(b"modified png data")
 
-    with runner.isolated_filesystem(temp_dir=repo_path):
-        result = runner.invoke(cli.cli, ["plots", "diff", "--md", str(plot_file)])
-        assert result.exit_code == 0
-        assert "|" in result.output  # Markdown table uses pipes
+    result = runner.invoke(cli.cli, ["plots", "diff", "--md", "plot.png"])
+    assert result.exit_code == 0
+    assert "|" in result.output  # Markdown table uses pipes
 
 
-def test_plots_diff_no_path_flag(runner: click.testing.CliRunner, git_repo: GitRepo) -> None:
+def test_plots_diff_no_path_flag(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """plots diff --no-path hides path column with explicit file target."""
+    _ = mock_discovery
     repo_path, commit = git_repo
+    monkeypatch.chdir(repo_path)
 
     plot_file = repo_path / "plot.png"
     plot_file.write_bytes(b"fake png data")
@@ -197,7 +237,6 @@ def test_plots_diff_no_path_flag(runner: click.testing.CliRunner, git_repo: GitR
     # Modify the plot file
     plot_file.write_bytes(b"modified png data")
 
-    with runner.isolated_filesystem(temp_dir=repo_path):
-        result = runner.invoke(cli.cli, ["plots", "diff", "--no-path", str(plot_file)])
-        assert result.exit_code == 0
-        assert "Path" not in result.output
+    result = runner.invoke(cli.cli, ["plots", "diff", "--no-path", "plot.png"])
+    assert result.exit_code == 0
+    assert "Path" not in result.output

--- a/tests/cli/test_cli_track.py
+++ b/tests/cli/test_cli_track.py
@@ -4,11 +4,14 @@ import pathlib
 from typing import TYPE_CHECKING, Annotated, TypedDict
 
 from helpers import register_test_stage
-from pivot import cli, loaders, outputs, project
+from pivot import cli, loaders, outputs
 from pivot.storage import track
 
 if TYPE_CHECKING:
     import click.testing
+    import pytest
+
+    from pivot.pipeline.pipeline import Pipeline
 
 
 # =============================================================================
@@ -88,108 +91,126 @@ def _process_real_data() -> _RealDataCsv:
 # =============================================================================
 
 
-def test_track_single_file(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_track_single_file(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Track one file creates .pvt file."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        data_file = pathlib.Path("data.txt")
-        data_file.write_text("tracked content")
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("tracked content")
 
-        result = runner.invoke(cli.cli, ["track", "data.txt"])
+    result = runner.invoke(cli.cli, ["track", "data.txt"])
 
-        assert result.exit_code == 0, f"Failed: {result.output}"
-        assert "Tracked: data.txt" in result.output
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Tracked: data.txt" in result.output
 
-        # .pvt file should exist
-        pvt_path = pathlib.Path("data.txt.pvt")
-        assert pvt_path.exists()
+    # .pvt file should exist
+    pvt_path = tmp_path / "data.txt.pvt"
+    assert pvt_path.exists()
 
-        # Read and verify .pvt content
-        pvt_data = track.read_pvt_file(pvt_path)
-        assert pvt_data is not None
-        assert pvt_data["path"] == "data.txt"
-        assert "hash" in pvt_data
-        assert "size" in pvt_data
+    # Read and verify .pvt content
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert pvt_data["path"] == "data.txt"
+    assert "hash" in pvt_data
+    assert "size" in pvt_data
 
 
-def test_track_directory(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_track_directory(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Track directory creates .pvt file with manifest."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create directory with files
-        data_dir = pathlib.Path("data_dir")
-        data_dir.mkdir()
-        (data_dir / "file1.txt").write_text("content1")
-        (data_dir / "file2.txt").write_text("content2")
+    # Create directory with files
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    (data_dir / "file1.txt").write_text("content1")
+    (data_dir / "file2.txt").write_text("content2")
 
-        result = runner.invoke(cli.cli, ["track", "data_dir"])
+    result = runner.invoke(cli.cli, ["track", "data_dir"])
 
-        assert result.exit_code == 0, f"Failed: {result.output}"
-        assert "Tracked: data_dir" in result.output
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Tracked: data_dir" in result.output
 
-        # .pvt file should exist
-        pvt_path = pathlib.Path("data_dir.pvt")
-        assert pvt_path.exists()
+    # .pvt file should exist
+    pvt_path = tmp_path / "data_dir.pvt"
+    assert pvt_path.exists()
 
-        # Read and verify .pvt content includes manifest
-        pvt_data = track.read_pvt_file(pvt_path)
-        assert pvt_data is not None
-        assert "manifest" in pvt_data
-        assert pvt_data.get("num_files") == 2
+    # Read and verify .pvt content includes manifest
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert "manifest" in pvt_data
+    assert pvt_data.get("num_files") == 2
 
 
-def test_track_force_overwrites(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_track_force_overwrites(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--force updates existing .pvt file."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        data_file = pathlib.Path("data.txt")
-        data_file.write_text("original content")
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("original content")
 
-        # First track
-        result = runner.invoke(cli.cli, ["track", "data.txt"])
-        assert result.exit_code == 0
+    # First track
+    result = runner.invoke(cli.cli, ["track", "data.txt"])
+    assert result.exit_code == 0
 
-        pvt_data_original = track.read_pvt_file(pathlib.Path("data.txt.pvt"))
-        original_hash = pvt_data_original["hash"] if pvt_data_original else ""
+    pvt_data_original = track.read_pvt_file(tmp_path / "data.txt.pvt")
+    original_hash = pvt_data_original["hash"] if pvt_data_original else ""
 
-        # Modify file
-        data_file.write_text("modified content")
+    # Modify file
+    data_file.write_text("modified content")
 
-        # Track again with --force
-        result = runner.invoke(cli.cli, ["track", "--force", "data.txt"])
+    # Track again with --force
+    result = runner.invoke(cli.cli, ["track", "--force", "data.txt"])
 
-        assert result.exit_code == 0
-        pvt_data_updated = track.read_pvt_file(pathlib.Path("data.txt.pvt"))
-        assert pvt_data_updated is not None
-        # Hash should be different due to modified content
-        assert pvt_data_updated["hash"] != original_hash
+    assert result.exit_code == 0
+    pvt_data_updated = track.read_pvt_file(tmp_path / "data.txt.pvt")
+    assert pvt_data_updated is not None
+    # Hash should be different due to modified content
+    assert pvt_data_updated["hash"] != original_hash
 
 
 def test_track_already_tracked_suggests_force(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Already tracked error suggests --force."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        data_file = pathlib.Path("data.txt")
-        data_file.write_text("content")
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("content")
 
-        # First track
-        runner.invoke(cli.cli, ["track", "data.txt"])
+    # First track
+    runner.invoke(cli.cli, ["track", "data.txt"])
 
-        # Try to track again without --force
-        result = runner.invoke(cli.cli, ["track", "data.txt"])
+    # Try to track again without --force
+    result = runner.invoke(cli.cli, ["track", "data.txt"])
 
-        assert result.exit_code != 0
-        assert "--force" in result.output
+    assert result.exit_code != 0
+    assert "--force" in result.output
 
 
 # =============================================================================
@@ -198,60 +219,66 @@ def test_track_already_tracked_suggests_force(
 
 
 def test_track_path_traversal_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Rejects paths with ../ components."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["track", "../outside.txt"])
+    result = runner.invoke(cli.cli, ["track", "../outside.txt"])
 
-        assert result.exit_code != 0
-        assert "traversal" in result.output.lower()
+    assert result.exit_code != 0
+    assert "traversal" in result.output.lower()
 
 
 def test_track_broken_symlink_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Rejects broken symlinks with clear error message."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create broken symlink
-        broken_link = pathlib.Path("broken_link")
-        broken_link.symlink_to("nonexistent_target")
+    # Create broken symlink
+    broken_link = tmp_path / "broken_link"
+    broken_link.symlink_to("nonexistent_target")
 
-        result = runner.invoke(cli.cli, ["track", "broken_link"])
+    result = runner.invoke(cli.cli, ["track", "broken_link"])
 
-        assert result.exit_code != 0
-        # Should mention broken symlink or target not existing
-        assert (
-            "broken symlink" in result.output.lower() or "does not exist" in result.output.lower()
-        )
+    assert result.exit_code != 0
+    # Should mention broken symlink or target not existing
+    assert "broken symlink" in result.output.lower() or "does not exist" in result.output.lower()
 
 
 def test_track_overlap_with_stage_output_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Rejects paths that overlap with declared stage outputs."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
-        pathlib.Path("input.txt").write_text("input")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "input.txt").write_text("input")
 
-        # Register a stage with output
-        register_test_stage(_helper_process, name="process")
+    # Register a stage with output
+    register_test_stage(_helper_process, name="process")
 
-        # Create the output file
-        pathlib.Path("output.txt").write_text("output")
+    # Create the output file
+    (tmp_path / "output.txt").write_text("output")
 
-        # Try to track the stage output
-        result = runner.invoke(cli.cli, ["track", "output.txt"])
+    # Try to track the stage output
+    result = runner.invoke(cli.cli, ["track", "output.txt"])
 
-        assert result.exit_code != 0
-        assert "stage output" in result.output.lower() or "overlap" in result.output.lower()
+    assert result.exit_code != 0
+    assert "stage output" in result.output.lower() or "overlap" in result.output.lower()
 
 
 # =============================================================================
@@ -260,54 +287,65 @@ def test_track_overlap_with_stage_output_rejected(
 
 
 def test_track_echoes_user_path_in_output(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Track echoes the path as user provided it."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        pathlib.Path("data.csv").write_text("a,b\n1,2")
+    (tmp_path / "data.csv").write_text("a,b\n1,2")
 
-        result = runner.invoke(cli.cli, ["track", "./data.csv"])
+    result = runner.invoke(cli.cli, ["track", "./data.csv"])
 
-        assert result.exit_code == 0, f"Failed: {result.output}"
-        # Output shows what user typed
-        assert "Tracked: ./data.csv" in result.output
-        # .pvt file should be created with normalized name
-        assert pathlib.Path("data.csv.pvt").exists()
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    # Output shows what user typed
+    assert "Tracked: ./data.csv" in result.output
+    # .pvt file should be created with normalized name
+    assert (tmp_path / "data.csv.pvt").exists()
 
 
 def test_track_file_not_found_error(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Track nonexistent file shows clear error."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["track", "nonexistent.txt"])
+    result = runner.invoke(cli.cli, ["track", "nonexistent.txt"])
 
-        assert result.exit_code != 0
-        assert "not found" in result.output.lower()
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
 
 
-def test_track_multiple_files(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_track_multiple_files(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Track multiple files at once."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path(".pivot").mkdir()
+    _ = mock_discovery
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        pathlib.Path("file1.txt").write_text("content1")
-        pathlib.Path("file2.txt").write_text("content2")
+    (tmp_path / "file1.txt").write_text("content1")
+    (tmp_path / "file2.txt").write_text("content2")
 
-        result = runner.invoke(cli.cli, ["track", "file1.txt", "file2.txt"])
+    result = runner.invoke(cli.cli, ["track", "file1.txt", "file2.txt"])
 
-        assert result.exit_code == 0
-        assert "Tracked: file1.txt" in result.output
-        assert "Tracked: file2.txt" in result.output
-        assert pathlib.Path("file1.txt.pvt").exists()
-        assert pathlib.Path("file2.txt.pvt").exists()
+    assert result.exit_code == 0
+    assert "Tracked: file1.txt" in result.output
+    assert "Tracked: file2.txt" in result.output
+    assert (tmp_path / "file1.txt.pvt").exists()
+    assert (tmp_path / "file2.txt.pvt").exists()
 
 
 # =============================================================================
@@ -316,161 +354,171 @@ def test_track_multiple_files(runner: click.testing.CliRunner, tmp_path: pathlib
 
 
 def test_track_symlink_to_stage_output_file_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tracking symlink that points to stage output file is rejected."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create stage output file
-        pathlib.Path("model.pkl").write_bytes(b"model")
+    # Create stage output file
+    (tmp_path / "model.pkl").write_bytes(b"model")
 
-        # Register stage with this file as output
-        register_test_stage(_train_model_pkl, name="train")
+    # Register stage with this file as output
+    register_test_stage(_train_model_pkl, name="train")
 
-        # Create symlink pointing to the stage output
-        pathlib.Path("model_link.pkl").symlink_to("model.pkl")
+    # Create symlink pointing to the stage output
+    (tmp_path / "model_link.pkl").symlink_to("model.pkl")
 
-        # Try to track the symlink
-        result = runner.invoke(cli.cli, ["track", "model_link.pkl"])
+    # Try to track the symlink
+    result = runner.invoke(cli.cli, ["track", "model_link.pkl"])
 
-        assert result.exit_code != 0, "Should reject symlink to stage output"
-        assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
-            "Error should mention overlap with stage output"
-        )
-        assert "resolves to" in result.output.lower(), (
-            "Error should show resolved path for debugging"
-        )
+    assert result.exit_code != 0, "Should reject symlink to stage output"
+    assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
+        "Error should mention overlap with stage output"
+    )
+    assert "resolves to" in result.output.lower(), "Error should show resolved path for debugging"
 
 
 def test_track_symlink_to_stage_output_directory_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tracking symlink that points to stage output directory is rejected."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create stage output directory
-        output_dir = pathlib.Path("outputs")
-        output_dir.mkdir()
-        (output_dir / "results.txt").write_text("data")
+    # Create stage output directory
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+    (output_dir / "results.txt").write_text("data")
 
-        # Register stage with directory as output (outputs/)
-        register_test_stage(_train_outputs_dir, name="process")
+    # Register stage with directory as output (outputs/)
+    register_test_stage(_train_outputs_dir, name="process")
 
-        # Create symlink pointing to the output directory
-        pathlib.Path("output_link").symlink_to("outputs")
+    # Create symlink pointing to the output directory
+    (tmp_path / "output_link").symlink_to("outputs")
 
-        # Try to track the symlink
-        result = runner.invoke(cli.cli, ["track", "output_link"])
+    # Try to track the symlink
+    result = runner.invoke(cli.cli, ["track", "output_link"])
 
-        assert result.exit_code != 0, "Should reject symlink to stage output directory"
-        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+    assert result.exit_code != 0, "Should reject symlink to stage output directory"
+    assert "overlap" in result.output.lower() or "output" in result.output.lower()
 
 
 def test_track_file_inside_symlinked_stage_output_rejected(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tracking file inside symlinked directory that's a stage output is rejected."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create actual directory with files
-        real_dir = pathlib.Path("real_outputs")
-        real_dir.mkdir()
-        (real_dir / "model.pkl").write_bytes(b"model")
+    # Create actual directory with files
+    real_dir = tmp_path / "real_outputs"
+    real_dir.mkdir()
+    (real_dir / "model.pkl").write_bytes(b"model")
 
-        # Create symlink to directory
-        pathlib.Path("outputs_link").symlink_to("real_outputs")
+    # Create symlink to directory
+    (tmp_path / "outputs_link").symlink_to("real_outputs")
 
-        # Register stage with symlinked path as output
-        register_test_stage(_process_outputs_link, name="train")
+    # Register stage with symlinked path as output
+    register_test_stage(_process_outputs_link, name="train")
 
-        # Try to track file via the real path
-        result = runner.invoke(cli.cli, ["track", "real_outputs/model.pkl"])
+    # Try to track file via the real path
+    result = runner.invoke(cli.cli, ["track", "real_outputs/model.pkl"])
 
-        assert result.exit_code != 0, "Should detect overlap through symlink aliasing"
-        assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
-            "Error should mention overlap with stage output"
-        )
+    assert result.exit_code != 0, "Should detect overlap through symlink aliasing"
+    assert "overlap" in result.output.lower() or "output" in result.output.lower(), (
+        "Error should mention overlap with stage output"
+    )
 
 
 def test_track_symlink_aliasing_same_file_different_paths(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tracking same file via different symlink paths detects aliasing."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create real file
-        pathlib.Path("real_data.csv").write_text("data")
+    # Create real file
+    (tmp_path / "real_data.csv").write_text("data")
 
-        # Create two symlinks to same file
-        pathlib.Path("link1.csv").symlink_to("real_data.csv")
-        pathlib.Path("link2.csv").symlink_to("real_data.csv")
+    # Create two symlinks to same file
+    (tmp_path / "link1.csv").symlink_to("real_data.csv")
+    (tmp_path / "link2.csv").symlink_to("real_data.csv")
 
-        # Register stage with one symlink as output
-        register_test_stage(_produce_link1, name="produce")
+    # Register stage with one symlink as output
+    register_test_stage(_produce_link1, name="produce")
 
-        # Try to track the other symlink (points to same file)
-        result = runner.invoke(cli.cli, ["track", "link2.csv"])
+    # Try to track the other symlink (points to same file)
+    result = runner.invoke(cli.cli, ["track", "link2.csv"])
 
-        assert result.exit_code != 0, "Should detect that link2 and link1 point to same file"
-        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+    assert result.exit_code != 0, "Should detect that link2 and link1 point to same file"
+    assert "overlap" in result.output.lower() or "output" in result.output.lower()
 
 
 def test_track_parent_directory_with_symlinked_stage_output(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tracking parent directory when child is symlinked stage output is rejected."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create directory structure
-        parent_dir = pathlib.Path("data")
-        parent_dir.mkdir()
-        real_file = parent_dir / "real_model.pkl"
-        real_file.write_bytes(b"model")
+    # Create directory structure
+    parent_dir = tmp_path / "data"
+    parent_dir.mkdir()
+    real_file = parent_dir / "real_model.pkl"
+    real_file.write_bytes(b"model")
 
-        # Create symlink inside parent directory
-        symlink = parent_dir / "model_link.pkl"
-        symlink.symlink_to("real_model.pkl")
+    # Create symlink inside parent directory
+    symlink = parent_dir / "model_link.pkl"
+    symlink.symlink_to("real_model.pkl")
 
-        # Register stage with symlink as output
-        register_test_stage(_train_model_link, name="train")
+    # Register stage with symlink as output
+    register_test_stage(_train_model_link, name="train")
 
-        # Try to track parent directory (contains stage output)
-        result = runner.invoke(cli.cli, ["track", "data"])
+    # Try to track parent directory (contains stage output)
+    result = runner.invoke(cli.cli, ["track", "data"])
 
-        assert result.exit_code != 0, "Should reject tracking directory containing stage output"
-        assert "overlap" in result.output.lower() or "output" in result.output.lower()
+    assert result.exit_code != 0, "Should reject tracking directory containing stage output"
+    assert "overlap" in result.output.lower() or "output" in result.output.lower()
 
 
 def test_track_with_normalized_vs_resolved_paths(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Error messages show both normalized and resolved paths for debugging."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        project._project_root_cache = None
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
 
-        # Create nested directory structure with symlink
-        pathlib.Path("real").mkdir()
-        pathlib.Path("real/data.csv").write_text("data")
-        pathlib.Path("link_to_real").symlink_to("real")
+    # Create nested directory structure with symlink
+    (tmp_path / "real").mkdir()
+    (tmp_path / "real/data.csv").write_text("data")
+    (tmp_path / "link_to_real").symlink_to("real")
 
-        # Register stage with real path
-        register_test_stage(_process_real_data, name="process")
+    # Register stage with real path
+    register_test_stage(_process_real_data, name="process")
 
-        # Try to track via symlinked path
-        result = runner.invoke(cli.cli, ["track", "link_to_real/data.csv"])
+    # Try to track via symlinked path
+    result = runner.invoke(cli.cli, ["track", "link_to_real/data.csv"])
 
-        assert result.exit_code != 0, "Should detect overlap via symlink"
-        # Both paths should appear in error for clarity
-        assert "link_to_real" in result.output, "Should show user's path"
-        assert "real" in result.output, "Should show resolved path"
+    assert result.exit_code != 0, "Should detect overlap via symlink"
+    # Both paths should appear in error for clarity
+    assert "link_to_real" in result.output, "Should show user's path"
+    assert "real" in result.output, "Should show resolved path"

--- a/tests/cli/test_dag_cmd.py
+++ b/tests/cli/test_dag_cmd.py
@@ -10,6 +10,9 @@ from pivot import cli, loaders, outputs
 
 if TYPE_CHECKING:
     import click.testing
+    import pytest
+
+    from pivot.pipeline.pipeline import Pipeline
 
 
 # =============================================================================
@@ -97,53 +100,71 @@ def _helper_merge(
 # =============================================================================
 
 
-def test_dag_empty_pipeline_ascii(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_empty_pipeline_ascii(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Empty pipeline shows empty graph placeholder in ASCII (default) format."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["dag"])
+    result = runner.invoke(cli.cli, ["dag"])
 
-        assert result.exit_code == 0
-        assert "(empty graph)" in result.output
+    assert result.exit_code == 0
+    assert "(empty graph)" in result.output
 
 
 def test_dag_empty_pipeline_mermaid(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Empty pipeline shows valid empty Mermaid flowchart."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["dag", "--mermaid"])
+    result = runner.invoke(cli.cli, ["dag", "--mermaid"])
 
-        assert result.exit_code == 0
-        assert result.output.strip() == "flowchart TD"
+    assert result.exit_code == 0
+    assert result.output.strip() == "flowchart TD"
 
 
-def test_dag_empty_pipeline_dot(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_empty_pipeline_dot(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Empty pipeline shows minimal DOT graph."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["dag", "--dot"])
+    result = runner.invoke(cli.cli, ["dag", "--dot"])
 
-        assert result.exit_code == 0
-        assert "digraph {" in result.output
-        assert "}" in result.output
+    assert result.exit_code == 0
+    assert "digraph {" in result.output
+    assert "}" in result.output
 
 
-def test_dag_empty_pipeline_md(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_empty_pipeline_md(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Empty pipeline shows Mermaid wrapped in markdown code block."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["dag", "--md"])
+    result = runner.invoke(cli.cli, ["dag", "--md"])
 
-        assert result.exit_code == 0
-        assert "```mermaid" in result.output
-        assert "```" in result.output
-        assert "flowchart TD" in result.output
+    assert result.exit_code == 0
+    assert "```mermaid" in result.output
+    assert "```" in result.output
+    assert "flowchart TD" in result.output
 
 
 # =============================================================================
@@ -151,33 +172,41 @@ def test_dag_empty_pipeline_md(runner: click.testing.CliRunner, tmp_path: pathli
 # =============================================================================
 
 
-def test_dag_single_stage_ascii(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_single_stage_ascii(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Single stage shows output artifact in ASCII."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_extract, name="extract")
 
-        result = runner.invoke(cli.cli, ["dag"])
+    result = runner.invoke(cli.cli, ["dag"])
 
-        assert result.exit_code == 0
-        # Should show the artifact path
-        assert "raw.csv" in result.output
+    assert result.exit_code == 0
+    # Should show the artifact path
+    assert "raw.csv" in result.output
 
 
 def test_dag_single_stage_stages_flag(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Single stage shows stage name with --stages flag."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_extract, name="extract")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--stages"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
 
 
 # =============================================================================
@@ -185,76 +214,96 @@ def test_dag_single_stage_stages_flag(
 # =============================================================================
 
 
-def test_dag_linear_chain_ascii(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_linear_chain_ascii(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Linear pipeline shows all artifacts in ASCII."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        result = runner.invoke(cli.cli, ["dag"])
+    result = runner.invoke(cli.cli, ["dag"])
 
-        assert result.exit_code == 0
-        assert "raw.csv" in result.output
-        assert "clean.csv" in result.output
-        assert "output.csv" in result.output
+    assert result.exit_code == 0
+    assert "raw.csv" in result.output
+    assert "clean.csv" in result.output
+    assert "output.csv" in result.output
 
 
-def test_dag_linear_chain_stages(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_linear_chain_stages(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Linear pipeline shows all stages with --stages flag."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--stages"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
-        assert "transform" in result.output
-        assert "load" in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
+    assert "transform" in result.output
+    assert "load" in result.output
 
 
-def test_dag_linear_chain_mermaid(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_linear_chain_mermaid(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Linear pipeline shows edges in Mermaid format."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        result = runner.invoke(cli.cli, ["dag", "--mermaid", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--mermaid", "--stages"])
 
-        assert result.exit_code == 0
-        assert "flowchart TD" in result.output
-        assert "extract" in result.output
-        assert "transform" in result.output
-        assert "load" in result.output
-        assert "-->" in result.output
+    assert result.exit_code == 0
+    assert "flowchart TD" in result.output
+    assert "extract" in result.output
+    assert "transform" in result.output
+    assert "load" in result.output
+    assert "-->" in result.output
 
 
-def test_dag_linear_chain_dot(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_linear_chain_dot(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Linear pipeline shows edges in DOT format."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        result = runner.invoke(cli.cli, ["dag", "--dot", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--dot", "--stages"])
 
-        assert result.exit_code == 0
-        assert "digraph {" in result.output
-        assert "extract" in result.output
-        assert "transform" in result.output
-        assert "load" in result.output
-        assert "->" in result.output
+    assert result.exit_code == 0
+    assert "digraph {" in result.output
+    assert "extract" in result.output
+    assert "transform" in result.output
+    assert "load" in result.output
+    assert "->" in result.output
 
 
 # =============================================================================
@@ -263,43 +312,49 @@ def test_dag_linear_chain_dot(runner: click.testing.CliRunner, tmp_path: pathlib
 
 
 def test_dag_diamond_pattern_stages(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Diamond pattern shows all stages."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_branch_a, name="branch_a")
-        register_test_stage(_helper_branch_b, name="branch_b")
-        register_test_stage(_helper_merge, name="merge")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_branch_a, name="branch_a")
+    register_test_stage(_helper_branch_b, name="branch_b")
+    register_test_stage(_helper_merge, name="merge")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--stages"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
-        assert "branch_a" in result.output
-        assert "branch_b" in result.output
-        assert "merge" in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
+    assert "branch_a" in result.output
+    assert "branch_b" in result.output
+    assert "merge" in result.output
 
 
 def test_dag_diamond_pattern_mermaid(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Diamond pattern shows correct edges in Mermaid."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_branch_a, name="branch_a")
-        register_test_stage(_helper_branch_b, name="branch_b")
-        register_test_stage(_helper_merge, name="merge")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_branch_a, name="branch_a")
+    register_test_stage(_helper_branch_b, name="branch_b")
+    register_test_stage(_helper_merge, name="merge")
 
-        result = runner.invoke(cli.cli, ["dag", "--mermaid", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--mermaid", "--stages"])
 
-        assert result.exit_code == 0
-        # Should have multiple edges (fan-out and fan-in)
-        assert result.output.count("-->") >= 4
+    assert result.exit_code == 0
+    # Should have multiple edges (fan-out and fan-in)
+    assert result.output.count("-->") >= 4
 
 
 # =============================================================================
@@ -307,80 +362,96 @@ def test_dag_diamond_pattern_mermaid(
 # =============================================================================
 
 
-def test_dag_target_single_stage(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_target_single_stage(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Target filtering by stage name shows stage and its upstream."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages", "transform"])
+    result = runner.invoke(cli.cli, ["dag", "--stages", "transform"])
 
-        assert result.exit_code == 0
-        # Should include extract (upstream) and transform
-        assert "extract" in result.output
-        assert "transform" in result.output
-        # Should NOT include load (downstream of transform)
-        assert "load" not in result.output
+    assert result.exit_code == 0
+    # Should include extract (upstream) and transform
+    assert "extract" in result.output
+    assert "transform" in result.output
+    # Should NOT include load (downstream of transform)
+    assert "load" not in result.output
 
 
-def test_dag_target_artifact_path(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_target_artifact_path(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Target filtering by artifact path resolves to producing stage and upstream."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
-        register_test_stage(_helper_load, name="load")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_load, name="load")
 
-        # Artifact path resolves to the stage that produces it and its upstream deps
-        result = runner.invoke(cli.cli, ["dag", "--stages", "clean.csv"])
+    # Artifact path resolves to the stage that produces it and its upstream deps
+    result = runner.invoke(cli.cli, ["dag", "--stages", "clean.csv"])
 
-        assert result.exit_code == 0
-        # Should include transform (produces clean.csv) and extract (upstream)
-        assert "transform" in result.output
-        assert "extract" in result.output
-        # Should NOT include load (downstream)
-        assert "load" not in result.output
+    assert result.exit_code == 0
+    # Should include transform (produces clean.csv) and extract (upstream)
+    assert "transform" in result.output
+    assert "extract" in result.output
+    # Should NOT include load (downstream)
+    assert "load" not in result.output
 
 
 def test_dag_target_multiple_targets(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Multiple targets includes all specified stages and their upstreams."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_branch_a, name="branch_a")
-        register_test_stage(_helper_branch_b, name="branch_b")
-        register_test_stage(_helper_merge, name="merge")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_branch_a, name="branch_a")
+    register_test_stage(_helper_branch_b, name="branch_b")
+    register_test_stage(_helper_merge, name="merge")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages", "branch_a", "branch_b"])
+    result = runner.invoke(cli.cli, ["dag", "--stages", "branch_a", "branch_b"])
 
-        assert result.exit_code == 0
-        # Should include extract (upstream of both)
-        assert "extract" in result.output
-        assert "branch_a" in result.output
-        assert "branch_b" in result.output
+    assert result.exit_code == 0
+    # Should include extract (upstream of both)
+    assert "extract" in result.output
+    assert "branch_a" in result.output
+    assert "branch_b" in result.output
 
 
 def test_dag_target_invalid_stage_error(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Invalid target that doesn't match any stage or artifact shows error."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_extract, name="extract")
 
-        result = runner.invoke(cli.cli, ["dag", "nonexistent_stage"])
+    result = runner.invoke(cli.cli, ["dag", "nonexistent_stage"])
 
-        # Should fail with informative error
-        assert result.exit_code != 0
-        assert "No stages found" in result.output or "Error" in result.output
+    # Should fail with informative error
+    assert result.exit_code != 0
+    assert "No stages found" in result.output or "Error" in result.output
 
 
 # =============================================================================
@@ -389,40 +460,48 @@ def test_dag_target_invalid_stage_error(
 
 
 def test_dag_md_format_wraps_mermaid(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--md flag wraps Mermaid output in markdown code block."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
 
-        result = runner.invoke(cli.cli, ["dag", "--md", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--md", "--stages"])
 
-        assert result.exit_code == 0
-        # Should have opening code fence
-        assert "```mermaid" in result.output
-        # Should have closing code fence
-        lines = result.output.strip().split("\n")
-        assert lines[-1] == "```"
-        # Should have Mermaid content inside
-        assert "flowchart TD" in result.output
+    assert result.exit_code == 0
+    # Should have opening code fence
+    assert "```mermaid" in result.output
+    # Should have closing code fence
+    lines = result.output.strip().split("\n")
+    assert lines[-1] == "```"
+    # Should have Mermaid content inside
+    assert "flowchart TD" in result.output
 
 
-def test_dag_ascii_default_format(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_ascii_default_format(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Default output format is ASCII."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
 
-        result = runner.invoke(cli.cli, ["dag"])
+    result = runner.invoke(cli.cli, ["dag"])
 
-        assert result.exit_code == 0
-        # ASCII format has box characters
-        assert "+" in result.output or "(empty graph)" in result.output
+    assert result.exit_code == 0
+    # ASCII format has box characters
+    assert "+" in result.output or "(empty graph)" in result.output
 
 
 # =============================================================================
@@ -430,82 +509,103 @@ def test_dag_ascii_default_format(runner: click.testing.CliRunner, tmp_path: pat
 # =============================================================================
 
 
-def test_dag_artifact_view_default(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_artifact_view_default(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Default view shows artifacts, not stage names."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_extract, name="extract")
 
-        result = runner.invoke(cli.cli, ["dag"])
+    result = runner.invoke(cli.cli, ["dag"])
 
-        assert result.exit_code == 0
-        # Should show artifact, not stage name
-        assert "raw.csv" in result.output
+    assert result.exit_code == 0
+    # Should show artifact, not stage name
+    assert "raw.csv" in result.output
 
 
-def test_dag_stage_view_with_flag(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_stage_view_with_flag(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--stages flag shows stage names instead of artifacts."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_extract, name="extract")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages"])
+    result = runner.invoke(cli.cli, ["dag", "--stages"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
 
 
 def test_dag_stages_flag_with_mermaid(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--stages flag works with --mermaid format."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages", "--mermaid"])
+    result = runner.invoke(cli.cli, ["dag", "--stages", "--mermaid"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
-        assert "transform" in result.output
-        # Should not show artifacts in stage view
-        assert "raw.csv" not in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
+    assert "transform" in result.output
+    # Should not show artifacts in stage view
+    assert "raw.csv" not in result.output
 
 
-def test_dag_stages_flag_with_dot(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_dag_stages_flag_with_dot(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--stages flag works with --dot format."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
 
-        result = runner.invoke(cli.cli, ["dag", "--stages", "--dot"])
+    result = runner.invoke(cli.cli, ["dag", "--stages", "--dot"])
 
-        assert result.exit_code == 0
-        assert "extract" in result.output
-        assert "transform" in result.output
+    assert result.exit_code == 0
+    assert "extract" in result.output
+    assert "transform" in result.output
 
 
 def test_dag_target_partial_resolution(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Command succeeds with partial target resolution (valid + invalid targets)."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        register_test_stage(_helper_extract, name="extract")
-        register_test_stage(_helper_transform, name="transform")
+    register_test_stage(_helper_extract, name="extract")
+    register_test_stage(_helper_transform, name="transform")
 
-        # Mix of valid and invalid targets - should succeed with valid targets
-        result = runner.invoke(cli.cli, ["dag", "extract", "nonexistent_stage", "--stages"])
+    # Mix of valid and invalid targets - should succeed with valid targets
+    result = runner.invoke(cli.cli, ["dag", "extract", "nonexistent_stage", "--stages"])
 
-        assert result.exit_code == 0
-        # Valid target should be in output
-        assert "extract" in result.output
-        # transform not requested, should not appear in filtered output
-        assert "transform" not in result.output
+    assert result.exit_code == 0
+    # Valid target should be in output
+    assert "extract" in result.output
+    # transform not requested, should not appear in filtered output
+    assert "transform" not in result.output

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -4,11 +4,15 @@ import pathlib
 from typing import TYPE_CHECKING, Annotated, TypedDict
 
 from helpers import register_test_stage
-from pivot import cli, executor, loaders, outputs
+from pivot import cli, executor, loaders, outputs, project
 from pivot.storage import cache, track
 
 if TYPE_CHECKING:
     import click.testing
+    import pytest
+    from pytest_mock import MockerFixture
+
+    from pivot.pipeline.pipeline import Pipeline
 
 
 # =============================================================================
@@ -34,73 +38,82 @@ def _helper_process(
 
 
 def test_run_dry_run_allow_missing_uses_pvt_hash(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """run --dry-run --allow-missing uses .pvt hash when dep file is missing."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        # Create and run
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
-        executor.run()
+    # Create and run
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
+    executor.run(pipeline=mock_discovery)
 
-        # Track input
-        input_hash = cache.hash_file(pathlib.Path("input.txt"))
-        pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
-        track.write_pvt_file(pathlib.Path("input.txt.pvt"), pvt_data)
+    # Track input
+    input_hash = cache.hash_file(pathlib.Path("input.txt"))
+    pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
+    track.write_pvt_file(pathlib.Path("input.txt.pvt"), pvt_data)
 
-        # Delete input (simulating CI)
-        pathlib.Path("input.txt").unlink()
+    # Delete input (simulating CI)
+    pathlib.Path("input.txt").unlink()
 
-        result = runner.invoke(cli.cli, ["run", "--dry-run", "--allow-missing"])
+    result = runner.invoke(cli.cli, ["run", "--dry-run", "--allow-missing"])
 
-        # Should show "would skip" not "Missing deps"
-        assert "Missing deps" not in result.output, f"Got: {result.output}"
-        assert "would skip" in result.output.lower(), f"Got: {result.output}"
+    # Should show "would skip" not "Missing deps"
+    assert "Missing deps" not in result.output, f"Got: {result.output}"
+    assert "would skip" in result.output.lower(), f"Got: {result.output}"
 
 
 def test_run_dry_run_explain_allow_missing_uses_pvt_hash(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """run --dry-run --explain --allow-missing uses .pvt hash when dep file is missing."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        # Create and run
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
-        executor.run()
+    # Create and run
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
+    executor.run(pipeline=mock_discovery)
 
-        # Track input
-        input_hash = cache.hash_file(pathlib.Path("input.txt"))
-        pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
-        track.write_pvt_file(pathlib.Path("input.txt.pvt"), pvt_data)
+    # Track input
+    input_hash = cache.hash_file(pathlib.Path("input.txt"))
+    pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
+    track.write_pvt_file(pathlib.Path("input.txt.pvt"), pvt_data)
 
-        # Delete input (simulating CI)
-        pathlib.Path("input.txt").unlink()
+    # Delete input (simulating CI)
+    pathlib.Path("input.txt").unlink()
 
-        result = runner.invoke(cli.cli, ["run", "--dry-run", "--explain", "--allow-missing"])
+    result = runner.invoke(cli.cli, ["run", "--dry-run", "--explain", "--allow-missing"])
 
-        # Should NOT show error about missing deps
-        assert "Missing deps" not in result.output, f"Got: {result.output}"
-        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+    # Should NOT show error about missing deps
+    assert "Missing deps" not in result.output, f"Got: {result.output}"
+    assert result.exit_code == 0, f"Expected success, got: {result.output}"
 
 
 def test_run_allow_missing_requires_dry_run(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """run --allow-missing without --dry-run errors."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
 
-        result = runner.invoke(cli.cli, ["run", "--allow-missing"])
+    result = runner.invoke(cli.cli, ["run", "--allow-missing"])
 
-        assert result.exit_code != 0
-        assert "--allow-missing" in result.output
-        assert "--dry-run" in result.output
+    assert result.exit_code != 0
+    assert "--allow-missing" in result.output
+    assert "--dry-run" in result.output
 
 
 # =============================================================================
@@ -109,123 +122,236 @@ def test_run_allow_missing_requires_dry_run(
 
 
 def test_run_tui_and_json_mutually_exclusive(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--tui and --json are mutually exclusive."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    register_test_stage(_helper_process, name="process")
+    pathlib.Path("input.txt").write_text("data")
 
-        result = runner.invoke(cli.cli, ["run", "--tui", "--json"])
+    result = runner.invoke(cli.cli, ["run", "--tui", "--json"])
 
-        assert result.exit_code != 0
-        assert "mutually exclusive" in result.output.lower()
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
 
 
-def test_run_tui_log_requires_tui(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_run_tui_log_requires_tui(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--tui-log requires --tui flag."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        register_test_stage(_helper_process, name="process")
-        pathlib.Path("input.txt").write_text("data")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    register_test_stage(_helper_process, name="process")
+    pathlib.Path("input.txt").write_text("data")
 
-        result = runner.invoke(cli.cli, ["run", "--tui-log", "log.jsonl"])
+    result = runner.invoke(cli.cli, ["run", "--tui-log", "log.jsonl"])
 
-        assert result.exit_code != 0
-        assert "--tui-log requires --tui" in result.output
+    assert result.exit_code != 0
+    assert "--tui-log requires --tui" in result.output
 
 
-def test_run_serve_requires_tui(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_run_serve_requires_tui(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--serve requires --tui flag in watch mode."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        register_test_stage(_helper_process, name="process")
-        pathlib.Path("input.txt").write_text("data")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    register_test_stage(_helper_process, name="process")
+    pathlib.Path("input.txt").write_text("data")
 
-        result = runner.invoke(cli.cli, ["run", "--watch", "--serve"])
+    result = runner.invoke(cli.cli, ["run", "--watch", "--serve"])
 
-        assert result.exit_code != 0
-        assert "--serve requires --tui" in result.output
+    assert result.exit_code != 0
+    assert "--serve requires --tui" in result.output
 
 
 def test_run_help_includes_tui_flag(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--tui flag appears in help text."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
 
-        result = runner.invoke(cli.cli, ["run", "--help"])
+    result = runner.invoke(cli.cli, ["run", "--help"])
 
-        assert result.exit_code == 0
-        assert "--tui" in result.output
-        # Help text is case-sensitive for "TUI"
-        assert "TUI display" in result.output
+    assert result.exit_code == 0
+    assert "--tui" in result.output
+    # Help text is case-sensitive for "TUI"
+    assert "TUI display" in result.output
 
 
-def test_run_json_flag_accepted(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_run_json_flag_accepted(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--json flag should work without --tui (plain is now default)."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
 
-        result = runner.invoke(cli.cli, ["run", "--json"])
+    result = runner.invoke(cli.cli, ["run", "--json"])
 
-        assert result.exit_code == 0
-        # JSONL output should start with schema version
-        assert '"type": "schema_version"' in result.output
+    assert result.exit_code == 0
+    # JSONL output should start with schema version
+    assert '"type": "schema_version"' in result.output
 
 
 def test_run_uses_plain_mode_by_default(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Plain text output is the default (no --tui flag needed)."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
 
-        # Run without any display flags
-        result = runner.invoke(cli.cli, ["run"])
+    # Run without any display flags
+    result = runner.invoke(cli.cli, ["run"])
 
-        assert result.exit_code == 0
-        # Plain mode shows stage status in simple text format
-        # (not JSONL format which has "type":)
-        assert '"type":' not in result.output
-        # Should contain stage name in output
-        assert "process" in result.output.lower()
+    assert result.exit_code == 0
+    # Plain mode shows stage status in simple text format
+    # (not JSONL format which has "type":)
+    assert '"type":' not in result.output
+    # Should contain stage name in output
+    assert "process" in result.output.lower()
 
 
-def test_run_serve_requires_watch(runner: click.testing.CliRunner, tmp_path: pathlib.Path) -> None:
+def test_run_serve_requires_watch(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """--serve requires --watch mode."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
 
-        result = runner.invoke(cli.cli, ["run", "--serve"])
+    result = runner.invoke(cli.cli, ["run", "--serve"])
 
-        assert result.exit_code != 0
-        assert "--serve requires --watch" in result.output
+    assert result.exit_code != 0
+    assert "--serve requires --watch" in result.output
 
 
 def test_run_tui_with_tui_log_validation_passes(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--tui --tui-log passes validation (log path is writable)."""
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
-        pathlib.Path("input.txt").write_text("data")
-        register_test_stage(_helper_process, name="process")
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+    pathlib.Path("input.txt").write_text("data")
+    register_test_stage(_helper_process, name="process")
 
-        log_path = tmp_path / "tui.jsonl"
+    log_path = tmp_path / "tui.jsonl"
 
-        # This will attempt to run TUI which fails in non-TTY test environment,
-        # but it should NOT fail on validation errors about --tui-log
-        result = runner.invoke(cli.cli, ["run", "--tui", "--tui-log", str(log_path)])
+    # This will attempt to run TUI which fails in non-TTY test environment,
+    # but it should NOT fail on validation errors about --tui-log
+    result = runner.invoke(cli.cli, ["run", "--tui", "--tui-log", str(log_path)])
 
-        # Should NOT have validation errors
-        assert "--tui-log requires --tui" not in result.output
-        assert "Cannot write to" not in result.output
-        # The log file should have been created during validation (touch())
-        assert log_path.exists()
+    # Should NOT have validation errors
+    assert "--tui-log requires --tui" not in result.output
+    assert "Cannot write to" not in result.output
+    # The log file should have been created during validation (touch())
+    assert log_path.exists()
+
+
+# =============================================================================
+# Pipeline Discovery Tests
+# =============================================================================
+
+
+def test_cli_run_discovers_pipeline(
+    tmp_path: pathlib.Path,
+    runner: click.testing.CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """pivot run should discover and use Pipeline from pipeline.py."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+
+    # Create pipeline.py that defines a Pipeline
+    pipeline_code = """
+import pathlib
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test", root=pathlib.Path(__file__).parent)
+
+def my_stage() -> None:
+    pass
+
+pipeline.register(my_stage, name="my_stage")
+"""
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+    (tmp_path / ".pivot").mkdir()
+
+    result = runner.invoke(cli.cli, ["run", "--dry-run"])
+
+    assert result.exit_code == 0, f"Expected success, got: {result.output}"
+    assert "my_stage" in result.output
+
+
+def test_cli_run_no_pipeline_found_error(
+    tmp_path: pathlib.Path,
+    runner: click.testing.CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """pivot run should error if no pipeline found (non-informational mode)."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+
+    # Create .pivot dir but no pipeline.py or pivot.yaml
+    (tmp_path / ".pivot").mkdir()
+
+    # Regular run (not --dry-run or --json) should error
+    result = runner.invoke(cli.cli, ["run"])
+
+    assert result.exit_code != 0
+    assert "pipeline" in result.output.lower() or "no pipeline" in result.output
+
+
+def test_run_dry_run_allow_missing_no_pvt_shows_would_run(
+    mock_discovery: Pipeline,
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run --dry-run --allow-missing shows stages without .pvt as would run.
+
+    Critical behavioral test: --allow-missing with --dry-run is for CI scenarios
+    where deps don't exist yet. It should show what would run (validation skipped),
+    not error. This is different from regular verify which requires all files.
+    """
+    monkeypatch.chdir(tmp_path)
+    pathlib.Path(".git").mkdir()
+
+    # Register stage but don't create the dep file OR .pvt file
+    register_test_stage(_helper_process, name="process")
+
+    result = runner.invoke(cli.cli, ["run", "--dry-run", "--allow-missing"])
+
+    # Should succeed and show stage as "would run" (not error)
+    assert result.exit_code == 0, f"Should succeed with --allow-missing, got: {result.output}"
+    assert "process" in result.output
+    assert "would run" in result.output.lower()
+    # Reason should indicate no previous run (not missing deps)
+    assert "No previous run" in result.output or "no previous" in result.output.lower()

--- a/tests/core/test_dag.py
+++ b/tests/core/test_dag.py
@@ -34,6 +34,7 @@ def _create_stage(name: str, deps: list[str], outs: list[str]) -> RegistryStageI
         dep_specs={},
         out_specs={},
         params_arg_name=None,
+        state_dir=None,
     )
 
 

--- a/tests/core/test_dag_render.py
+++ b/tests/core/test_dag_render.py
@@ -43,6 +43,7 @@ def _create_stage(
         dep_specs={},
         out_specs={},
         params_arg_name=None,
+        state_dir=None,
     )
 
 

--- a/tests/core/test_discovery.py
+++ b/tests/core/test_discovery.py
@@ -7,155 +7,205 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conftest import stage_module_isolation
-from helpers import register_test_stage
-from pivot import discovery, outputs, registry
+from pivot import discovery
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
 # =============================================================================
-# Basic Discovery Tests
+# Pipeline Discovery Tests (discover_pipeline)
 # =============================================================================
 
 
-def test_discover_returns_none_when_no_files(set_project_root: Path) -> None:
-    """discover_and_register returns None when no pivot.yaml or pipeline.py."""
-    result = discovery.discover_and_register(set_project_root)
+def test_discover_pipeline_returns_none_when_no_files(set_project_root: Path) -> None:
+    """discover_pipeline returns None when no pivot.yaml or pipeline.py."""
+    result = discovery.discover_pipeline(set_project_root)
     assert result is None
 
 
-def test_discover_pivot_yaml(set_project_root: Path) -> None:
-    """discover_and_register finds and loads pivot.yaml."""
-    # Create stages module
+def test_discover_pipeline_from_pipeline_py(set_project_root: Path) -> None:
+    """discover_pipeline should find Pipeline instance in pipeline.py."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    # Create pipeline.py that defines a Pipeline
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test_pipeline")
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="my_stage")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.discover_pipeline(set_project_root)
+
+    assert result is not None
+    assert isinstance(result, Pipeline)
+    assert result.name == "test_pipeline"
+    assert "my_stage" in result.list_stages()
+
+
+def test_discover_pipeline_missing_pipeline_variable(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError when pipeline.py has Pipeline but wrong name."""
+    # Create pipeline.py with Pipeline assigned to wrong variable name
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+
+# Note: we're assigning to 'my_pipe' instead of 'pipeline'
+my_pipe = Pipeline("oops")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    with pytest.raises(
+        discovery.DiscoveryError,
+        match="does not define a 'pipeline' variable.*Found Pipeline instance named 'my_pipe'",
+    ):
+        discovery.discover_pipeline(set_project_root)
+
+
+def test_discover_pipeline_wrong_type(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError when 'pipeline' is not a Pipeline instance."""
+    # Create pipeline.py with wrong type for 'pipeline'
+    pipeline_code = """\
+pipeline = "not a Pipeline"
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    with pytest.raises(
+        discovery.DiscoveryError,
+        match="not a Pipeline instance",
+    ):
+        discovery.discover_pipeline(set_project_root)
+
+
+def test_discover_pipeline_both_files_raises_error(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError when both pivot.yaml and pipeline.py exist."""
+    # Create pivot.yaml
+    (set_project_root / "pivot.yaml").write_text("stages: {}")
+
+    # Create pipeline.py
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+pipeline = Pipeline("test")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    with pytest.raises(
+        discovery.DiscoveryError,
+        match="Found both pivot.yaml and pipeline.py",
+    ):
+        discovery.discover_pipeline(set_project_root)
+
+
+def test_discover_pipeline_sys_exit_raises(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError when pipeline.py calls sys.exit()."""
+    # Create pipeline.py that calls sys.exit
+    pipeline_code = """\
+import sys
+sys.exit(42)
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    with pytest.raises(discovery.DiscoveryError, match=r"sys\.exit\(42\)"):
+        discovery.discover_pipeline(set_project_root)
+
+
+def test_discover_pipeline_runtime_error_raises(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError when pipeline.py has runtime error."""
+    # Create pipeline.py with an error
+    pipeline_code = """\
+raise RuntimeError("intentional error")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
+        discovery.discover_pipeline(set_project_root)
+
+
+def test_discover_pipeline_from_yaml(set_project_root: Path) -> None:
+    """discover_pipeline returns Pipeline when only pivot.yaml exists."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    # Create a simple stage module
     stages_py = set_project_root / "stages.py"
     stages_py.write_text(
         """\
-def preprocess():
-    pass
+import pathlib
+from typing import Annotated, TypedDict
+from pivot import loaders, outputs
+
+class ProcessOutputs(TypedDict):
+    out: Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]
+
+def process() -> ProcessOutputs:
+    return {"out": pathlib.Path("output.txt")}
 """
     )
 
-    # Create pivot.yaml
-    pivot_yaml = set_project_root / "pivot.yaml"
-    pivot_yaml.write_text(
+    # Create only pivot.yaml (no pipeline.py)
+    (set_project_root / "pivot.yaml").write_text(
         """\
+pipeline: yaml_pipeline
 stages:
-  preprocess:
-    python: stages.preprocess
-    deps: {}
-    outs:
-      output: output.txt
+  process:
+    python: stages.process
 """
     )
 
     with stage_module_isolation(set_project_root):
-        result = discovery.discover_and_register(set_project_root)
+        result = discovery.discover_pipeline(set_project_root)
 
-        assert result == str(pivot_yaml)
-        assert "preprocess" in registry.REGISTRY.list_stages()
+    assert result is not None
+    assert isinstance(result, Pipeline)
+    assert result.name == "yaml_pipeline"
+    assert "process" in result.list_stages()
 
 
-def test_discover_pivot_yml(set_project_root: Path) -> None:
-    """discover_and_register finds and loads pivot.yml (alternate extension)."""
-    # Create stages module
+def test_discover_pipeline_from_yml(set_project_root: Path) -> None:
+    """discover_pipeline returns Pipeline when only pivot.yml exists."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    # Create a simple stage module
     stages_py = set_project_root / "stages.py"
     stages_py.write_text(
         """\
-def analyze():
-    pass
+import pathlib
+from typing import Annotated, TypedDict
+from pivot import loaders, outputs
+
+class AnalyzeOutputs(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+def analyze() -> AnalyzeOutputs:
+    return {"result": pathlib.Path("result.txt")}
 """
     )
 
-    # Create pivot.yml (note: .yml not .yaml)
-    pivot_yml = set_project_root / "pivot.yml"
-    pivot_yml.write_text(
+    # Create only pivot.yml (note: .yml not .yaml)
+    (set_project_root / "pivot.yml").write_text(
         """\
+pipeline: yml_pipeline
 stages:
   analyze:
     python: stages.analyze
-    deps: {}
-    outs:
-      result: result.txt
 """
     )
 
     with stage_module_isolation(set_project_root):
-        result = discovery.discover_and_register(set_project_root)
+        result = discovery.discover_pipeline(set_project_root)
 
-        assert result == str(pivot_yml)
-        assert "analyze" in registry.REGISTRY.list_stages()
-
-
-def test_discover_pipeline_py(set_project_root: Path) -> None:
-    """discover_and_register finds and loads pipeline.py."""
-    # Create pipeline.py that registers a stage using annotation-based outputs
-    pipeline_py = set_project_root / "pipeline.py"
-    pipeline_py.write_text(
-        """\
-import pathlib
-from typing import Annotated
-from pivot.registry import REGISTRY
-from pivot.outputs import Out
-from pivot.loaders import PathOnly
-
-def my_stage() -> Annotated[pathlib.Path, Out("output.txt", PathOnly())]:
-    pass
-
-REGISTRY.register(my_stage)
-"""
-    )
-
-    result = discovery.discover_and_register(set_project_root)
-
-    assert result == str(pipeline_py)
-    assert "my_stage" in registry.REGISTRY.list_stages()
+    assert result is not None
+    assert isinstance(result, Pipeline)
+    assert result.name == "yml_pipeline"
+    assert "analyze" in result.list_stages()
 
 
-def test_discover_both_files_raises_error(set_project_root: Path) -> None:
-    """Having both pivot.yaml and pipeline.py raises DiscoveryError."""
-    # Create stages module
-    stages_py = set_project_root / "stages.py"
-    stages_py.write_text(
-        """\
-def yaml_stage():
-    pass
-"""
-    )
-
-    # Create both pivot.yaml and pipeline.py
-    pivot_yaml = set_project_root / "pivot.yaml"
-    pivot_yaml.write_text(
-        """\
-stages:
-  yaml_stage:
-    python: stages.yaml_stage
-"""
-    )
-
-    pipeline_py = set_project_root / "pipeline.py"
-    pipeline_py.write_text(
-        """\
-from pivot import registry
-
-def python_stage():
-    pass
-
-registry.REGISTRY.register(python_stage)
-"""
-    )
-
-    with pytest.raises(discovery.DiscoveryError, match="Found both pivot.yaml and pipeline.py"):
-        discovery.discover_and_register(set_project_root)
-
-
-# =============================================================================
-# Error Handling Tests
-# =============================================================================
-
-
-def test_discover_invalid_pivot_yaml_raises(set_project_root: Path) -> None:
-    """discover_and_register raises DiscoveryError for invalid pivot.yaml."""
+def test_discover_pipeline_invalid_yaml_raises(set_project_root: Path) -> None:
+    """discover_pipeline raises DiscoveryError for invalid pivot.yaml."""
     pivot_yaml = set_project_root / "pivot.yaml"
     pivot_yaml.write_text(
         """\
@@ -167,61 +217,4 @@ stages:
     )
 
     with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
-        discovery.discover_and_register(set_project_root)
-
-
-def test_discover_invalid_pipeline_py_raises(set_project_root: Path) -> None:
-    """discover_and_register raises DiscoveryError for invalid pipeline.py."""
-    pipeline_py = set_project_root / "pipeline.py"
-    pipeline_py.write_text(
-        """\
-# This will raise an error when executed
-raise RuntimeError("intentional error")
-"""
-    )
-
-    with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
-        discovery.discover_and_register(set_project_root)
-
-
-def test_discover_pipeline_py_sys_exit_raises(set_project_root: Path) -> None:
-    """discover_and_register raises DiscoveryError when pipeline.py calls sys.exit()."""
-    pipeline_py = set_project_root / "pipeline.py"
-    pipeline_py.write_text(
-        """\
-import sys
-sys.exit(1)
-"""
-    )
-
-    with pytest.raises(discovery.DiscoveryError, match="sys.exit"):
-        discovery.discover_and_register(set_project_root)
-
-
-# =============================================================================
-# Helper Function Tests
-# =============================================================================
-
-
-def test_has_registered_stages_false_when_empty() -> None:
-    """has_registered_stages returns False when no stages registered."""
-    # Registry is already cleared by autouse clean_registry fixture
-    assert discovery.has_registered_stages() is False
-
-
-def test_has_registered_stages_true_after_registration(
-    set_project_root: Path,
-) -> None:
-    """has_registered_stages returns True after stage registration."""
-    import pathlib as pathlib_module
-    from typing import Annotated
-
-    from pivot import loaders
-
-    def test_stage() -> Annotated[
-        pathlib_module.Path, outputs.Out("test_output.txt", loaders.PathOnly())
-    ]:
-        return pathlib_module.Path("test_output.txt")
-
-    register_test_stage(test_stage, name="test")
-    assert discovery.has_registered_stages() is True
+        discovery.discover_pipeline(set_project_root)

--- a/tests/engine/test_graph.py
+++ b/tests/engine/test_graph.py
@@ -29,6 +29,7 @@ def _create_stage(name: str, deps: list[str], outs: list[str]) -> RegistryStageI
         dep_specs={},
         out_specs={},
         params_arg_name=None,
+        state_dir=None,
     )
 
 

--- a/tests/engine/test_run_history.py
+++ b/tests/engine/test_run_history.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import pathlib
 
     from pivot.engine import engine
+    from pivot.pipeline.pipeline import Pipeline
 
 
 def _helper_stage_func(params: None) -> dict[str, str]:
@@ -23,11 +24,12 @@ def _helper_stage_func(params: None) -> dict[str, str]:
 
 
 @pytest.fixture
-def registered_stage() -> str:
+def registered_stage(test_pipeline: Pipeline) -> str:
     """Register a simple stage for testing."""
     helpers.register_test_stage(
         func=_helper_stage_func,
         name="history_test",
+        pipeline=test_pipeline,
     )
     return "history_test"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,14 +2,39 @@
 
 from __future__ import annotations
 
+import inspect
+import pathlib
+import textwrap
 from typing import TYPE_CHECKING, Any
 
-from pivot import outputs, registry
-
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping, Sequence
 
-    from pivot import stage_def
+    from pivot import outputs, registry, stage_def
+    from pivot.pipeline import pipeline as pipeline_mod
+
+
+# Module-level test pipeline for tests that don't have explicit Pipeline context.
+# This is reset between tests by the clean_test_pipeline fixture in conftest.py.
+_test_pipeline: pipeline_mod.Pipeline | None = None
+
+
+def get_test_pipeline() -> pipeline_mod.Pipeline:
+    """Get the current test pipeline.
+
+    Raises RuntimeError if no test pipeline is set.
+    """
+    if _test_pipeline is None:
+        raise RuntimeError(
+            "No test pipeline available. Use the 'test_pipeline' fixture or call set_test_pipeline() before registering stages."
+        )
+    return _test_pipeline
+
+
+def set_test_pipeline(pipeline: pipeline_mod.Pipeline | None) -> None:
+    """Set the module-level test pipeline."""
+    global _test_pipeline
+    _test_pipeline = pipeline
 
 
 def register_test_stage(
@@ -20,15 +45,29 @@ def register_test_stage(
     variant: str | None = None,
     dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
     out_path_overrides: Mapping[str, registry.OutOverrideInput] | None = None,
+    *,
+    pipeline: pipeline_mod.Pipeline | None = None,
 ) -> None:
     """Register a stage for testing.
+
+    Args:
+        func: The stage function.
+        name: Stage name (defaults to function name).
+        params: Stage parameters class or instance.
+        mutex: Mutex groups.
+        variant: Variant name.
+        dep_path_overrides: Override paths for dependencies.
+        out_path_overrides: Override paths for outputs.
+        pipeline: Pipeline to register with. If not provided, uses the module-level
+            test pipeline (set via set_test_pipeline or the test_pipeline fixture).
 
     Note: deps and outs are now defined via annotations on the function, not
     as parameters to this function. Use Annotated[T, Dep(...)] for deps and
     Annotated[T, Out(...)] return types for outputs.
     """
-    registry.REGISTRY.register(
-        func=func,
+    target = pipeline or get_test_pipeline()
+    target.register(
+        func,
         name=name,
         params=params,
         mutex=mutex,
@@ -36,3 +75,85 @@ def register_test_stage(
         dep_path_overrides=dep_path_overrides,
         out_path_overrides=out_path_overrides,
     )
+
+
+def create_pipeline_py(
+    stages: Sequence[Callable[..., Any]],
+    *,
+    path: pathlib.Path | None = None,
+    extra_imports: str = "",
+    extra_code: str = "",
+    names: Mapping[str, str] | None = None,
+) -> pathlib.Path:
+    """Create a pipeline.py file that registers the given stages.
+
+    This is useful for CLI tests that use runner.isolated_filesystem()
+    and need discover_pipeline() to find stages.
+
+    Args:
+        stages: Sequence of stage functions to include. Their source code
+            will be extracted and included in the generated file.
+        path: Directory to create pipeline.py in. Defaults to current directory.
+        extra_imports: Additional import statements to include at the top.
+        extra_code: Additional code to include (e.g., TypedDict definitions).
+        names: Mapping of function names to registered stage names.
+            E.g., {"_helper_process": "process"} registers with name="process".
+
+    Returns:
+        Path to the created pipeline.py file.
+
+    Example:
+        with runner.isolated_filesystem():
+            create_pipeline_py([my_stage_func])
+            result = runner.invoke(cli.cli, ["run"])
+    """
+    target_dir = path or pathlib.Path.cwd()
+    pipeline_path = target_dir / "pipeline.py"
+    names = names or {}
+
+    # Build the pipeline.py content
+    lines = [
+        "from __future__ import annotations",
+        "",
+        "import pathlib",
+        "from typing import Annotated, TypedDict",
+        "",
+        "from pivot import loaders, outputs",
+        "from pivot.pipeline.pipeline import Pipeline",
+    ]
+
+    if extra_imports:
+        lines.append(extra_imports)
+
+    lines.extend(
+        [
+            "",
+            "pipeline = Pipeline('test')",
+            "",
+        ]
+    )
+
+    if extra_code:
+        lines.append(extra_code)
+        lines.append("")
+
+    # Extract and include each stage function's source
+    for func in stages:
+        source = inspect.getsource(func)
+        # Dedent in case the function was defined at non-zero indentation
+        source = textwrap.dedent(source)
+        lines.append(source)
+        lines.append("")
+
+    # Register each stage
+    for func in stages:
+        func_name = func.__name__
+        if func_name in names:
+            lines.append(f'pipeline.register({func_name}, name="{names[func_name]}")')
+        else:
+            lines.append(f"pipeline.register({func_name})")
+
+    lines.append("")  # Final newline
+
+    pipeline_path.write_text("\n".join(lines))
+    return pipeline_path

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Annotated, TypedDict
+
+import pytest
+
+from pivot import exceptions, loaders, outputs, project
+from pivot.pipeline.pipeline import Pipeline
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+# Module-level helper for stage registration tests
+class _SimpleOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _simple_stage() -> _SimpleOutput:
+    pathlib.Path("result.txt").write_text("done")
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def test_pipeline_creation_with_name() -> None:
+    """Pipeline should be creatable with a name."""
+    p = Pipeline("my_pipeline")
+    assert p.name == "my_pipeline"
+
+
+def test_pipeline_infers_root_from_caller() -> None:
+    """Pipeline should infer root directory from caller's __file__."""
+    p = Pipeline("test")
+
+    # Should be the directory containing this test file
+    expected = pathlib.Path(__file__).parent
+    assert p.root == expected
+
+
+def test_pipeline_accepts_explicit_root() -> None:
+    """Pipeline should accept explicit root override."""
+    custom_root = pathlib.Path("/custom/path")
+    p = Pipeline("test", root=custom_root)
+    assert p.root == custom_root
+
+
+def test_pipeline_state_dir_derived_from_root() -> None:
+    """Pipeline state_dir should be root/.pivot."""
+    custom_root = pathlib.Path("/custom/path")
+    p = Pipeline("test", root=custom_root)
+    assert p.state_dir == custom_root / ".pivot"
+
+
+# =============================================================================
+# Pipeline Name Validation Tests
+# =============================================================================
+
+
+def test_pipeline_name_validation_valid_names() -> None:
+    """Pipeline should accept valid names."""
+    # Various valid patterns
+    valid_names = [
+        "pipeline",
+        "MyPipeline",
+        "pipeline_1",
+        "my-pipeline",
+        "A",
+        "a123",
+        "Pipeline_With_Underscores",
+        "pipeline-with-hyphens",
+    ]
+    for name in valid_names:
+        p = Pipeline(name)
+        assert p.name == name
+
+
+def test_pipeline_name_validation_empty_fails() -> None:
+    """Pipeline should reject empty name."""
+    from pivot.pipeline.yaml import PipelineConfigError
+
+    with pytest.raises(PipelineConfigError, match="cannot be empty"):
+        Pipeline("")
+
+
+def test_pipeline_name_validation_invalid_patterns() -> None:
+    """Pipeline should reject names with invalid patterns."""
+    from pivot.pipeline.yaml import PipelineConfigError
+
+    invalid_names = [
+        "1pipeline",  # starts with number
+        "_pipeline",  # starts with underscore
+        "-pipeline",  # starts with hyphen
+        "pipe.line",  # contains period
+        "pipe/line",  # contains slash
+        "pipe line",  # contains space
+        "pipeline!",  # contains special char
+        "../escape",  # path traversal attempt
+    ]
+    for name in invalid_names:
+        with pytest.raises(PipelineConfigError, match="Invalid pipeline name"):
+            Pipeline(name)
+
+
+# Stage registration tests
+
+
+def test_pipeline_register_stage(tmp_path: pathlib.Path) -> None:
+    """Pipeline.register should register a stage with the pipeline's state_dir."""
+    p = Pipeline("test", root=tmp_path)
+    p.register(_simple_stage, name="my_stage")
+
+    assert "my_stage" in p.list_stages()
+    info = p.get("my_stage")
+    assert info["state_dir"] == tmp_path / ".pivot"
+
+
+def test_pipeline_stages_isolated(tmp_path: pathlib.Path) -> None:
+    """Two pipelines can have stages with the same name."""
+    p1 = Pipeline("pipeline1", root=tmp_path / "p1")
+    p2 = Pipeline("pipeline2", root=tmp_path / "p2")
+
+    p1.register(_simple_stage, name="train")
+    p2.register(_simple_stage, name="train")
+
+    assert "train" in p1.list_stages()
+    assert "train" in p2.list_stages()
+
+    # Each has its own state_dir
+    assert p1.get("train")["state_dir"] == tmp_path / "p1" / ".pivot"
+    assert p2.get("train")["state_dir"] == tmp_path / "p2" / ".pivot"
+
+
+# =============================================================================
+# Invalid Registration Tests
+# =============================================================================
+
+
+class _InvalidOutputMissingAnnotation(TypedDict):
+    # Missing Annotated[] wrapper - should be caught
+    result: pathlib.Path
+
+
+def _stage_with_invalid_output_missing_annotation() -> _InvalidOutputMissingAnnotation:
+    pathlib.Path("result.txt").write_text("done")
+    return _InvalidOutputMissingAnnotation(result=pathlib.Path("result.txt"))
+
+
+def test_pipeline_register_missing_annotation_fails(tmp_path: pathlib.Path) -> None:
+    """Pipeline.register fails when output TypedDict field missing Annotated wrapper.
+
+    Critical for catching user errors where they forget Annotated[] on TypedDict fields.
+    This prevents silent registration of stages that won't work at runtime.
+    """
+    p = Pipeline("test", root=tmp_path)
+
+    with pytest.raises(exceptions.StageDefinitionError, match="without Out annotations"):
+        p.register(_stage_with_invalid_output_missing_annotation, name="invalid")
+
+
+# =============================================================================
+# get() Tests
+# =============================================================================
+
+
+def test_pipeline_get_raises_keyerror_for_unknown_stage(tmp_path: pathlib.Path) -> None:
+    """get() should raise KeyError with stage name for unknown stages."""
+    p = Pipeline("test", root=tmp_path)
+
+    with pytest.raises(KeyError, match="unknown_stage"):
+        p.get("unknown_stage")
+
+
+# =============================================================================
+# build_dag() Tests
+# =============================================================================
+
+
+# Helper stages for DAG tests - defined at module level for fingerprinting
+class _StageAOutput(TypedDict):
+    data: Annotated[pathlib.Path, outputs.Out("a.txt", loaders.PathOnly())]
+
+
+def _stage_a() -> _StageAOutput:
+    pathlib.Path("a.txt").write_text("a")
+    return _StageAOutput(data=pathlib.Path("a.txt"))
+
+
+class _StageBOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("b.txt", loaders.PathOnly())]
+
+
+def _stage_b(
+    data: Annotated[pathlib.Path, outputs.Dep("a.txt", loaders.PathOnly())],
+) -> _StageBOutput:
+    pathlib.Path("b.txt").write_text(f"b depends on {data}")
+    return _StageBOutput(result=pathlib.Path("b.txt"))
+
+
+# Cycle test helpers - at module level for type hint resolution
+class _CycleAOutput(TypedDict):
+    data: Annotated[pathlib.Path, outputs.Out("cycle_a.txt", loaders.PathOnly())]
+
+
+def _cycle_a(
+    dep: Annotated[pathlib.Path, outputs.Dep("cycle_b.txt", loaders.PathOnly())],
+) -> _CycleAOutput:
+    return _CycleAOutput(data=pathlib.Path("cycle_a.txt"))
+
+
+class _CycleBOutput(TypedDict):
+    data: Annotated[pathlib.Path, outputs.Out("cycle_b.txt", loaders.PathOnly())]
+
+
+def _cycle_b(
+    dep: Annotated[pathlib.Path, outputs.Dep("cycle_a.txt", loaders.PathOnly())],
+) -> _CycleBOutput:
+    return _CycleBOutput(data=pathlib.Path("cycle_b.txt"))
+
+
+def test_pipeline_build_dag_with_valid_stages(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """build_dag() should return a valid DAG for registered stages."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()  # Project root marker
+
+    p = Pipeline("test", root=tmp_path)
+    p.register(_stage_a, name="stage_a")
+    p.register(_stage_b, name="stage_b")
+
+    dag = p.build_dag(validate=True)
+
+    # DAG should have both stages as nodes
+    assert "stage_a" in dag.nodes
+    assert "stage_b" in dag.nodes
+
+    # stage_b depends on stage_a (edge from consumer to producer: b -> a)
+    assert dag.has_edge("stage_b", "stage_a")
+
+
+def test_pipeline_build_dag_validate_false_skips_dependency_check(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """build_dag(validate=False) should not raise for missing dependencies."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path)
+    # Only register stage_b which depends on a.txt (not provided by any stage)
+    p.register(_stage_b, name="stage_b")
+
+    # validate=False should not raise
+    dag = p.build_dag(validate=False)
+    assert "stage_b" in dag.nodes
+
+
+def test_pipeline_build_dag_detects_cycles(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """build_dag() should raise CyclicGraphError for circular dependencies."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path)
+    p.register(_cycle_a, name="cycle_a")
+    p.register(_cycle_b, name="cycle_b")
+
+    with pytest.raises(exceptions.CyclicGraphError):
+        p.build_dag(validate=True)
+
+
+# =============================================================================
+# snapshot() and restore() Tests
+# =============================================================================
+
+
+def test_pipeline_snapshot_captures_current_state(tmp_path: pathlib.Path) -> None:
+    """snapshot() should capture current registry state for rollback."""
+    p = Pipeline("test", root=tmp_path)
+    p.register(_simple_stage, name="stage1")
+
+    snap = p.snapshot()
+
+    assert "stage1" in snap
+    assert snap["stage1"]["name"] == "stage1"
+    assert snap["stage1"]["func"] == _simple_stage
+
+
+def test_pipeline_restore_replaces_state(tmp_path: pathlib.Path) -> None:
+    """restore() should replace registry state from snapshot."""
+    p = Pipeline("test", root=tmp_path)
+    p.register(_simple_stage, name="stage1")
+
+    # Take snapshot
+    snap = p.snapshot()
+
+    # Modify pipeline
+    p.register(_stage_a, name="stage_a")
+    assert "stage_a" in p.list_stages()
+
+    # Restore from snapshot
+    p.restore(snap)
+
+    # Should have original state
+    assert "stage1" in p.list_stages()
+    assert "stage_a" not in p.list_stages()
+
+
+def test_pipeline_clear_removes_all_stages(tmp_path: pathlib.Path) -> None:
+    """clear() should remove all registered stages."""
+    p = Pipeline("test", root=tmp_path)
+    p.register(_simple_stage, name="stage1")
+    p.register(_stage_a, name="stage_a")
+
+    assert len(p.list_stages()) == 2
+
+    p.clear()
+
+    assert len(p.list_stages()) == 0

--- a/tests/tui/test_agent_server.py
+++ b/tests/tui/test_agent_server.py
@@ -22,6 +22,8 @@ from pivot.types import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pivot.pipeline.pipeline import Pipeline
+
 
 # =============================================================================
 # Output TypedDicts for annotation-based stages
@@ -221,7 +223,7 @@ async def test_dispatch_cancel(mock_engine: MagicMock, socket_path: Path) -> Non
 
 @pytest.mark.asyncio
 async def test_dispatch_stages_returns_registered_stages(
-    mock_engine: MagicMock, socket_path: Path
+    test_pipeline: Pipeline, mock_discovery: Pipeline, mock_engine: MagicMock, socket_path: Path
 ) -> None:
     """Test stages method returns all registered stages."""
 
@@ -249,7 +251,9 @@ async def test_dispatch_stages_returns_registered_stages(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_run_queues_execution(mock_engine: MagicMock, socket_path: Path) -> None:
+async def test_dispatch_run_queues_execution(
+    test_pipeline: Pipeline, mock_discovery: Pipeline, mock_engine: MagicMock, socket_path: Path
+) -> None:
     """Test run() queues execution request to engine via try_start_run."""
 
     # Register a test stage (clean_registry autouse fixture handles cleanup)
@@ -281,7 +285,7 @@ async def test_dispatch_run_queues_execution(mock_engine: MagicMock, socket_path
 
 @pytest.mark.asyncio
 async def test_dispatch_run_with_invalid_stage_returns_error(
-    mock_engine: MagicMock, socket_path: Path
+    test_pipeline: Pipeline, mock_discovery: Pipeline, mock_engine: MagicMock, socket_path: Path
 ) -> None:
     """Test run() with non-existent stage returns STAGE_NOT_FOUND error."""
     server = agent_server.AgentServer(mock_engine, socket_path)

--- a/tests/tui/test_diff_panels.py
+++ b/tests/tui/test_diff_panels.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
+    from pivot.pipeline.pipeline import Pipeline
     from pivot.registry import RegistryStageInfo
 
 
@@ -180,6 +181,7 @@ def test_compute_output_changes_no_lock_shows_added(tmp_path: pathlib.Path) -> N
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
 
     result = diff_panels.compute_output_changes(None, registry_info)
@@ -211,6 +213,7 @@ def test_compute_output_changes_missing_file_shows_removed(tmp_path: pathlib.Pat
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
 
     lock_data: LockData = {
@@ -251,6 +254,7 @@ def test_compute_output_changes_unchanged(tmp_path: pathlib.Path) -> None:
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
 
     lock_data: LockData = {
@@ -295,6 +299,7 @@ def test_compute_output_changes_detects_output_types(tmp_path: pathlib.Path) -> 
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
 
     result = diff_panels.compute_output_changes(None, registry_info)
@@ -505,6 +510,7 @@ def test_input_panel_empty_state_no_explanation() -> None:
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
     panel._explanation = None
     result = panel._render_empty_state()
@@ -530,6 +536,7 @@ def test_input_panel_empty_state_no_inputs() -> None:
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
     panel._explanation = StageExplanation(
         stage_name="some_stage",
@@ -586,6 +593,7 @@ def test_output_panel_empty_state_in_progress() -> None:
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
     panel._stage_status = StageStatus.IN_PROGRESS
     result = panel._render_empty_state()
@@ -611,6 +619,7 @@ def test_output_panel_empty_state_no_outputs() -> None:
         "dep_specs": {},
         "out_specs": {},
         "params_arg_name": None,
+        "state_dir": None,
     }
     panel._stage_status = None
     result = panel._render_empty_state()
@@ -736,7 +745,9 @@ def test_output_panel_is_changed_not_found() -> None:
 # =============================================================================
 
 
-def test_input_panel_set_from_snapshot(mocker: MockerFixture) -> None:
+def test_input_panel_set_from_snapshot(
+    test_pipeline: Pipeline, mock_discovery: Pipeline, mocker: MockerFixture
+) -> None:
     """InputDiffPanel.set_from_snapshot loads snapshot data correctly."""
     panel = diff_panels.InputDiffPanel()
 
@@ -767,7 +778,9 @@ def test_input_panel_set_from_snapshot(mocker: MockerFixture) -> None:
     mock_update.assert_called_once()
 
 
-def test_output_panel_set_from_snapshot(mocker: MockerFixture) -> None:
+def test_output_panel_set_from_snapshot(
+    test_pipeline: Pipeline, mock_discovery: Pipeline, mocker: MockerFixture
+) -> None:
     """OutputDiffPanel.set_from_snapshot loads snapshot data correctly."""
     panel = diff_panels.OutputDiffPanel()
 


### PR DESCRIPTION
## Summary

- Adds `Pipeline` class (`src/pivot/pipeline/pipeline.py`) for programmatic pipeline management
- Adds `state_dir` field to `RegistryStageInfo` to support per-pipeline state directories
- Refactors CLI commands to accept optional `Pipeline` instance instead of relying solely on global registry
- Updates all test infrastructure to use `test_pipeline` fixture pattern for isolated testing

## Changes

- **New `Pipeline` class**: Encapsulates pipeline configuration, registry, and state directory
- **Registry enhancement**: `RegistryStageInfo` now includes `state_dir` for pipeline-aware stage execution
- **CLI refactoring**: Commands can now operate on specific `Pipeline` instances
- **Test infrastructure**: New `test_pipeline` fixture and helpers for cleaner, isolated tests

Closes #309

## Test plan

- [x] All existing tests pass
- [x] New tests in `tests/pipeline/test_pipeline.py` cover `Pipeline` class behavior
- [x] Type checking passes (`basedpyright`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)