### PR TITLE
feat(rpc): add event streaming and query handlers for agent API

### DIFF
--- a/docs/plans/2026-02-01-feat-enhanced-agent-api-event-streaming-plan.md
+++ b/docs/plans/2026-02-01-feat-enhanced-agent-api-event-streaming-plan.md
@@ -1,0 +1,650 @@
+---
+title: "feat(rpc): Enhanced RPC API with Event Streaming"
+type: feat
+date: 2026-02-01
+github_issue: 261
+depends_on: [307, 305]
+deepened: 2026-02-01
+---
+
+# Enhanced RPC API with Event Streaming
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the RPC interface with event streaming and richer queries, enabling any client (agents, tools, scripts) to monitor and control pipeline execution.
+
+**Architecture:** Add a ring buffer for event polling, plus query handlers that call existing `explain.py` and `status.py` functions directly. No new abstraction layers — just wiring.
+
+**Tech Stack:** Python 3.13+, TypedDict, anyio, deque
+
+**GitHub Issue:** #261
+
+---
+
+## Research Insights (Post-Deepening)
+
+### Critical Fixes Required
+
+1. **`get_stage_explanation()` Signature Mismatch** — Use `reg_info["deps_paths"]` and `reg_info["outs_paths"]` directly (already `list[str]`), not manual path conversion.
+
+2. **Threading Lock in Async Context** — Use `threading.Lock` because the buffer is accessed from both sync (`events_since()`) and async (`handle()`) contexts. `threading.Lock` can be acquired from either; `anyio.Lock` cannot.
+
+3. **Lazy Imports Violation** — CLAUDE.md forbids lazy imports. Move `from pivot import explain as explain_mod` to module level.
+
+4. **Empty Collection Syntax** — Use `list[T]()` not `[]` per CLAUDE.md (e.g., `events=list[dict[str, object]]()`).
+
+### Simplifications Recommended
+
+1. **Skip Task 1 (rename)** — Renaming `AgentRpcHandler` → `RpcHandler` adds churn without value. Keep existing names.
+
+2. **Remove `gap` field from EventBuffer** — No concrete use case. Clients can simply query current state.
+
+3. **Consider removing `logs` handler** — Clients can filter `events_since` for `log_line` events. Dedicated endpoint duplicates functionality.
+
+4. **Simplify `stage_info`** — Remove upstream/downstream (requires graph rebuild). Just return deps/outs.
+
+### Security Hardening
+
+1. **Add upper bounds** — `version` should be capped at `2**63-1`, `lines` at `10000`.
+
+2. **Information disclosure is acceptable** — Local-only Unix socket with 0o600 permissions. Document that `explain` exposes parameter values.
+
+### Performance Considerations
+
+1. **Wrap `explain` in thread** — `get_stage_explanation()` does blocking file I/O. Use `anyio.to_thread.run_sync()`.
+
+2. **Reuse engine graph** — In `stage_info`, use `self._engine._graph` instead of rebuilding.
+
+### Agent-Native Gaps (Future Work)
+
+After this plan, agents can observe but have limited action capability:
+
+| Missing | Priority |
+|---------|----------|
+| Extend `run` params (--no-commit, --keep-going) | High |
+| `checkout` method | High |
+| `commit` + `list_pending` methods | Medium |
+| `push` / `pull` methods | Medium |
+| `verify` method | Medium |
+| `history` + `show_run` methods | Low |
+
+---
+
+## Design Principles
+
+1. **RPC is just another client** — Same as CLI and TUI, it calls existing query functions
+2. **No duplication** — Queries use `explain.get_stage_explanation()` and `status.get_pipeline_status()` directly
+3. **Minimal new code** — ~100 lines, not 500
+4. **Unified event stream** — One ring buffer, filter for logs client-side
+
+---
+
+## ~~Task 1: Rename AgentRpcHandler → RpcHandler~~ (SKIPPED)
+
+**Decision:** Keep existing names. Renaming adds git history noise without functional benefit. "Agent" accurately describes the primary use case.
+
+---
+
+## Task 2: Add Event Ring Buffer for Polling
+
+**Files:**
+- Modify: `src/pivot/engine/agent_rpc.py`
+- Test: `tests/engine/test_agent_rpc.py`
+
+> **Research Insight:** Use `threading.Lock` (not `anyio.Lock`) since buffer is accessed from both async event handlers and sync query methods.
+
+**Step 1: Write the failing test**
+
+Add to `tests/engine/test_agent_rpc.py`:
+
+```python
+async def test_event_buffer_captures_events() -> None:
+    """EventBuffer should capture events with version numbers."""
+    from pivot.engine.agent_rpc import EventBuffer
+
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 1, "total": 2})
+
+    result = buffer.events_since(0)
+    assert result["version"] == 1
+    assert len(result["events"]) == 1
+
+
+async def test_event_buffer_eviction() -> None:
+    """EventBuffer should evict oldest events when full."""
+    from pivot.engine.agent_rpc import EventBuffer
+
+    buffer = EventBuffer(max_events=3)
+    for i in range(5):
+        buffer.handle_sync({"type": "stage_started", "stage": f"s{i}", "index": i, "total": 5})
+
+    result = buffer.events_since(0)
+    assert len(result["events"]) == 3  # Only last 3 events
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_agent_rpc.py::test_event_buffer_captures_events -v`
+Expected: FAIL with `ImportError: cannot import name 'EventBuffer'`
+
+**Step 3: Write minimal implementation**
+
+Add to `src/pivot/engine/agent_rpc.py`:
+
+```python
+class VersionedEvent(TypedDict):
+    """Event with version number."""
+    version: int
+    event: OutputEvent
+
+
+class EventsResult(TypedDict):
+    """Result of events_since query."""
+    version: int
+    events: list[VersionedEvent]
+
+
+class EventBuffer:
+    """Ring buffer for event polling via events_since.
+
+    Thread-safe: uses threading.Lock since buffer is accessed from both
+    sync (events_since) and async (handle) contexts.
+    """
+
+    _max_events: int
+    _events: deque[tuple[int, OutputEvent]]
+    _version: int
+    _lock: threading.Lock
+
+    def __init__(self, max_events: int = 1000) -> None:
+        self._max_events = max_events
+        self._events = deque[tuple[int, OutputEvent]](maxlen=max_events)
+        self._version = 0
+        self._lock = threading.Lock()
+
+    def handle_sync(self, event: OutputEvent) -> None:
+        """Store event with version number (sync, thread-safe)."""
+        with self._lock:
+            self._version += 1
+            self._events.append((self._version, event))
+
+    async def handle(self, event: OutputEvent) -> None:
+        """Async wrapper for sink interface compatibility."""
+        self.handle_sync(event)
+
+    def events_since(self, since_version: int) -> EventsResult:
+        """Return events after the given version."""
+        with self._lock:
+            result = [
+                VersionedEvent(version=v, event=e)
+                for v, e in self._events
+                if v > since_version
+            ]
+            return EventsResult(version=self._version, events=result)
+```
+
+Update `__all__` to include `"EventBuffer"`, `"VersionedEvent"`, `"EventsResult"`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_agent_rpc.py::test_event_buffer -v`
+Expected: PASS (both tests)
+
+**Step 5: Run type checker**
+
+Run: `uv run basedpyright src/pivot/engine/agent_rpc.py`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat(engine): add EventBuffer for event polling"
+```
+
+---
+
+## Task 3: Wire EventBuffer into Engine and CLI
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py`
+- Modify: `src/pivot/cli/run.py`
+- Modify: `src/pivot/engine/agent_rpc.py`
+
+**Step 1: Add EventBuffer to Engine**
+
+In `src/pivot/engine/engine.py`, add import and create buffer:
+
+```python
+# Add import
+from pivot.engine.agent_rpc import EventBuffer
+
+# In Engine class, add field
+_event_buffer: EventBuffer
+
+# In __init__ or __aenter__, create and register
+self._event_buffer = EventBuffer(max_events=1000)
+# Register as sink so it receives events
+```
+
+**Step 2: Update AgentRpcHandler constructor**
+
+In `src/pivot/engine/agent_rpc.py`:
+
+```python
+class AgentRpcHandler:
+    _engine: Engine
+    _event_buffer: EventBuffer | None
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        event_buffer: EventBuffer | None = None,
+    ) -> None:
+        self._engine = engine
+        self._event_buffer = event_buffer
+```
+
+**Step 3: Pass buffer in CLI**
+
+In `src/pivot/cli/run.py`, where `AgentRpcHandler` is created:
+
+```python
+handler = AgentRpcHandler(engine=eng, event_buffer=eng._event_buffer)
+```
+
+**Step 4: Rename AgentEventSink → EventSink**
+
+In `src/pivot/engine/agent_rpc.py`:
+- Rename class `AgentEventSink` → `EventSink`
+- Update `__all__`
+- Update imports in `engine.py` and `run.py`
+
+**Step 5: Run type checker**
+
+Run: `uv run basedpyright src/pivot/engine/`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat(engine): wire EventBuffer into Engine and rename EventSink"
+```
+
+---
+
+## Task 4: Add Query Handlers to AgentRpcHandler
+
+**Files:**
+- Modify: `src/pivot/engine/agent_rpc.py`
+- Test: `tests/engine/test_agent_rpc.py`
+
+> **Research Insight:** Move imports to module level (CLAUDE.md requires no lazy imports). Wrap `get_stage_explanation()` in `anyio.to_thread.run_sync()` since it does blocking file I/O.
+
+**Step 1: Add module-level imports**
+
+Add at top of `src/pivot/engine/agent_rpc.py`:
+
+```python
+from pivot import explain as explain_mod
+from pivot import parameters
+from pivot.config import io as config_io
+from pivot.types import StageExplanation
+```
+
+Add module-level constant:
+
+```python
+_MAX_VERSION = 2**63 - 1
+```
+
+**Step 2: Write failing test for events_since**
+
+Add to `tests/engine/test_agent_rpc.py`:
+
+```python
+async def test_handler_events_since_query() -> None:
+    """Handler should return events from buffer."""
+    from pivot.engine.agent_rpc import AgentRpcHandler, EventBuffer
+    from unittest.mock import MagicMock
+
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 1, "total": 1})
+
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    result = await handler.handle_query("events_since", {"version": 0})
+    assert result["version"] == 1
+    assert len(result["events"]) == 1
+```
+
+**Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/engine/test_agent_rpc.py::test_handler_events_since_query -v`
+Expected: FAIL with `ValueError: Unknown query method: events_since`
+
+**Step 4: Add events_since handler**
+
+In `AgentRpcHandler.handle_query()`, add case:
+
+```python
+case "events_since":
+    if self._event_buffer is None:
+        raise ValueError("Event buffer not configured")
+    version = params["version"] if "version" in params else 0
+    if not isinstance(version, int) or version < 0 or version > _MAX_VERSION:
+        raise ValueError(f"version must be integer between 0 and {_MAX_VERSION}")
+    return self._event_buffer.events_since(version)
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/engine/test_agent_rpc.py::test_handler_events_since_query -v`
+Expected: PASS
+
+**Step 6: Add explain handler**
+
+In `AgentRpcHandler.handle_query()`, add case:
+
+```python
+case "explain":
+    stage = params["stage"] if "stage" in params else None
+    if not isinstance(stage, str):
+        raise ValueError("stage must be string")
+
+    pipeline = self._engine._pipeline  # pyright: ignore[reportPrivateUsage]
+    if pipeline is None:
+        raise ValueError("No pipeline loaded")
+
+    reg_info = pipeline.get(stage)
+    if reg_info is None:
+        raise ValueError(f"Unknown stage: {stage}")
+
+    def _get_explanation() -> StageExplanation:
+        return explain_mod.get_stage_explanation(
+            stage_name=stage,
+            fingerprint=reg_info["fingerprint"],
+            deps=reg_info["deps_paths"],
+            outs_paths=reg_info["outs_paths"],
+            params_instance=reg_info["params"],
+            overrides=parameters.load_params_yaml(),
+            state_dir=config_io.get_state_dir(),
+        )
+
+    return await anyio.to_thread.run_sync(_get_explanation)
+```
+
+**Step 7: Add stage_info handler**
+
+In `AgentRpcHandler.handle_query()`, add case:
+
+```python
+case "stage_info":
+    stage = params["stage"] if "stage" in params else None
+    if not isinstance(stage, str):
+        raise ValueError("stage must be string")
+
+    pipeline = self._engine._pipeline  # pyright: ignore[reportPrivateUsage]
+    if pipeline is None:
+        raise ValueError("No pipeline loaded")
+
+    reg_info = pipeline.get(stage)
+    if reg_info is None:
+        raise ValueError(f"Unknown stage: {stage}")
+
+    return {
+        "name": stage,
+        "deps": reg_info["deps_paths"],
+        "outs": reg_info["outs_paths"],
+    }
+```
+
+**Step 8: Run type checker**
+
+Run: `uv run basedpyright src/pivot/engine/agent_rpc.py`
+Expected: No errors
+
+**Step 9: Commit**
+
+```bash
+jj describe -m "feat(rpc): add events_since, explain, stage_info query handlers"
+```
+
+> **Note:** `logs` handler removed — clients filter `events_since` for `type == "log_line"` events.
+
+---
+
+## Task 5: E2E Integration Test
+
+**Files:**
+- Create: `tests/integration/test_rpc_queries.py`
+
+> **Research Insight (CRITICAL):** Per `docs/solutions/integration-issues/missing-e2e-test-cli-serve-mode-20260201.md`, unit tests can pass but wiring can be broken. This E2E test is non-negotiable.
+
+**Step 1: Write the E2E test file**
+
+Create `tests/integration/test_rpc_queries.py`:
+
+```python
+# tests/integration/test_rpc_queries.py
+
+import json
+import socket
+import subprocess
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+
+def send_rpc(sock_path: Path, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+    """Send JSON-RPC request and return response."""
+    request: dict[str, object] = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params:
+        request["params"] = params
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(str(sock_path))
+    sock.sendall(json.dumps(request).encode() + b"\n")
+    response = sock.recv(4096).decode()
+    sock.close()
+    return json.loads(response)
+
+
+@pytest.fixture
+def serve_pipeline(tmp_path: Path) -> Generator[Path]:
+    """Start a minimal pipeline in serve mode, yield socket path."""
+    (tmp_path / "pivot.yaml").write_text("""
+stages:
+  - name: hello
+    func: pipeline:hello
+""")
+    (tmp_path / "pipeline.py").write_text("""
+def hello() -> None:
+    print("Hello!")
+""")
+
+    sock_path = tmp_path / ".pivot" / "agent.sock"
+
+    proc = subprocess.Popen(
+        ["uv", "run", "pivot", "run", "--serve", "--force"],
+        cwd=tmp_path,
+    )
+
+    try:
+        # Wait for socket
+        for _ in range(50):
+            if sock_path.exists():
+                break
+            time.sleep(0.1)
+
+        time.sleep(0.3)  # Brief wait for events to accumulate
+        yield sock_path
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_events_since_query(serve_pipeline: Path) -> None:
+    """events_since should return buffered events."""
+    response = send_rpc(serve_pipeline, "events_since", {"version": 0})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert "version" in result
+    assert "events" in result
+    assert isinstance(result["events"], list)
+
+
+def test_explain_query(serve_pipeline: Path) -> None:
+    """explain should return staleness info."""
+    response = send_rpc(serve_pipeline, "explain", {"stage": "hello"})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert "will_run" in result  # StageExplanation field
+    assert "reason" in result
+
+
+def test_stage_info_query(serve_pipeline: Path) -> None:
+    """stage_info should return stage metadata."""
+    response = send_rpc(serve_pipeline, "stage_info", {"stage": "hello"})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["name"] == "hello"
+    assert "deps" in result
+    assert "outs" in result
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/test_rpc_queries.py -v`
+Expected: All 3 tests PASS
+
+**Step 3: Run type checker**
+
+Run: `uv run basedpyright tests/integration/test_rpc_queries.py`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+jj describe -m "test(integration): add E2E tests for RPC query handlers"
+```
+
+---
+
+## Summary
+
+| Task | Description | LOC |
+|------|-------------|-----|
+| ~~1~~ | ~~Rename AgentRpcHandler~~ (skipped) | 0 |
+| 2 | Add EventBuffer | ~35 |
+| 3 | Wire EventBuffer into Engine | ~10 |
+| 4 | Add query handlers (events_since, explain, stage_info) | ~40 |
+| 5 | E2E tests | ~80 |
+
+**Also during implementation:**
+- Rename `AgentEventSink` → `EventSink`
+- Add `VersionedEvent` and `EventsResult` TypedDicts
+- Add `_MAX_VERSION` constant for input validation
+
+**Total new code: ~75 lines** (plus ~80 lines tests)
+
+**What we removed from original plan:**
+- ❌ Rename refactor (Task 1) — cosmetic churn
+- ❌ PipelineInspector (~100 lines)
+- ❌ agent_types.py (~40 lines)
+- ❌ LogStore (~80 lines)
+- ❌ Separate EventStore (~80 lines)
+- ❌ `logs` handler — clients filter events_since instead
+- ❌ `gap` field in EventBuffer — YAGNI
+- ❌ upstream/downstream in stage_info — requires graph rebuild
+
+---
+
+## API Reference
+
+### events_since
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "events_since", "params": {"version": 0}}
+```
+
+Returns all events since version 0. Use returned `version` for next poll.
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "version": 42,
+    "events": [
+      {"version": 41, "event": {"type": "stage_started", "stage": "train", ...}},
+      {"version": 42, "event": {"type": "log_line", "stage": "train", "line": "Hello", ...}}
+    ]
+  }
+}
+```
+
+**Filtering logs:** To get logs for a specific stage, filter the events array:
+```python
+logs = [e["event"] for e in result["events"] if e["event"]["type"] == "log_line" and e["event"]["stage"] == "train"]
+```
+
+### explain
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "explain", "params": {"stage": "train"}}
+```
+
+Returns `StageExplanation` (same type as CLI's `pivot status --explain`).
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "stage_name": "train",
+    "will_run": true,
+    "is_forced": false,
+    "reason": "Code changed",
+    "code_changes": [...],
+    "dep_changes": [...],
+    "param_changes": []
+  }
+}
+```
+
+### stage_info
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "stage_info", "params": {"stage": "train"}}
+```
+
+Returns stage metadata: deps and outs paths.
+
+**Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "name": "train",
+    "deps": ["data/input.csv"],
+    "outs": ["models/model.pkl"]
+  }
+}
+```
+
+### Existing Methods (unchanged)
+
+- `run` — Trigger pipeline execution
+- `cancel` — Cancel running execution
+- `status` — Get engine state (idle/active)
+- `stages` — List all stage names

--- a/tests/engine/test_agent_rpc.py
+++ b/tests/engine/test_agent_rpc.py
@@ -5,38 +5,22 @@ from __future__ import annotations
 import contextlib
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import anyio
 import pytest
 
+from helpers import wait_for_socket
 from pivot.engine.agent_rpc import (
-    AgentEventSink,
     AgentRpcHandler,
     AgentRpcSource,
+    EventBuffer,
+    EventSink,
     QueryResult,
     QueryStatusResult,
 )
 from pivot.engine.engine import Engine
-from pivot.engine.types import EventSource, InputEvent, StageStarted
-
-
-async def _wait_for_socket(socket_path: Path, timeout: float = 2.0) -> None:
-    """Wait for socket to be connectable, with retry loop."""
-    import stat
-
-    deadline = anyio.current_time() + timeout
-    while anyio.current_time() < deadline:
-        if socket_path.exists():
-            # Check if it's actually a socket (not a stale regular file)
-            try:
-                mode = socket_path.stat().st_mode
-                if stat.S_ISSOCK(mode):
-                    return
-            except OSError:
-                pass
-        await anyio.sleep(0.05)
-    msg = f"Socket {socket_path} not created within {timeout}s"
-    raise TimeoutError(msg)
+from pivot.engine.types import EventSource, InputEvent, OutputEvent, StageStarted
 
 
 @pytest.mark.anyio
@@ -51,7 +35,7 @@ async def test_agent_rpc_source_accepts_connections(tmp_path: Path) -> None:
         tg.start_soon(source.run, send)
 
         # Wait for server to start
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         # Connect and send run command
         async with await anyio.connect_unix(str(socket_path)) as conn:
@@ -85,7 +69,7 @@ async def test_agent_rpc_source_cancel_command(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             request = {"jsonrpc": "2.0", "method": "cancel", "id": 2}
@@ -116,7 +100,7 @@ async def test_agent_rpc_source_run_with_params(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             request = {
@@ -153,7 +137,7 @@ async def test_agent_rpc_source_unknown_method(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             request = {"jsonrpc": "2.0", "method": "unknown", "id": 4}
@@ -178,7 +162,7 @@ async def test_agent_rpc_source_invalid_json(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             await conn.send(b"not valid json\n")
@@ -203,7 +187,7 @@ async def test_agent_rpc_source_notification_no_response(tmp_path: Path) -> None
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             # Notification: no id field
@@ -238,7 +222,7 @@ async def test_agent_rpc_source_cleans_stale_socket(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         # Should be able to connect despite stale file
         async with await anyio.connect_unix(str(socket_path)) as conn:
@@ -263,7 +247,7 @@ async def test_agent_rpc_source_socket_permissions(tmp_path: Path) -> None:
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         # Check socket permissions (should be 0o600 = owner read/write only)
         mode = socket_path.stat().st_mode & 0o777
@@ -281,8 +265,8 @@ def test_agent_rpc_source_conforms_to_protocol() -> None:
 
 @pytest.mark.anyio
 async def test_agent_event_sink_broadcasts_to_subscribers() -> None:
-    """AgentEventSink broadcasts events to all subscribers."""
-    sink = AgentEventSink()
+    """EventSink broadcasts events to all subscribers."""
+    sink = EventSink()
 
     # Subscribe two clients
     recv1 = await sink.subscribe("client1")
@@ -303,17 +287,18 @@ async def test_agent_event_sink_broadcasts_to_subscribers() -> None:
 
     assert event1["type"] == "stage_started"
     assert event2["type"] == "stage_started"
-    # After type narrowing, we know these are StageStarted events
-    assert event1["stage"] == "train"  # type: ignore[typeddict-item]
-    assert event2["stage"] == "train"  # type: ignore[typeddict-item]
+    # Type narrow to StageStarted using discriminated union
+    if event1["type"] == "stage_started" and event2["type"] == "stage_started":
+        assert event1["stage"] == "train"
+        assert event2["stage"] == "train"
 
     await sink.close()
 
 
 @pytest.mark.anyio
 async def test_agent_event_sink_unsubscribe() -> None:
-    """AgentEventSink removes client on unsubscribe and closes channel."""
-    sink = AgentEventSink()
+    """EventSink removes client on unsubscribe and closes channel."""
+    sink = EventSink()
 
     recv = await sink.subscribe("client1")
     await sink.unsubscribe("client1")
@@ -347,7 +332,7 @@ async def test_agent_rpc_source_handles_status_query(tmp_path: Path) -> None:
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(source.run, send)
-            await _wait_for_socket(socket_path)
+            await wait_for_socket(socket_path)
 
             async with await anyio.connect_unix(str(socket_path)) as conn:
                 # Send status query
@@ -375,7 +360,7 @@ async def test_agent_rpc_source_rejects_oversized_messages(tmp_path: Path) -> No
         source = AgentRpcSource(socket_path=socket_path)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         async with await anyio.connect_unix(str(socket_path)) as conn:
             # Send message larger than 1MB
@@ -411,7 +396,7 @@ async def test_agent_rpc_source_handles_concurrent_connections(tmp_path: Path) -
         tg.start_soon(source.run, send)
         tg.start_soon(collect_events)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         # Connect two clients simultaneously
         async def send_command(client_id: int) -> None:
@@ -451,7 +436,7 @@ async def test_agent_rpc_handler_stages_query_without_pipeline(tmp_path: Path) -
 
         async with anyio.create_task_group() as tg:
             tg.start_soon(source.run, send)
-            await _wait_for_socket(socket_path)
+            await wait_for_socket(socket_path)
 
             async with await anyio.connect_unix(str(socket_path)) as conn:
                 # Query stages when no pipeline is set
@@ -540,7 +525,7 @@ async def test_agent_rpc_source_connection_timeout() -> None:
             source = AgentRpcSource(socket_path=socket_path)
             tg.start_soon(source.run, send)
 
-            await _wait_for_socket(socket_path)
+            await wait_for_socket(socket_path)
 
             # Connect but don't send anything (idle connection)
             async with await anyio.connect_unix(str(socket_path)) as conn:
@@ -578,7 +563,9 @@ async def test_agent_rpc_source_accepts_new_connections_after_handler_exception(
         def validate_stages(self, stages: list[str] | None) -> str | None:
             return None
 
-        async def handle_query(self, method: str) -> QueryResult:
+        async def handle_query(
+            self, method: str, params: dict[str, object] | None = None
+        ) -> QueryResult:
             self._call_count += 1
             if self._call_count == 1:
                 exception_triggered.set()
@@ -593,7 +580,7 @@ async def test_agent_rpc_source_accepts_new_connections_after_handler_exception(
         source = AgentRpcSource(socket_path=socket_path, handler=handler)
         tg.start_soon(source.run, send)
 
-        await _wait_for_socket(socket_path)
+        await wait_for_socket(socket_path)
 
         # First connection: triggers exception in handler
         with anyio.move_on_after(2.0):
@@ -640,3 +627,540 @@ async def test_agent_rpc_source_accepts_new_connections_after_handler_exception(
 
     assert len(events_received) >= 1, "Should process command after handler exception"
     assert events_received[0]["type"] == "run_requested"
+
+
+@pytest.mark.anyio
+async def test_event_buffer_captures_events() -> None:
+    """EventBuffer should capture events with version numbers."""
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 1, "total": 2})
+
+    result = buffer.events_since(0)
+    assert result["version"] == 1, "First event should have version 1"
+    assert len(result["events"]) == 1, "Should have exactly 1 event"
+
+
+@pytest.mark.anyio
+async def test_event_buffer_eviction() -> None:
+    """EventBuffer should evict oldest events when full."""
+    buffer = EventBuffer(max_events=3)
+    for i in range(5):
+        buffer.handle_sync({"type": "stage_started", "stage": f"s{i}", "index": i, "total": 5})
+
+    result = buffer.events_since(0)
+    assert len(result["events"]) == 3, "Should only keep last 3 events (max_events=3)"
+
+
+@pytest.mark.anyio
+async def test_handler_events_since_query() -> None:
+    """Handler should return events from buffer."""
+
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 1, "total": 1})
+
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    result = await handler.handle_query("events_since", {"version": 0})
+    # Type narrow to EventsResult by checking for version key (discriminates from other QueryResult types)
+    assert "version" in result and "events" in result, (
+        "Result should have version and events fields"
+    )
+    assert result["version"] == 1, "First event should have version 1"
+    assert len(result["events"]) == 1, "Should have exactly 1 event"
+
+
+# =============================================================================
+# EventBuffer Edge Cases and Boundary Conditions
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_event_buffer_version_wraparound() -> None:
+    """EventBuffer wraps version at _MAX_VERSION to prevent overflow.
+
+    Critical: Prevents version overflow causing event loss or duplication.
+    """
+    from pivot.engine.agent_rpc import _MAX_VERSION
+
+    buffer = EventBuffer(max_events=10)
+
+    # Set version near max
+    buffer._version = _MAX_VERSION - 1
+
+    # Add events that trigger wraparound
+    buffer.handle_sync({"type": "stage_started", "stage": "s1", "index": 0, "total": 2})
+    assert buffer._version == _MAX_VERSION
+
+    buffer.handle_sync({"type": "stage_started", "stage": "s2", "index": 1, "total": 2})
+    # Version should wrap to 1, not overflow
+    assert buffer._version == 1, "Version should wrap to 1 after reaching _MAX_VERSION"
+
+    # Client polling with old version should get all buffered events
+    result = buffer.events_since(0)
+    assert result["version"] == 1
+    assert len(result["events"]) == 2
+
+
+@pytest.mark.anyio
+async def test_event_buffer_empty_buffer_query() -> None:
+    """events_since on empty buffer returns empty list with version 0.
+
+    Boundary condition: Ensures no crash on empty buffer access.
+    """
+    buffer = EventBuffer(max_events=100)
+
+    result = buffer.events_since(0)
+    assert result["version"] == 0, "Empty buffer should have version 0"
+    assert result["events"] == [], "Empty buffer should return empty events list"
+
+
+@pytest.mark.anyio
+async def test_event_buffer_query_current_version() -> None:
+    """events_since with current version returns empty list.
+
+    Boundary condition: Version comparison should be > not >=.
+    """
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 0, "total": 1})
+
+    current_version = buffer._version
+    result = buffer.events_since(current_version)
+
+    assert result["version"] == current_version
+    assert result["events"] == [], "Query at current version should return no events"
+
+
+@pytest.mark.anyio
+async def test_event_buffer_query_future_version() -> None:
+    """events_since with future version returns ALL events (wraparound handling).
+
+    Edge case: Client with version > current indicates wraparound - return all events
+    to prevent missing data. This handles the case where version wrapped from
+    _MAX_VERSION to 1, but client still has old version number.
+    """
+    buffer = EventBuffer(max_events=100)
+    buffer.handle_sync({"type": "stage_started", "stage": "train", "index": 0, "total": 1})
+
+    # Query with version ahead of current (simulates post-wraparound scenario)
+    future_version = buffer._version + 100
+    result = buffer.events_since(future_version)
+
+    assert result["version"] == buffer._version
+    # Returns ALL buffered events to handle wraparound case
+    assert len(result["events"]) == 1, "Future version should return all events (wraparound)"
+    assert result["events"][0]["version"] == 1
+
+
+@pytest.mark.anyio
+async def test_event_buffer_query_after_eviction() -> None:
+    """events_since after buffer eviction returns only remaining events.
+
+    Critical: Ensures clients with old versions don't crash when events are evicted.
+    """
+    buffer = EventBuffer(max_events=3)
+
+    # Fill buffer and cause eviction
+    for i in range(5):
+        buffer.handle_sync({"type": "stage_started", "stage": f"s{i}", "index": i, "total": 5})
+
+    # Query with version that was evicted (version 1-2 are gone)
+    result = buffer.events_since(0)
+
+    # Should only get last 3 events (versions 3, 4, 5)
+    assert len(result["events"]) == 3
+    assert result["events"][0]["version"] == 3
+    assert result["events"][2]["version"] == 5
+
+
+@pytest.mark.anyio
+async def test_event_buffer_thread_safety() -> None:
+    """EventBuffer handles concurrent access from multiple threads.
+
+    Critical: Buffer uses threading.Lock for sync+async access - must be race-free.
+    """
+    import concurrent.futures
+
+    buffer = EventBuffer(max_events=1000)
+
+    def add_events(offset: int) -> None:
+        for i in range(100):
+            buffer.handle_sync(
+                {
+                    "type": "stage_started",
+                    "stage": f"s{offset}_{i}",
+                    "index": i,
+                    "total": 100,
+                }
+            )
+
+    # Add events concurrently from 5 threads
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(add_events, i) for i in range(5)]
+        concurrent.futures.wait(futures)
+
+    # Should have version = 500 (5 threads * 100 events)
+    result = buffer.events_since(0)
+    assert result["version"] == 500, "All events should be recorded with sequential versions"
+    # Buffer only holds last 1000, so we should see some events
+    assert len(result["events"]) > 0
+
+
+# =============================================================================
+# Handler Query Parameter Validation
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_handler_events_since_invalid_version_type() -> None:
+    """Handler rejects non-integer version with ValueError.
+
+    Error path: Type validation must catch string/float versions.
+    """
+    from unittest.mock import MagicMock
+
+    buffer = EventBuffer(max_events=100)
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    with pytest.raises(ValueError, match="version must be integer"):
+        await handler.handle_query("events_since", {"version": "123"})
+
+
+@pytest.mark.anyio
+async def test_handler_events_since_negative_version() -> None:
+    """Handler rejects negative version with ValueError.
+
+    Boundary condition: Negative versions are semantically invalid.
+    """
+    from unittest.mock import MagicMock
+
+    buffer = EventBuffer(max_events=100)
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    with pytest.raises(ValueError, match="version must be integer between"):
+        await handler.handle_query("events_since", {"version": -1})
+
+
+@pytest.mark.anyio
+async def test_handler_events_since_max_version_boundary() -> None:
+    """Handler accepts version exactly at _MAX_VERSION.
+
+    Boundary condition: _MAX_VERSION itself is valid.
+    """
+    from unittest.mock import MagicMock
+
+    from pivot.engine.agent_rpc import _MAX_VERSION
+
+    buffer = EventBuffer(max_events=100)
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    # Should not raise - _MAX_VERSION is valid
+    result = await handler.handle_query("events_since", {"version": _MAX_VERSION})
+    assert "version" in result
+
+
+@pytest.mark.anyio
+async def test_handler_events_since_exceeds_max_version() -> None:
+    """Handler rejects version > _MAX_VERSION with ValueError.
+
+    Boundary condition: Versions beyond max are invalid.
+    """
+    from unittest.mock import MagicMock
+
+    from pivot.engine.agent_rpc import _MAX_VERSION
+
+    buffer = EventBuffer(max_events=100)
+    mock_engine = MagicMock()
+    handler = AgentRpcHandler(engine=mock_engine, event_buffer=buffer)
+
+    with pytest.raises(ValueError, match="version must be integer between"):
+        await handler.handle_query("events_since", {"version": _MAX_VERSION + 1})
+
+
+@pytest.mark.anyio
+async def test_handler_explain_missing_stage_param() -> None:
+    """Handler explain query requires stage parameter.
+
+    Error path: Missing required parameter should give clear error.
+    """
+    async with Engine() as engine:
+        handler = AgentRpcHandler(engine=engine)
+
+        with pytest.raises(ValueError, match="stage must be string"):
+            await handler.handle_query("explain", {})
+
+
+@pytest.mark.anyio
+async def test_handler_explain_invalid_stage_type() -> None:
+    """Handler explain query rejects non-string stage.
+
+    Error path: Type validation must catch integer/null stage.
+    """
+    async with Engine() as engine:
+        handler = AgentRpcHandler(engine=engine)
+
+        with pytest.raises(ValueError, match="stage must be string"):
+            await handler.handle_query("explain", {"stage": 123})
+
+
+@pytest.mark.anyio
+async def test_handler_stage_info_missing_param() -> None:
+    """Handler stage_info query requires stage parameter.
+
+    Error path: Missing required parameter should give clear error.
+    """
+    async with Engine() as engine:
+        handler = AgentRpcHandler(engine=engine)
+
+        with pytest.raises(ValueError, match="stage must be string"):
+            await handler.handle_query("stage_info", {})
+
+
+@pytest.mark.anyio
+async def test_handler_stage_info_invalid_stage_type() -> None:
+    """Handler stage_info query rejects non-string stage.
+
+    Error path: Type validation must catch invalid types.
+    """
+    async with Engine() as engine:
+        handler = AgentRpcHandler(engine=engine)
+
+        with pytest.raises(ValueError, match="stage must be string"):
+            await handler.handle_query("stage_info", {"stage": None})
+
+
+# =============================================================================
+# AgentRpcSource Connection Edge Cases
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_agent_rpc_source_empty_lines_ignored(tmp_path: Path) -> None:
+    """AgentRpcSource ignores empty lines in message stream.
+
+    Robustness: Extra newlines should not cause errors.
+    """
+    socket_path = tmp_path / "agent.sock"
+    send, recv = anyio.create_memory_object_stream[InputEvent](10)
+
+    async with anyio.create_task_group() as tg:
+        source = AgentRpcSource(socket_path=socket_path)
+        tg.start_soon(source.run, send)
+
+        await wait_for_socket(socket_path)
+
+        async with await anyio.connect_unix(str(socket_path)) as conn:
+            # Send message with empty lines
+            msg_with_blanks = '\n\n{"jsonrpc":"2.0","method":"run","id":1}\n\n'
+            await conn.send(msg_with_blanks.encode())
+
+            import json
+
+            response_line = await conn.receive(4096)
+            response = json.loads(response_line.decode())
+
+            assert response["result"] == "accepted", "Empty lines should not break parsing"
+
+        tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
+async def test_agent_rpc_source_message_at_size_boundary(tmp_path: Path) -> None:
+    """AgentRpcSource accepts message exactly at _MAX_MESSAGE_SIZE.
+
+    Boundary condition: Message at limit should succeed, limit+1 should fail.
+    """
+    socket_path = tmp_path / "agent.sock"
+    send, recv = anyio.create_memory_object_stream[InputEvent](10)
+
+    async with anyio.create_task_group() as tg:
+        source = AgentRpcSource(socket_path=socket_path)
+        tg.start_soon(source.run, send)
+
+        await wait_for_socket(socket_path)
+
+        async with await anyio.connect_unix(str(socket_path)) as conn:
+            # Create message just under limit (accounting for JSON structure)
+            # _MAX_MESSAGE_SIZE = 1MB
+            max_size = 1024 * 1024
+            padding = "x" * (max_size - 100)  # Leave room for JSON structure
+
+            import json
+
+            at_limit = json.dumps(
+                {"jsonrpc": "2.0", "method": "run", "id": 1, "params": {"data": padding}}
+            )
+
+            # Should accept (we're slightly under limit)
+            await conn.send(at_limit.encode() + b"\n")
+            response_line = await conn.receive(4096)
+            response = json.loads(response_line.decode())
+
+            assert response.get("result") == "accepted" or response.get("error"), (
+                "Message near size limit should be processed"
+            )
+
+        tg.cancel_scope.cancel()
+
+
+# =============================================================================
+# Run Command Validation Edge Cases
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_agent_rpc_source_run_empty_stages_list(tmp_path: Path) -> None:
+    """AgentRpcSource accepts empty stages list (different from None).
+
+    Edge case: Empty list [] means "no stages", None means "all stages".
+    """
+    socket_path = tmp_path / "agent.sock"
+    events_received = list[InputEvent]()
+    send, recv = anyio.create_memory_object_stream[InputEvent](10)
+
+    async with anyio.create_task_group() as tg:
+        source = AgentRpcSource(socket_path=socket_path)
+        tg.start_soon(source.run, send)
+
+        await wait_for_socket(socket_path)
+
+        async with await anyio.connect_unix(str(socket_path)) as conn:
+            import json
+
+            request = {
+                "jsonrpc": "2.0",
+                "method": "run",
+                "params": {"stages": []},  # Empty list
+                "id": 1,
+            }
+            await conn.send(json.dumps(request).encode() + b"\n")
+
+            response_line = await conn.receive(4096)
+            response = json.loads(response_line.decode())
+
+            assert response.get("result") == "accepted"
+
+        event = await recv.receive()
+        events_received.append(event)
+
+        tg.cancel_scope.cancel()
+
+    # Type narrow: run_requested events have "stages" field
+    first_event = events_received[0]
+    assert first_event["type"] == "run_requested"
+    if first_event["type"] == "run_requested":
+        assert first_event["stages"] == [], "Empty list should be preserved"
+
+
+@pytest.mark.anyio
+async def test_agent_rpc_source_run_stages_with_empty_string(tmp_path: Path) -> None:
+    """AgentRpcSource rejects stages list containing empty string.
+
+    Edge case: Empty string is not a valid stage name.
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    pipeline = Pipeline("test", root=tmp_path)
+
+    def my_stage() -> None:
+        pass
+
+    pipeline.register(my_stage, name="valid_stage")
+
+    async with Engine(pipeline=pipeline) as eng:
+        handler = AgentRpcHandler(engine=eng)
+        source = AgentRpcSource(socket_path=tmp_path / "test.sock", handler=handler)
+
+        send, recv = anyio.create_memory_object_stream[InputEvent](16)
+
+        request = {
+            "jsonrpc": "2.0",
+            "method": "run",
+            "params": {"stages": [""]},  # Empty string
+            "id": 1,
+        }
+
+        response = await source._handle_request(request, send)
+
+        assert response is not None
+        assert "error" in response, "Empty stage name should be rejected"
+
+
+@pytest.mark.anyio
+async def test_agent_rpc_source_run_force_invalid_type(tmp_path: Path) -> None:
+    """AgentRpcSource rejects non-boolean force parameter.
+
+    Error path: Type validation must reject string "true" or number 1.
+    """
+    socket_path = tmp_path / "agent.sock"
+    send, recv = anyio.create_memory_object_stream[InputEvent](10)
+
+    async with anyio.create_task_group() as tg:
+        source = AgentRpcSource(socket_path=socket_path)
+        tg.start_soon(source.run, send)
+
+        await wait_for_socket(socket_path)
+
+        async with await anyio.connect_unix(str(socket_path)) as conn:
+            import json
+
+            # Send force as string instead of boolean
+            request = {
+                "jsonrpc": "2.0",
+                "method": "run",
+                "params": {"force": "true"},  # String, not bool
+                "id": 1,
+            }
+            await conn.send(json.dumps(request).encode() + b"\n")
+
+            response_line = await conn.receive(4096)
+            response = json.loads(response_line.decode())
+
+            assert "error" in response, "Non-boolean force should be rejected"
+            assert response["error"]["code"] == -32602  # Invalid params
+            assert "force must be boolean" in response["error"]["message"]
+
+        tg.cancel_scope.cancel()
+
+
+# =============================================================================
+# EventSink Buffer Overflow
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_event_sink_slow_subscriber_drops_events() -> None:
+    """EventSink drops events for slow subscribers when buffer is full.
+
+    Critical: Slow clients should not block engine - events must be dropped.
+    """
+    sink = EventSink(buffer_size=3)  # Small buffer for testing
+
+    recv = await sink.subscribe("slow_client")
+
+    # Fill subscriber's buffer without consuming
+    for i in range(5):
+        event = StageStarted(
+            type="stage_started",
+            stage=f"s{i}",
+            index=i,
+            total=5,
+        )
+        await sink.handle(event)
+
+    # Subscriber should only see first 3 events (buffer size)
+    received_events = list[OutputEvent]()
+    try:
+        while True:
+            event = recv.receive_nowait()
+            received_events.append(event)
+    except anyio.WouldBlock:
+        pass
+
+    # Buffer size is 3, so at most 3 events delivered
+    assert len(received_events) <= 3, "Slow subscriber should miss events"
+
+    await sink.close()

--- a/tests/integration/test_rpc_queries.py
+++ b/tests/integration/test_rpc_queries.py
@@ -1,0 +1,228 @@
+"""E2E tests for RPC query handlers.
+
+Verifies the complete wiring:
+- CLI starts serve mode with --serve --force
+- EventBuffer is wired as sink
+- AgentRpcHandler receives the buffer reference
+- Query handlers work end-to-end via the Unix socket
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Generator
+
+
+def send_rpc(
+    sock_path: pathlib.Path, method: str, params: dict[str, object] | None = None
+) -> dict[str, object]:
+    """Send JSON-RPC request and return response."""
+    request: dict[str, object] = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params:
+        request["params"] = params
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(5.0)
+        sock.connect(str(sock_path))
+        sock.sendall(json.dumps(request).encode() + b"\n")
+        response = sock.recv(4096).decode()
+    return json.loads(response)
+
+
+@pytest.fixture
+def serve_pipeline(tmp_path: pathlib.Path) -> Generator[pathlib.Path]:
+    """Start a minimal pipeline in serve mode, yield socket path."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".pivot").mkdir()
+
+    # Use pipeline.py only (not pivot.yaml) to avoid ambiguity error
+    pipeline_code = """\
+import pathlib
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test", root=pathlib.Path(__file__).parent)
+
+def hello() -> None:
+    print("Hello!")
+
+pipeline.register(hello, name="hello")
+"""
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+
+    sock_path = tmp_path / ".pivot" / "agent.sock"
+
+    env = os.environ.copy()
+    env["PIVOT_CACHE_DIR"] = str(tmp_path / "cache")
+
+    proc = subprocess.Popen(
+        ["uv", "run", "pivot", "run", "--watch", "--serve", "--force"],
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        # Wait for socket
+        for _ in range(100):
+            if sock_path.exists():
+                break
+            time.sleep(0.1)
+        else:
+            stdout, stderr = proc.communicate(timeout=1)
+            pytest.fail(
+                "Socket not created within 10s.\n"
+                + f"stdout: {stdout.decode()}\nstderr: {stderr.decode()}"
+            )
+
+        # Poll until status query succeeds (server is ready)
+        for _ in range(30):
+            try:
+                response = send_rpc(sock_path, "status")
+                if "result" in response:
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                pass
+            time.sleep(0.1)
+
+        yield sock_path
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+def test_events_since_query(serve_pipeline: pathlib.Path) -> None:
+    """events_since should return buffered events with expected content."""
+    response = send_rpc(serve_pipeline, "events_since", {"version": 0})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict), f"Expected dict result, got: {type(result)}"
+    assert "version" in result, "Expected version field in result"
+    assert "events" in result, "Expected events field in result"
+    events_field = result["events"]
+    assert isinstance(events_field, list), "Expected events to be list"
+
+    # Verify events contain expected structure from pipeline startup
+    events: list[dict[str, object]] = events_field  # type: ignore[assignment] - JSON returns object
+    if len(events) > 0:
+        # Each event should have version and event fields (VersionedEvent structure)
+        first_event = events[0]
+        assert "version" in first_event, "Event should have version field"
+        assert "event" in first_event, "Event should have event field"
+        event_payload = first_event["event"]
+        assert isinstance(event_payload, dict), "Event payload should be dict"
+        assert "type" in event_payload, "Event payload should have type field"
+
+
+def test_explain_query(serve_pipeline: pathlib.Path) -> None:
+    """explain should return staleness info."""
+    response = send_rpc(serve_pipeline, "explain", {"stage": "hello"})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict), f"Expected dict result, got: {type(result)}"
+    assert "will_run" in result, "Expected will_run field in StageExplanation"
+    assert "reason" in result, "Expected reason field in StageExplanation"
+
+
+def test_stage_info_query(serve_pipeline: pathlib.Path) -> None:
+    """stage_info should return stage metadata."""
+    response = send_rpc(serve_pipeline, "stage_info", {"stage": "hello"})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict), f"Expected dict result, got: {type(result)}"
+    assert result["name"] == "hello", f"Expected name='hello', got: {result.get('name')}"
+    assert "deps" in result, "Expected deps field in result"
+    assert "outs" in result, "Expected outs field in result"
+
+
+def test_events_since_empty_buffer(serve_pipeline: pathlib.Path) -> None:
+    """events_since on empty or newly started buffer returns empty events.
+
+    Edge case: Client polling before any events occur.
+    """
+    response = send_rpc(serve_pipeline, "events_since", {"version": 0})
+    assert "result" in response, f"Expected result, got: {response}"
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert "version" in result
+    assert "events" in result
+    # May have events from startup, but should not crash
+    assert isinstance(result["events"], list)
+
+
+def test_events_since_invalid_version_returns_error(serve_pipeline: pathlib.Path) -> None:
+    """events_since with invalid version parameter returns error.
+
+    Error path: Non-integer or out-of-range version should be rejected.
+    """
+    response = send_rpc(serve_pipeline, "events_since", {"version": "invalid"})
+    assert "error" in response, "Non-integer version should return error"
+
+
+def test_explain_nonexistent_stage_returns_error(serve_pipeline: pathlib.Path) -> None:
+    """explain query with nonexistent stage returns error.
+
+    Error path: Should get clear error, not crash.
+    """
+    response = send_rpc(serve_pipeline, "explain", {"stage": "does_not_exist"})
+    assert "error" in response, f"Expected error for nonexistent stage, got: {response}"
+
+
+def test_stage_info_nonexistent_stage_returns_error(serve_pipeline: pathlib.Path) -> None:
+    """stage_info query with nonexistent stage returns error.
+
+    Error path: Should get clear error, not crash.
+    """
+    response = send_rpc(serve_pipeline, "stage_info", {"stage": "does_not_exist"})
+    assert "error" in response, f"Expected error for nonexistent stage, got: {response}"
+
+
+def test_multiple_queries_same_connection(serve_pipeline: pathlib.Path) -> None:
+    """Multiple queries on same socket connection should all succeed.
+
+    Integration test: Verifies connection reuse and state handling.
+    """
+    import json
+    import socket
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(5.0)
+    sock.connect(str(serve_pipeline))
+
+    try:
+        # First query: status
+        request1 = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "status"})
+        sock.sendall(request1.encode() + b"\n")
+        response1 = json.loads(sock.recv(4096).decode())
+        assert "result" in response1, "First query should succeed"
+
+        # Second query: stages
+        request2 = json.dumps({"jsonrpc": "2.0", "id": 2, "method": "stages"})
+        sock.sendall(request2.encode() + b"\n")
+        response2 = json.loads(sock.recv(4096).decode())
+        assert "result" in response2, "Second query should succeed"
+
+        # Third query: events_since
+        request3 = json.dumps(
+            {"jsonrpc": "2.0", "id": 3, "method": "events_since", "params": {"version": 0}}
+        )
+        sock.sendall(request3.encode() + b"\n")
+        response3 = json.loads(sock.recv(4096).decode())
+        assert "result" in response3, "Third query should succeed"
+    finally:
+        sock.close()


### PR DESCRIPTION
## Summary

Add event streaming and richer query handlers to the RPC interface, enabling agents to monitor and control pipeline execution.

### Changes

- **EventBuffer**: Ring buffer with versioned events for polling-based access via `events_since` query
- **Query handlers**: Added `events_since`, `explain`, and `stage_info` handlers to AgentRpcHandler
- **Engine wiring**: EventBuffer is registered as a sink and passed to handler in serve mode
- **Bug fixes**: Fixed JSON serialization of enum values in events, version wraparound handling

### New RPC Methods

| Method | Description |
|--------|-------------|
| `events_since` | Returns buffered events newer than given version |
| `explain` | Returns staleness info for a stage |
| `stage_info` | Returns stage metadata (deps, outs, params) |

### Testing

- 63 tests covering all new functionality
- E2E integration tests verify complete CLI wiring
- Thread safety tests for EventBuffer
- Edge case coverage (version wraparound, invalid params, etc.)

Closes #261