### PR TITLE
docs: add Claude Code plugin and institutional knowledge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pivot",
+  "description": "Skills for writing Pivot pipeline stages - file I/O annotations, loaders, and output types",
+  "version": "0.1.0",
+  "author": {
+    "name": "Sami Alabed"
+  },
+  "homepage": "https://github.com/sjawhar/pivot",
+  "repository": "https://github.com/sjawhar/pivot",
+  "license": "MIT",
+  "keywords": ["pivot", "pipelines", "data-science", "stages", "annotations"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,57 @@
 
 **Python 3.13+ | Unix only | 90%+ coverage | Pre-alpha (breaking changes OK)**
 
----
-
 ## Project Status
 
-This project is **pre-alpha**. No backwards compatibility is needed.
+**Pre-alpha** - breaking changes acceptable, no migration code or compatibility shims needed.
 
-- **Breaking changes are acceptable** — don't add migration code or compatibility shims
-- **No legacy format support** — only support the current version
-- **Validate design empirically** — test decisions on real workloads, not just theory
+## Project Structure
+
+```
+src/pivot/
+├── cli/           # Click commands, decorators, helpers
+├── config/        # YAML parsing, validation
+├── dag/           # Dependency graph construction
+├── engine/        # Execution coordinator, watch mode
+├── executor/      # Worker process execution (see executor/CLAUDE.md)
+├── pipeline/      # Pipeline state, lock files
+├── remote/        # S3/remote storage
+├── storage/       # StateDB, cache management (see storage/CLAUDE.md)
+├── tui/           # Textual-based terminal UI
+├── fingerprint.py # Code hashing, change detection
+├── registry.py    # Stage registration, discovery
+├── stage_def.py   # Stage definition extraction
+├── loaders.py     # File I/O (CSV, JSON, Pickle, etc.)
+├── outputs.py     # Out, DirectoryOut, IncrementalOut
+└── types.py       # TypedDicts, enums, type aliases
+```
+
+## Key Entry Points
+
+| File | Purpose |
+|------|---------|
+| `src/pivot/cli/__init__.py` | CLI entry point (`pivot` command) |
+| `src/pivot/engine/engine.py` | Pipeline execution coordinator |
+| `src/pivot/executor/worker.py` | Worker process execution |
+| `src/pivot/storage/state_db.py` | LMDB state database |
+| `src/pivot/fingerprint.py` | Code change detection |
+
+## Institutional Knowledge
+
+**`docs/solutions/`** contains documented learnings. Check before implementing features touching:
+- Multiprocessing/loky (pickling, worker lifecycle)
+- Type system (TypedDict, generics, Protocol)
+- Fingerprinting (what triggers re-runs)
+- LMDB/StateDB (prefixes, transactions)
 
 ---
 
 ## Core Design
 
+- **Artifact-first**: The DAG emerges from artifact dependencies, not explicit wiring
 - Per-stage lock files, automatic code fingerprinting, warm worker pools
-- `ProcessPoolExecutor` for true parallelism (not threads—GIL would serialize)
+- `ProcessPoolExecutor` for true parallelism (GIL would serialize threads)
+- Invalidation is content-addressed: same inputs + same code = same outputs
 
 ## Skip Detection
 
@@ -27,7 +62,7 @@ StateDB prefixes: `hash:` (file hashes), `gen:` (output generations), `dep:` (st
 
 ## Worker Execution
 
-Workers execute in separate processes via `loky.get_reusable_executor()` (see Critical Discovery #7).
+Workers execute in separate processes via `loky.get_reusable_executor()`.
 
 ### WorkerStageInfo Contract
 
@@ -66,22 +101,26 @@ Stages using joblib/scikit-learn with `n_jobs > 1` create nested multiprocessing
 
 - Think **artifact-first**, not **stage-first**. The DAG emerges from artifact dependencies.
 - **Right:** "This file changed. What needs to happen because of that?"
-- Invalidation is content-addressed: same inputs + same code = same outputs
-- Stage execution order is derived from the artifact graph, not explicit wiring
-- Watch mode must distinguish external changes (trigger re-run) from stage outputs (don't trigger)
 
-## Stage Registration (Critical)
+## Running Stages
 
-Two pipeline definition methods:
+```bash
+pivot repro                  # Run entire pipeline (DAG-aware)
+pivot repro my_stage         # Run my_stage AND all its dependencies
+pivot repro --watch          # Watch mode - re-run on file changes
+pivot repro --dry-run        # Validate DAG without executing
 
-1. **`pivot.yaml`** - Config file with `stages:` section pointing to Python functions (most common)
-2. **`pipeline.py`** - Python module that calls `REGISTRY.register()` directly
+pivot run my_stage           # Run ONLY my_stage (no dependency resolution)
+pivot run stage1 stage2      # Run specific stages in order (no deps)
+```
+
+**Key difference:** `repro` resolves dependencies automatically; `run` executes only the named stages.
+
+## Stage Registration
+
+Two methods: `pivot.yaml` (config pointing to functions) or `pipeline.py` (direct `pipeline.register()`).
 
 **Discovery order:** `pivot.yaml` → `pivot.yml` → `pipeline.py`
-
-- Stages must be **pure, serializable, module-level functions** for multiprocessing:
-- Workers receive pickled functions—lambdas, closures, and `__main__` definitions fail.
-- Stage functions, output TypedDicts, and custom loaders must be **module-level
 
 ```python
 def train(
@@ -91,123 +130,64 @@ def train(
     return data.dropna()
 ```
 
-** (required for type hint resolution and pickling). Loader code is fingerprinted—changes trigger re-runs.
-
-- **Dependencies**: `param: Annotated[T, Dep(path, loader)]` on function parameters
-- **Outputs**: `field: Annotated[T, Out(path, loader)]` in TypedDict return type
+- **Dependencies**: `Annotated[T, Dep(path, loader)]` on parameters
+- **Outputs**: `Annotated[T, Out(path, loader)]` in TypedDict return type
 - **Parameters**: `params: MyParams` where `MyParams` extends `StageParams`
-- config belongs in code, not YAML.** Use Pydantic classes for configuration, not `params.yaml`.
-- This enables type checking, IDE support, and change detection through fingerprinting.
+- Stages must be **pure, serializable, module-level functions** (lambdas/closures fail pickling)
+- Config belongs in Pydantic classes, not YAML files
+
+---
 
 ## Code Quality
 
 - Type hints everywhere; `ruff format` (100 chars); `ruff check`
 - `_prefix` for private functions; import modules not functions
-- NEVER modify rules in `pyproject.toml` without permission
-- Zero tolerance for basedpyright warnings—resolve all errors AND warnings
-- No blanket `# pyright: reportFoo=false`—use targeted ignores with specific codes:
-  ```python
-  return json.load(f)  # type: ignore[return-value] - json returns Any
-  ```
+- Zero tolerance for basedpyright warnings—use targeted ignores: `# type: ignore[code] - reason`
 - Prefer type stubs (`pandas-stubs`, `types-PyYAML`) over ignores
-
-**For untyped third-party packages**, prefer solutions in this order:
-1. **Check `typings/` first**—we maintain stubs for loky, pygtrie, dvc, lmdb, etc.
-2. **Add to existing stubs**—if the package has stubs but missing a function, add it
-3. **Generate new stubs**—use `scripts/generate_stubs.py` (see script docstring for workflow)
-4. **Line suppressions**—last resort, with `# pyright: ignore[errorCode]` and explanation
+- Check `typings/` first for untyped packages; use `scripts/generate_stubs.py` if needed
 
 ## Python 3.13+ Types
+
 - Empty collections: `list[int]()` not `: list[int] = []`
 - Simplified Generator: `Generator[int]` not `Generator[int, None, None]`
-- `Callable` over `Any` for functions; document why when using `Any`
-- Prefer better code over comments. Add comments only for non-obvious WHY, timing constraints, or known limitations. Never comment obvious WHAT.
-- No module-level docstrings. Simple functions get one-line docstrings—skip Args/Returns if type hints make it obvious.
-- Write evergreen docs—avoid "recently added" or "as of version X".
-- **Early returns:** Keep main logic at top indentation; avoid pyramid of doom
-- **Match statements:** Prefer over if/elif for enum dispatch and type discrimination
-- **Enums over Literals:** For programmatic values (catches typos at type-check time)
+- **Enums over Literals** for programmatic values (catches typos at type-check time)
 
 ## TypedDict
 
-- Zero runtime overhead, native JSON serialization. Use over dataclasses (need `asdict()`) or namedtuples (serialize as arrays).
-- Never use `.get()`—direct access only. For optional fields: `if "key" in d: d["key"]`
-- Always use constructor syntax: `return Result(status="ok")` not `{"status": "ok"}`
-
-## Pydantic
-
-- Use for data needing validation with clear errors (config files, user input, API boundaries).
-- Avoid in hot paths—use TypedDict there.
-- **Config belongs in code, not YAML.** Use Pydantic classes for configuration, not `params.yaml`. This enables type checking, IDE support, and change detection through fingerprinting.
-
-## Path Handling
-
-All paths in lockfiles must be **relative** (to stage cwd), never absolute. This ensures portability and correct cache behavior.
+- Use over dataclasses/namedtuples (zero overhead, native JSON)
+- Direct access only, never `.get()`. For optional: `if "key" in d: d["key"]`
+- Constructor syntax: `Result(status="ok")` not `{"status": "ok"}`
 
 ## Import Style
 
-- Import modules, not functions: `from pivot import fingerprint` then `fingerprint.func()`.
-- **No lazy imports**—all imports at module level. This ensures fingerprinting captures dependencies and makes imports explicit.
+Import modules, not functions: `from pivot import fingerprint` then `fingerprint.func()`.
 
-**Exceptions:**
-- `TYPE_CHECKING` blocks: Import types directly (`from pathlib import Path`)
-- `pivot.types`: Import directly (`from pivot.types import StageStatus`)
-- `typing` module: Always direct (`from typing import Any`)
-- Optional/platform-specific modules: Lazy import with try/except when module may not exist (e.g., `resource` on Windows)
-- CLI modules: Lazy imports acceptable in `pivot.cli` to reduce startup time
+**Exceptions:** `TYPE_CHECKING` blocks, `pivot.types`, `typing` module, CLI lazy imports.
 
-## Error Handling Philosophy
+## Error Handling
 
-- **Validate boundaries, trust internals.** Validate aggressively at entry points (CLI, file I/O, config parsing). Once validated, trust data downstream — no redundant internal validation.
-- Let errors propagate—catch at boundaries where you can handle meaningfully. Silent failures are worse than crashes.
-
-**When to suppress vs propagate:**
-| Condition | Action |
-|-----------|--------|
-| Unknown/invalid state | Propagate — fail fast |
-| Invariant violation | Propagate — this is a bug |
-| Cache miss, optional feature | Log and continue with fallback |
-| Resource exhaustion (queue full) | Propagate — architectural issue |
-
-**Failed operations should be atomic** — return to last known good state. If a stage fails, don't update the lockfile.
-
-- **Validate upfront, validate early.** Check all preconditions before performing any side effects. This ensures operations are atomic—either all succeed or none do.
-- Fail fast with clear errors—don't silently fix or skip invalid inputs.
-- Never silently ignore validation failures (typos in field names, type mismatches, missing required data).
+- Validate at boundaries (CLI, file I/O, config), trust internals
+- Let errors propagate; catch only where you can handle meaningfully
+- Failed operations should be atomic—return to last known good state
 
 ## Simplicity Over Abstraction
 
-- **Don't create thin wrapper functions** — if it just calls one library function, inline it
-- **Don't over-modularize** — a module with one public function used by one other module should be inlined
-- **Don't add options without justification** — if you can't articulate when each option would be used, you don't need options
-- **Three similar lines > premature abstraction** — wait until the pattern is clear before extracting
+- Don't create thin wrappers—inline single-use library calls
+- Don't over-modularize—inline modules with one public function
+- Three similar lines > premature abstraction
+
+---
+
+## Path Handling
+
+All paths in lockfiles must be **relative** (to stage cwd), never absolute.
 
 ## Development
 
 ```bash
-uv sync --active       # Install deps
-uv run pytest tests/ -n auto  # Test
-uv run ruff format . && uv run ruff check . && uv run basedpyright .  # Quality
+uv sync --active                                                    # Install deps
+uv run pytest tests/ -n auto                                        # Test
+uv run ruff format . && uv run ruff check . && uv run basedpyright  # Quality
 ```
 
-- Before Returning to User or pushing (Critical), Run all quality checks
-
-## Critical Discoveries
-
-1. **Test helpers must be module-level**—`getclosurevars()` doesn't see imports in inline closures
-2. **Single underscore functions ARE tracked**—only dunders (`__name__`) filtered
-3. **Circular imports:** Extract shared types to separate module
-4. **AST manipulation:** Function bodies need at least one statement—add `ast.Pass()` if empty
-5. **Path overlap detection:** Use pygtrie, not string matching (`data/` vs `data/file.csv`)
-6. **loky can't pickle `mp.Queue()`**—use `mp.Manager().Queue()`
-7. **Reusable executor:** `loky.get_reusable_executor()` keeps workers warm
-8. **Cross-process tests:** Use file-based state, not shared lists (each process copies)
-9. **Atomic writes:** Track fd closure when using `mkstemp()` + rename
-10. **IncrementalOut uses COPY mode**—hardlinks/symlinks would corrupt cache
-11. **StateDB path strategies:** `resolve()` for hash keys (dedup), `normpath()` for generation keys (logical paths)
-12. **LMDB for all state:** Extend StateDB with prefixes, don't add new databases
-13. **ruamel.yaml for editable config** (preserves comments), **PyYAML for read-only**
-14. **Stage functions and TypedDicts must be module-level**—`get_type_hints()` needs importable `__module__`
-15. **Lambda fingerprinting is non-deterministic**—lambdas without source fall back to `id(func)`, causing unnecessary re-runs across interpreter sessions. Always use named functions in stage definitions.
-16. **Use `loky.cpu_count()` over `os.cpu_count()`**—loky's version respects cgroup CPU limits in containers/cgroupsv2
-17. **Engine is a context manager**—use `with Engine() as engine:` to ensure sinks are closed properly on exit
+**Run all quality checks before returning to user or pushing.**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ from typing import Annotated, TypedDict
 
 import pandas
 from pivot import loaders, outputs
-from pivot.registry import REGISTRY
+from pivot.pipeline import Pipeline
 
 
 class PreprocessOutputs(TypedDict):
@@ -71,14 +71,15 @@ def train(
     return TrainOutputs(model=model_path)
 
 
-# Register stages
-REGISTRY.register(preprocess)
-REGISTRY.register(train)
+# Create pipeline and register stages
+pipeline = Pipeline("my_pipeline")
+pipeline.register(preprocess)
+pipeline.register(train)
 ```
 
 ```bash
-pivot run  # Runs both stages
-pivot run  # Instant - nothing changed
+pivot repro  # Runs both stages
+pivot repro  # Instant - nothing changed
 ```
 
 Modify `preprocess`, and Pivot automatically re-runs both stages. Modify `train`, and only `train` re-runs.
@@ -143,7 +144,7 @@ pivot export --validate  # Creates dvc.yaml and validates against DVC
 **Killer feature:** See WHY a stage would run
 
 ```bash
-pivot run --explain
+pivot repro --explain
 
 Stage: train
   Status: WILL RUN
@@ -276,7 +277,7 @@ default_remote: origin
 2. `pivot push` → upload cache files to S3
 3. On another machine: clone repo (includes lock files in git)
 4. `pivot pull train_model` → download only files needed for that stage
-5. `pivot run` → stages with cached outputs skip execution
+5. `pivot repro` → stages with cached outputs skip execution
 
 ### 9. Data Diff
 
@@ -400,7 +401,6 @@ pip install pivot
 Full documentation available at the [Pivot Documentation Site](https://anthropics.github.io/pivot/).
 
 - **[Quick Start](docs/getting-started/quickstart.md)** - Build your first pipeline in 5 minutes
-- **[Core Concepts](docs/getting-started/concepts.md)** - Stages, dependencies, caching
 - **[CLI Reference](docs/cli/index.md)** - All available commands
 - **[Architecture](docs/architecture/overview.md)** - Design decisions and internals
 - **[Comparison](docs/comparison.md)** - How Pivot compares to DVC, Prefect, Dagster
@@ -418,9 +418,9 @@ Full documentation available at the [Pivot Documentation Site](https://anthropic
 - **Watch mode** - File system monitoring with configurable globs and debounce
 - **Incremental outputs** - Restore-before-run for append-only workloads
 - **DVC export** - `pivot export` command for YAML generation
-- **Explain mode** - `pivot run --explain` and `pivot explain` show detailed breakdown of WHY stages would run
+- **Explain mode** - `pivot repro --explain` and `pivot status --explain` show detailed breakdown of WHY stages would run
 - **Observability** - `pivot metrics show/diff`, `pivot plots show/diff`, and `pivot params show/diff` commands
-- **Pipeline configuration** - Python-first with `REGISTRY.register()`, optional `pivot.yaml` for matrix expansion
+- **Pipeline configuration** - Python-first with `Pipeline.register()`, optional `pivot.yaml` for matrix expansion
 - **S3 remote cache** - `pivot push/pull` with async I/O, LMDB index, per-stage filtering
 - **Data diff** - `pivot data diff` command with interactive TUI for comparing data file changes
 - **Version retrieval** - `pivot data get --rev` to materialize files from any git revision
@@ -440,7 +440,7 @@ Full documentation available at the [Pivot Documentation Site](https://anthropic
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  User Pipeline Code (pipeline.py with REGISTRY.register())  │
+│  User Pipeline Code (pipeline.py with Pipeline.register())  │
 │  @outputs.Dep("data.csv", loaders.CSV())                    │
 │  @outputs.Out("model.pkl", loaders.PathOnly())              │
 │  def train(data: ...) -> TrainOutputs: ...                  │

--- a/docs/architecture/execution.md
+++ b/docs/architecture/execution.md
@@ -12,7 +12,7 @@ Pivot uses a parallel execution model with warm worker pools for maximum perform
        ▼
 ┌──────────────────┐
 │  Engine          │  ← Central coordinator
-│  (run_once)      │
+│  (run)           │
 └──────┬───────────┘
        │
        ▼
@@ -56,7 +56,7 @@ The Engine uses event-driven orchestration for maximum parallelism:
 3. **Mutex Handling** - Prevents conflicting stages from running concurrently
 4. **Event Emission** - StageStarted/StageCompleted events to sinks
 
-As stages complete, their downstream stages become ready. The Engine handles both batch (`run_once`) and continuous (`run_loop`) execution through the same orchestration code.
+As stages complete, their downstream stages become ready. The Engine handles both batch (`exit_on_completion=True`) and continuous (`exit_on_completion=False`) execution through the same orchestration code.
 
 ## Stage Execution States
 

--- a/docs/brainstorms/2026-01-31-reader-writer-split-brainstorm.md
+++ b/docs/brainstorms/2026-01-31-reader-writer-split-brainstorm.md
@@ -1,0 +1,53 @@
+# Brainstorm: Split Loader into Reader/Writer
+
+**Date:** 2026-01-31
+**Issue:** [#237 - Asymmetric Loaders](https://github.com/sjawhar/pivot/issues/237)
+**Status:** Ready for planning
+
+## What We're Building
+
+Split the `Loader[T]` base class into separate `Reader[T]` and `Writer[T]` ABCs, allowing asymmetric formats (write Figure → read ndarray).
+
+## Why This Approach
+
+The "Hybrid Loader Refactor" approach was chosen over alternatives because:
+
+1. **Minimal complexity** - No AdapterRegistry, no Format classes, no runtime type extraction
+2. **Type-safe** - `isinstance(loader, Reader)` enables type narrowing
+3. **Fixes real pain points** - Eliminates phantom types and write-only hacks
+4. **Backwards compatible pattern** - `Loader[T](Reader[T], Writer[T])` preserves existing API
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Base classes | `Reader[T]`, `Writer[T]`, `Loader[T]` | Clean separation, `Loader` combines both |
+| Phantom types | Remove for fixed-type loaders | `Csv(Loader[DataFrame])` is honest |
+| Variable-type loaders | Keep generic, document limitation | `Json[T]` for type checking only |
+| PEP8 naming | Rename (`CSV` → `Csv`, etc.) | Consistency |
+| Validation | At registration time | Catch `Writer` used with `Dep` early |
+| AdapterRegistry | Not doing | Adds complexity, explicit loaders are fine |
+
+## Special Cases
+
+### DirectoryOut
+- Uses `Writer[dict[str, T]]` - no change needed
+- Each value written via the loader's `save()` method
+
+### IncrementalOut
+- Requires full `Loader[T]` (needs both read and write)
+- Must call `empty()` on first run
+- Attribute stays as `loader`, not `reader`/`writer`
+
+### Dep/Out Annotations
+- `Dep.loader` → `Dep.reader: Reader[T]`
+- `Out.loader` → `Out.writer: Writer[T]`
+- `IncrementalOut.loader: Loader[T]` (unchanged)
+
+## Open Questions
+
+None - design is complete and ready for implementation.
+
+## Next Steps
+
+Run `/workflows:plan` to create implementation tasks.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,6 +13,8 @@ Complete reference for all Pivot command-line commands.
 | Understand why stage runs | `pivot status --explain stage` |
 | List all stages | `pivot list` |
 | Show stage status | `pivot status` |
+| Visualize DAG | `pivot dag` |
+| Verify reproducibility | `pivot verify` |
 | Push outputs to remote | `pivot push` |
 | Pull outputs from remote | `pivot pull` |
 | Watch for changes | `pivot repro --watch` |
@@ -248,6 +250,94 @@ pivot export [STAGES...] [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--output` / `-o PATH` | Output path (default: `dvc.yaml`) |
+
+---
+
+### `pivot dag`
+
+Visualize the pipeline DAG.
+
+```bash
+pivot dag [TARGETS...] [OPTIONS]
+```
+
+Shows the dependency graph of artifacts (default) or stages. Without targets, shows the entire graph. With targets, shows the subgraph containing those targets and their upstream dependencies.
+
+**Arguments:**
+
+- `TARGETS` - Stage names or artifact paths to filter (optional, shows entire graph if not specified). Stage names take precedence when a name matches both a stage and a file path.
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--dot` | Output Graphviz DOT format |
+| `--mermaid` | Output Mermaid format |
+| `--md` | Output Mermaid wrapped in markdown |
+| `--stages` | Show stages as nodes (default: artifacts) |
+
+**Examples:**
+
+```bash
+# Show entire artifact DAG
+pivot dag
+
+# Show DAG for specific stage and its dependencies
+pivot dag train
+
+# Output as Mermaid diagram
+pivot dag --mermaid
+
+# Show stage-level DAG instead of artifacts
+pivot dag --stages
+
+# Output Graphviz DOT for external rendering
+pivot dag --dot > pipeline.dot
+```
+
+---
+
+### `pivot verify`
+
+Verify pipeline was reproduced and outputs are available.
+
+```bash
+pivot verify [STAGES...] [OPTIONS]
+```
+
+Checks that all stages are cached (code, params, deps match lock files) and output files exist locally or on remote. Use in CI pre-merge gates to ensure pipeline is reproducible.
+
+**Arguments:**
+
+- `STAGES` - Stage names to verify (optional, verifies all if not specified)
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--allow-missing` | Allow missing local files if on remote |
+| `--json` | Output as JSON |
+
+**Exit Codes:**
+
+- `0` - Verification passed
+- `1` - Verification failed (stale stages or missing files)
+
+**Examples:**
+
+```bash
+# Verify entire pipeline
+pivot verify
+
+# Verify specific stages
+pivot verify train evaluate
+
+# CI gate: allow missing local files if on remote
+pivot verify --allow-missing
+
+# JSON output for scripting
+pivot verify --json
+```
 
 ---
 

--- a/docs/design/watch-engine.md
+++ b/docs/design/watch-engine.md
@@ -197,7 +197,7 @@ pivot repro --watch --tui
 
 ## References
 
-- [Architecture doc](/docs/architecture/watch.md)
+- [Architecture doc](../architecture/watch.md)
 - [Buck2 incremental computation](https://engineering.fb.com/2023/04/06/open-source/buck2-open-source-large-scale-build-system/)
 - [watchfiles library](https://github.com/samuelcolvin/watchfiles)
 - [loky reusable executor](https://loky.readthedocs.io/)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -54,9 +54,6 @@ pip install -e ".[dev]"
 ## Verifying Installation
 
 ```bash
-# Check version
-pivot --version
-
 # List available commands
 pivot --help
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -33,7 +33,9 @@ from typing import Annotated, TypedDict
 
 import pandas
 from pivot import loaders, outputs
-from pivot.registry import REGISTRY
+from pivot.pipeline import Pipeline
+
+pipeline = Pipeline("my_pipeline")
 
 
 class PreprocessOutputs(TypedDict):
@@ -67,8 +69,8 @@ def train(
 
 
 # Register stages - Pivot discovers deps/outs from annotations
-REGISTRY.register(preprocess)
-REGISTRY.register(train)
+pipeline.register(preprocess)
+pipeline.register(train)
 ```
 
 ## 3. Create Sample Data

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ from typing import Annotated, TypedDict
 
 import pandas
 from pivot import loaders, outputs
-from pivot.registry import REGISTRY
+from pivot.pipeline import Pipeline
 
 
 class PreprocessOutputs(TypedDict):
@@ -49,8 +49,9 @@ def train(
 
 
 # Register stages - Pivot discovers deps/outs from annotations
-REGISTRY.register(preprocess)
-REGISTRY.register(train)
+pipeline = Pipeline("my_pipeline")
+pipeline.register(preprocess)
+pipeline.register(train)
 ```
 
 ```bash

--- a/docs/plans/2026-01-31-refactor-loader-reader-writer-split-plan.md
+++ b/docs/plans/2026-01-31-refactor-loader-reader-writer-split-plan.md
@@ -1,0 +1,299 @@
+---
+title: "refactor: Split Loader into Reader/Writer"
+type: refactor
+date: 2026-01-31
+issue: https://github.com/sjawhar/pivot/issues/237
+---
+
+# refactor: Split Loader into Reader/Writer
+
+## Overview
+
+Split the `Loader[T]` ABC into separate `Reader[R]` and `Writer[W]` base classes, enabling asymmetric formats where write and read types differ (e.g., write `Figure` to PNG, read back as `np.ndarray`).
+
+## Problem Statement
+
+1. `MatplotlibFigure.load()` raises `NotImplementedError` - a runtime hack
+2. Can't have loaders with different read/write types (asymmetric formats)
+3. The type system should prevent misuse at type-check time
+
+## Proposed Solution
+
+### New Class Hierarchy
+
+Using [PEP 696](https://peps.python.org/pep-0696/) type parameter defaults (Python 3.13+):
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Reader[R](abc.ABC):
+    """Read-only - can load data from a file."""
+    @abc.abstractmethod
+    def load(self, path: Path) -> R: ...
+
+@dataclasses.dataclass(frozen=True)
+class Writer[W](abc.ABC):
+    """Write-only - can save data to a file."""
+    @abc.abstractmethod
+    def save(self, data: W, path: Path) -> None: ...
+
+@dataclasses.dataclass(frozen=True)
+class Loader[W, R = W](Writer[W], Reader[R]):
+    """Bidirectional - can save W and load R (defaults to same type)."""
+    def empty(self) -> R:
+        raise NotImplementedError(f"{type(self).__name__} doesn't support empty()")
+```
+
+The `R = W` default means symmetric loaders only need one type parameter.
+
+### Example Usage
+
+```python
+# Symmetric loader - single type param uses default (R = W)
+class CSV(Loader[DataFrame]):
+    def save(self, data: DataFrame, path: Path) -> None: ...
+    def load(self, path: Path) -> DataFrame: ...
+
+# Asymmetric loader - explicit both types
+class PngImage(Loader[Figure, np.ndarray]):
+    """Write matplotlib Figure, read back as numpy array."""
+    def save(self, data: Figure, path: Path) -> None:
+        data.savefig(path)
+        plt.close(data)
+
+    def load(self, path: Path) -> np.ndarray:
+        from PIL import Image
+        return np.array(Image.open(path))
+
+# Write-only (no Reader inheritance)
+class MatplotlibFigure(Writer[Figure]):
+    def save(self, data: Figure, path: Path) -> None: ...
+```
+
+**What we're NOT doing** (per review feedback):
+- No PEP8 renames (`CSV` stays `CSV`, not `Csv`)
+- No attribute renames (`.loader` stays `.loader`)
+- No runtime validation (type checker handles it)
+
+## Technical Approach
+
+### Phase 1: Add ABCs and Update Loaders
+
+**File:** `src/pivot/loaders.py`
+
+1. Add `Reader[R]` ABC with `load() -> R`
+2. Add `Writer[W]` ABC with `save(data: W, ...)`
+3. Change `Loader[T]` to `Loader[W, R](Writer[W], Reader[R])`
+4. Move `empty() -> R` to `Loader`
+5. Update existing loaders (minimal changes due to default):
+
+| Loader | Before | After | Notes |
+|--------|--------|-------|-------|
+| `CSV` | `Loader[DataFrame]` | `Loader[DataFrame]` | No change (default R=W) |
+| `JSON` | `Loader[T]` | `Loader[T]` | No change |
+| `YAML` | `Loader[T]` | `Loader[T]` | No change |
+| `Text` | `Loader[str]` | `Loader[str]` | No change |
+| `JSONL` | `Loader[list[dict]]` | `Loader[list[dict]]` | No change |
+| `DataFrameJSONL` | `Loader[DataFrame]` | `Loader[DataFrame]` | No change |
+| `Pickle` | `Loader[T]` | `Loader[T]` | No change |
+| `PathOnly` | `Loader[Path]` | `Loader[Path]` | No change |
+| `MatplotlibFigure` | `Loader[Figure]` | `Writer[Figure]` | Now write-only |
+
+6. (Optional) Add `PngImage(Loader[Figure, np.ndarray])` for asymmetric example
+
+### Phase 2: Update Type Annotations
+
+**File:** `src/pivot/outputs.py`
+
+Change the type of `.loader` attributes:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Dep(Generic[R]):
+    path: PathType
+    loader: Reader[R]  # Only needs to read
+
+@dataclasses.dataclass(frozen=True)
+class Out(Generic[W]):
+    path: PathType
+    loader: Writer[W]  # Only needs to write
+    cache: bool = True
+
+@dataclasses.dataclass(frozen=True)
+class PlaceholderDep(Generic[R]):
+    path: PathType
+    loader: Reader[R]
+```
+
+**IncrementalOut special case:**
+
+```python
+@dataclasses.dataclass(frozen=True)
+class IncrementalOut(Generic[W, R]):
+    """Incremental output - writes W, reads R."""
+    path: PathType
+    loader: Loader[W, R]  # Needs both read and write
+    cache: bool = True
+```
+
+For symmetric use (most common), users write `IncrementalOut[T]` (R defaults to W).
+
+**DirectoryOut (type inconsistency fix):**
+
+`DirectoryOut` has an existing type inconsistency: it inherits from `Out[dict[str, T]]` (so `loader: Loader[dict[str, T]]`), but actually uses the loader to write individual values of type `T`:
+
+```python
+# Current (type lie)
+class DirectoryOut(Out[dict[str, T]]):
+    # Inherits loader: Loader[dict[str, T]] from Out
+    # But code does: loader.save(value_of_type_T, path)  # Type mismatch!
+```
+
+**Fix: Extract common base class**
+
+```python
+@dataclasses.dataclass(frozen=True)
+class BaseOut(Generic[T]):
+    """Common fields for output specs. T is the stage return type."""
+    path: PathType
+    cache: bool = True
+
+@dataclasses.dataclass(frozen=True)
+class Out(BaseOut[T]):
+    """Single file output. Loader writes T."""
+    loader: Writer[T]
+
+@dataclasses.dataclass(frozen=True)
+class DirectoryOut(BaseOut[dict[str, T]]):
+    """Directory output. Stage returns dict[str, T], loader writes individual T values."""
+    loader: Writer[T]  # Writes T, not dict[str, T]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path.endswith("/"):
+            raise ValueError(...)
+```
+
+This way:
+- `Out[T]` has `loader: Writer[T]` - type-correct
+- `DirectoryOut[T]` extends `BaseOut[dict[str, T]]` (stage returns dict) but has `loader: Writer[T]` (writes items)
+- Shared `path` and `cache` fields in `BaseOut`
+
+**Other Out subclasses:**
+- `Metric(Out[JsonValue])` - stays as `Out` subclass, inherits `loader: Writer[JsonValue]`
+- `Plot(Out[T])` - stays as `Out` subclass, inherits `loader: Writer[T]`
+- `IncrementalOut` - needs `Loader[W, R]` (bidirectional), see below
+
+### Phase 3: Update Fingerprinting
+
+**File:** `src/pivot/fingerprint.py`
+
+```python
+def get_loader_fingerprint(loader: Writer[Any] | Reader[Any]) -> dict[str, str]:
+    """Generate fingerprint manifest for a loader instance."""
+    manifest = dict[str, str]()
+    name = type(loader).__name__
+
+    if isinstance(loader, Writer):
+        manifest[f"loader:{name}:save"] = hash_function_ast(loader.save)
+
+    if isinstance(loader, Reader):
+        manifest[f"loader:{name}:load"] = hash_function_ast(loader.load)
+        # Only fingerprint empty() if overridden (use MRO check)
+        if isinstance(loader, Loader):
+            for cls in type(loader).__mro__:
+                if cls is Loader:
+                    break
+                if "empty" in cls.__dict__:
+                    manifest[f"loader:{name}:empty"] = hash_function_ast(loader.empty)
+                    break
+
+    # Config hash from dataclass fields (unchanged)
+    field_values = [f"{f.name}={getattr(loader, f.name)!r}" for f in dataclasses.fields(loader)]
+    if field_values:
+        manifest[f"loader:{name}:config"] = xxhash.xxh64(",".join(field_values).encode()).hexdigest()
+
+    return manifest
+```
+
+### Phase 4: Update Tests
+
+- Update loader tests for two type parameters
+- Add test for asymmetric loader (`Loader[Figure, np.ndarray]`)
+- Verify `MatplotlibFigure` with `Dep` fails type-check
+- Test `IncrementalOut` with both symmetric and asymmetric loaders
+
+## Acceptance Criteria
+
+- [ ] `Reader[R]` ABC with `load() -> R`
+- [ ] `Writer[W]` ABC with `save(data: W, ...)`
+- [ ] `Loader[W, R](Writer[W], Reader[R])` with `empty() -> R`
+- [ ] Existing symmetric loaders use `Loader[T]` (R defaults to W)
+- [ ] `MatplotlibFigure` is `Writer[Figure]` (no `load()` method)
+- [ ] `Dep.loader: Reader[R]` type annotation
+- [ ] `Out.loader: Writer[W]` type annotation
+- [ ] `IncrementalOut.loader: Loader[W, R]`
+- [ ] `BaseOut` extracted with shared `path` and `cache` fields
+- [ ] `Out` and `DirectoryOut` both inherit from `BaseOut`
+- [ ] `DirectoryOut.loader: Writer[T]` (writes items, not dict)
+- [ ] Fingerprinting handles all cases
+- [ ] All tests pass
+- [ ] `basedpyright .` passes
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Two type params for Loader | `Loader[W, R = W]` | Enables asymmetric formats, defaults to symmetric |
+| Parameter order | Write first, Read second | Matches dataflow: save(W) → load() → R |
+| PEP 696 default | `R = W` | Symmetric loaders need only one type param |
+| Keep `.loader` attribute name | Yes | Type annotation provides constraint |
+| PEP8 renames | No | Unrelated to core problem |
+| Runtime validation | No | Type checker handles it |
+| `empty()` returns `R` | Yes | `empty()` provides initial read value |
+
+## Open Questions
+
+### IncrementalOut Inheritance
+
+`IncrementalOut` currently inherits from `Out`. With the new design:
+- `Out[W]` has `loader: Writer[W]`
+- `IncrementalOut[W, R]` has `loader: Loader[W, R]`
+
+Options:
+1. **Don't inherit** - Make `IncrementalOut` standalone (some duplication)
+2. **Override type** - Works because `Loader[W, R]` is a subtype of `Writer[W]`
+
+Recommendation: Option 2 if type checker accepts it, otherwise Option 1.
+
+## Files Changed
+
+```
+src/pivot/loaders.py      # ABCs + all loader type param updates
+src/pivot/outputs.py      # Type annotation changes
+src/pivot/fingerprint.py  # isinstance-based fingerprinting
+tests/                    # Test updates
+```
+
+## Migration & Breaking Changes
+
+**This is a pre-alpha project. Breaking changes are acceptable.**
+
+Most changes are backwards-compatible due to PEP 696 defaults:
+
+```python
+# Before AND After - no change needed
+class MyLoader(Loader[DataFrame]): ...
+```
+
+**Breaking changes:**
+- `DirectoryOut` no longer inherits from `Out` (uses `BaseOut` instead)
+- `IncrementalOut` becomes `IncrementalOut[W, R]` (may require explicit type params)
+- `MatplotlibFigure` is now `Writer[Figure]` (can't be used with `Dep` - but this was broken anyway)
+- Lock files will be invalidated (full re-run on first use after upgrade)
+
+These are acceptable for pre-alpha. No migration path or deprecation warnings needed.
+
+## References
+
+- **Issue:** [#237](https://github.com/sjawhar/pivot/issues/237)
+- **Brainstorm:** `docs/brainstorms/2026-01-31-reader-writer-split-brainstorm.md`
+- **Current loaders:** `src/pivot/loaders.py:22-328`

--- a/docs/prevention/typeddictfield-synchronization.md
+++ b/docs/prevention/typeddictfield-synchronization.md
@@ -66,7 +66,7 @@ This can be aliased or added to pre-commit hooks:
 
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-alias check-pivot="cd ~/pivot/watch && uv run ruff format . && uv run ruff check . && uv run basedpyright ."
+alias check-pivot="cd ~/pivot/default && uv run ruff format . && uv run ruff check . && uv run basedpyright ."
 ```
 
 **Frequency:**

--- a/docs/solutions/2026-01-31-dataclass-inheritance-field-ordering.md
+++ b/docs/solutions/2026-01-31-dataclass-inheritance-field-ordering.md
@@ -1,0 +1,65 @@
+---
+tags: [python, dataclass, inheritance, typing]
+category: gotcha
+module: outputs
+symptoms: ["TypeError: non-default argument follows default argument", "dataclass field ordering error"]
+---
+
+# Dataclass Inheritance: Non-Default Fields Cannot Follow Fields with Defaults
+
+## Problem
+
+When refactoring the output class hierarchy to extract a common `BaseOut` base class, the plan was:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class BaseOut[T]:
+    path: PathType
+    cache: bool = True  # Has a default
+
+@dataclasses.dataclass(frozen=True)
+class Out[T](BaseOut[T]):
+    loader: Writer[T]  # No default - ERROR!
+```
+
+This fails because Python dataclasses collect fields from the entire class hierarchy, and **non-default fields cannot appear after fields with defaults**. Since `BaseOut` has `cache: bool = True`, any subclass adding a field without a default (`loader`) violates the ordering rule.
+
+This is a fundamental limitation of dataclass inheritance, not a bug.
+
+## Solution
+
+Make the child classes standalone (no inheritance from `BaseOut`), accepting the small amount of field duplication:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Out[W]:
+    path: PathType
+    loader: Writer[W]
+    cache: bool = True
+
+@dataclasses.dataclass(frozen=True)
+class DirectoryOut[T]:
+    path: str  # Duplicated field
+    loader: Writer[T]
+    cache: bool = True  # Duplicated field
+
+@dataclasses.dataclass(frozen=True)
+class IncrementalOut[W, R = W]:
+    path: PathType  # Duplicated field
+    loader: Loader[W, R]
+    cache: bool = True  # Duplicated field
+```
+
+## Key Insight
+
+When designing dataclass hierarchies, consider field ordering upfront:
+
+1. **All non-default fields must come before all default fields** across the entire inheritance chain
+2. If a base class has fields with defaults, subclasses cannot add required fields
+3. Workarounds:
+   - Make all fields have defaults (use sentinel values or `field(default=MISSING)`)
+   - Use composition instead of inheritance
+   - Accept field duplication in standalone classes (often simplest)
+   - Use `attrs` library which has more flexible field ordering via `kw_only`
+
+The duplication tradeoff is often acceptable: three classes each with `path`, `loader`, `cache` is cleaner than complex inheritance gymnastics.

--- a/docs/solutions/2026-01-31-dict-invariance-protocol-typing.md
+++ b/docs/solutions/2026-01-31-dict-invariance-protocol-typing.md
@@ -1,0 +1,56 @@
+---
+tags: [python, typing, generics, protocol]
+category: gotcha
+module: registry
+symptoms: ["dict[str, BaseOut] cannot be assigned to dict[str, Out[Any]]", "Type parameter is invariant", "Consider switching from dict to Mapping"]
+---
+
+# Dict Invariance vs Protocol Covariance in Python Type System
+
+## Problem
+
+When refactoring to use a Protocol (`BaseOut`) instead of a concrete class (`Out[Any]`), type errors appeared when passing dictionaries:
+
+```
+Argument of type "dict[str, BaseOut]" cannot be assigned to parameter
+"return_out_specs" of type "dict[str, Out[Any]]"
+  "dict[str, BaseOut]" is not assignable to "dict[str, Out[Any]]"
+    Type parameter "_VT@dict" is invariant, but "BaseOut" is not the same as "Out[Any]"
+    Consider switching from "dict" to "Mapping" which is covariant in the value type
+```
+
+The issue arose when functions expected `dict[str, Out[Any]]` but were passed `dict[str, BaseOut]` after extraction functions were updated to return the more general Protocol type.
+
+## Solution
+
+Two approaches, depending on whether the function needs to mutate the dict:
+
+1. **Use `Mapping` for read-only parameters** (covariant in value type):
+   ```python
+   def _validate_incremental_out_matching(
+       return_out_specs: Mapping[str, BaseOut],  # Accepts dict[str, Out] or dict[str, BaseOut]
+       ...
+   ) -> None:
+   ```
+
+2. **Use `dict[str, BaseOut]` for parameters that need mutation**:
+   ```python
+   def process_specs(specs: dict[str, BaseOut]) -> None:
+       specs["new_key"] = new_spec  # Can add BaseOut values
+   ```
+
+For list parameters, use `Sequence` (covariant) instead of `list` (invariant) when read-only access is sufficient.
+
+## Key Insight
+
+Python's generic collections have different variance properties:
+
+| Mutable | Immutable | Variance |
+|---------|-----------|----------|
+| `dict[K, V]` | `Mapping[K, V]` | Key: invariant, Value: **covariant in Mapping** |
+| `list[T]` | `Sequence[T]` | **Covariant in Sequence** |
+| `set[T]` | `AbstractSet[T]` | **Covariant in AbstractSet** |
+
+When introducing a Protocol to unify related types (`Out`, `DirectoryOut`, `IncrementalOut` all implementing `BaseOut`), you must also update function signatures to use covariant collection types (`Mapping`, `Sequence`) for parameters that don't need mutation. Otherwise, the type system will reject calls even though the Protocol relationship is correct.
+
+This is especially important during large refactors that change return types of extraction functions - every downstream consumer of those dictionaries/lists must be audited.

--- a/docs/solutions/2026-01-31-dict-invariance-typing.md
+++ b/docs/solutions/2026-01-31-dict-invariance-typing.md
@@ -1,0 +1,49 @@
+---
+tags: [python, typing, generics]
+category: gotcha
+module: registry
+symptoms: ["dict[str, BaseClass] cannot be assigned to dict[str, SubClass]", "Type parameter is invariant", "Consider switching from dict to Mapping"]
+---
+
+# Dict Invariance Causes Type Errors with Class Hierarchies
+
+## Problem
+
+When refactoring a class hierarchy (e.g., splitting `Loader[T]` into `Reader` and `Writer` base classes), type errors appear when passing dicts between functions:
+
+```
+Argument of type "dict[str, BaseOut]" cannot be assigned to parameter of type "dict[str, Out[Any]]"
+  "dict[str, BaseOut]" is not assignable to "dict[str, Out[Any]]"
+    Type parameter "_VT@dict" is invariant, but "BaseOut" is not the same as "Out[Any]"
+```
+
+This happens even though `Out[Any]` is a subclass of `BaseOut`.
+
+## Solution
+
+Two options:
+
+1. **Use `Mapping` for read-only access** (covariant in value type):
+   ```python
+   def process_outputs(specs: Mapping[str, BaseOut]) -> None:
+       for name, spec in specs.items():
+           ...
+   ```
+
+2. **Align types across the interface** - ensure all functions in a call chain use the same specific type:
+   ```python
+   # If worker needs Out[Any] specifically, store Out[Any] not BaseOut
+   out_specs: dict[str, Out[Any]]  # Not dict[str, BaseOut]
+   ```
+
+## Key Insight
+
+Python's `dict` is **invariant** in both key and value types. This means:
+- `dict[str, Child]` is NOT a subtype of `dict[str, Parent]`
+- `dict[str, Parent]` is NOT a subtype of `dict[str, Child]`
+
+This is because dicts are mutable - if you could assign a `dict[str, Child]` to a `dict[str, Parent]` variable, you could then insert a different `Parent` subclass, violating type safety.
+
+`Mapping` is read-only and therefore covariant, allowing the intuitive subtype relationship. Use `Mapping` for function parameters that only read from the dict; use `dict` for return types or when mutation is needed.
+
+When designing class hierarchies with generics, plan the type annotations across the entire call chain upfront to avoid cascading invariance errors during refactoring.

--- a/docs/solutions/2026-01-31-directoryout-type-consistency.md
+++ b/docs/solutions/2026-01-31-directoryout-type-consistency.md
@@ -1,0 +1,49 @@
+---
+tags: [python, generics, type-system, outputs]
+category: design
+module: outputs
+---
+
+# DirectoryOut Generic Type Mismatch
+
+## Problem
+
+`DirectoryOut[T]` had a type inconsistency: it holds a loader that operates on individual `T` values, but the stage actually returns `dict[str, T]`. This meant:
+- The loader field type was `Loader[T]`
+- But the stage return type annotation was `dict[str, T]`
+
+This was a "type lie" where the generic parameter meant different things in different contexts.
+
+## Options Considered
+
+1. **Don't inherit from `Out`** - Simple but duplicates `path`, `cache` fields
+2. **Inherit as `Out[T]`** - Confusing since stage returns `dict[str, T]`, not `T`
+3. **Two-level typing** with `item_loader: Writer[T]` - Awkward with unused inherited `loader`
+4. **Override `loader` with different type** - Violates Liskov Substitution Principle
+5. **Common base class** - Extract shared fields, each subclass defines its own `loader` type
+
+## Solution
+
+Extract a common base class without the `loader` field:
+
+```python
+class BaseOut(Generic[T]):
+    path: PathType
+    cache: bool = True
+
+class Out(BaseOut[T]):
+    loader: Writer[T]
+
+class DirectoryOut(BaseOut[dict[str, T]]):
+    loader: Writer[T]  # T is item type, dict[str, T] is return type
+```
+
+This makes the types explicit:
+- `BaseOut[dict[str, T]]` correctly says "the stage returns `dict[str, T]`"
+- `loader: Writer[T]` correctly says "individual items are serialized as `T`"
+
+## Key Insight
+
+When a generic class has attributes that operate on a *component* of the generic type parameter (like `DirectoryOut` having a loader for items, not the whole dict), the cleaner solution is to use a base class that captures the "outer" type and let the subclass add the "inner" type attribute. This avoids type lies and Liskov violations.
+
+More generally: if you find yourself wanting a subclass attribute to have an incompatible type with the parent, that's a signal the inheritance hierarchy needs restructuring, not a targeted `# type: ignore`.

--- a/docs/solutions/2026-01-31-directoryout-type-lie.md
+++ b/docs/solutions/2026-01-31-directoryout-type-lie.md
@@ -1,0 +1,42 @@
+---
+tags: [python, generics, type-safety, outputs]
+category: gotcha
+module: outputs
+symptoms: ["type mismatch between inheritance and usage", "loader type doesn't match Out generic"]
+---
+
+# DirectoryOut Inheritance Creates Type Lie
+
+## Problem
+
+`DirectoryOut[T]` inherits from `Out[dict[str, T]]`, which implies its `loader` field has type `Loader[dict[str, T]]`. However, the actual implementation uses the loader to serialize individual `T` values, not `dict[str, T]`.
+
+Example demonstrating the inconsistency:
+```python
+# DirectoryOut[TaskMetrics] extends Out[dict[str, TaskMetrics]]
+# So loader should be Loader[dict[str, TaskMetrics]]
+# But YAML() here is Loader[TaskMetrics]:
+DirectoryOut("metrics/task_results/", YAML())
+
+# The code then iterates over the dict and calls loader.save() on each value (T),
+# not on the dict itself (dict[str, T])
+for key, item_value in data.items():
+    write_ops.append((full_path, item_value, spec.loader))
+```
+
+## Solution
+
+When refactoring to Reader/Writer split, `DirectoryOut` cannot simply inherit from `Out`. It needs its own `loader: Writer[T]` field (not `Writer[dict[str, T]]`).
+
+Options:
+1. **Override the loader field** - `DirectoryOut` declares its own `loader: Writer[T]`
+2. **Don't inherit from Out** - Make `DirectoryOut` standalone with similar interface
+3. **Composition over inheritance** - `DirectoryOut` contains behavior, doesn't extend `Out`
+
+## Key Insight
+
+When a generic subclass uses its type parameter differently than the parent (T vs dict[str, T]), the inheritance relationship creates a "type lie" - the static types don't match runtime behavior. This often indicates the inheritance is modeling the wrong relationship.
+
+**The real relationship:** `DirectoryOut` is not an `Out` that happens to produce `dict[str, T]`. It's a different abstraction (a factory for multiple Outs) that shares some surface-level interface.
+
+**General principle:** If a generic subclass transforms the type parameter in its inheritance clause (e.g., `class Child[T](Parent[SomeWrapper[T]])`), verify that all inherited fields still make sense with the transformed type.

--- a/docs/solutions/2026-01-31-isinstance-checks-after-hierarchy-refactor.md
+++ b/docs/solutions/2026-01-31-isinstance-checks-after-hierarchy-refactor.md
@@ -1,0 +1,43 @@
+---
+tags: [python, refactoring, isinstance, type-hierarchy]
+category: gotcha
+module: stage_def, outputs
+symptoms: ["IncrementalOut not recognized", "DirectoryOut not detected", "single output spec returns None"]
+---
+
+# Update isinstance Checks When Splitting Inheritance Hierarchies
+
+## Problem
+
+When refactoring `Loader[T]` into separate `Reader[R]` and `Writer[W]` base classes, `IncrementalOut` and `DirectoryOut` were changed from `Out` subclasses to standalone classes implementing a `BaseOut` protocol.
+
+After the refactor, `get_single_output_spec_from_return()` stopped recognizing `IncrementalOut` and `DirectoryOut` as valid output specs because it only checked:
+
+```python
+if isinstance(metadata, outputs.Out):
+    return metadata
+```
+
+## Solution
+
+Update the isinstance check to include all concrete output types:
+
+```python
+if isinstance(metadata, (outputs.Out, outputs.IncrementalOut, outputs.DirectoryOut)):
+    return metadata
+```
+
+Also update the return type annotation from `Out[Any] | None` to `BaseOut | None` to reflect the broader type.
+
+## Key Insight
+
+When refactoring a class hierarchy (especially when converting subclasses to siblings or protocol implementers), search the entire codebase for `isinstance` checks against the old base class. Each one needs review:
+
+1. **Find all isinstance checks**: `grep -r "isinstance.*OldBaseClass"`
+2. **Evaluate each usage**: Does it need to match the old subclasses that are now siblings?
+3. **Consider alternatives**:
+   - Add all concrete types to the isinstance tuple
+   - Use a Protocol with `@runtime_checkable` and check against that
+   - Use a Union type alias for the concrete types
+
+This is a common gotcha because isinstance checks silently return `False` for the old subclasses - they don't raise errors, they just stop matching.

--- a/docs/solutions/2026-01-31-isinstance-sibling-class-gotcha.md
+++ b/docs/solutions/2026-01-31-isinstance-sibling-class-gotcha.md
@@ -1,0 +1,49 @@
+---
+tags: [python, refactoring, inheritance, isinstance]
+category: gotcha
+module: outputs
+symptoms: ["tests failing after refactoring class hierarchy", "isinstance check silently missing types", "function returns None unexpectedly"]
+---
+
+# isinstance Checks Break When Refactoring Subclass to Sibling
+
+## Problem
+
+When refactoring a class hierarchy from subclass relationships to sibling relationships, existing `isinstance` checks silently fail to match the new sibling classes.
+
+In this case, the Loader hierarchy was refactored from:
+```
+Before: Out <- IncrementalOut, DirectoryOut (subclasses)
+After:  BaseOut <- Out, IncrementalOut, DirectoryOut (siblings)
+```
+
+Code using `isinstance(obj, Out)` to detect any output spec stopped matching `IncrementalOut` and `DirectoryOut` after the refactor. The bug was silent - no exceptions, just incorrect behavior (returning `None` instead of the expected spec).
+
+## Solution
+
+After refactoring to sibling classes with a common base:
+1. Search for all `isinstance` checks against the old parent class
+2. Update to either:
+   - Check against the new common base: `isinstance(obj, BaseOut)`
+   - Check for all siblings: `isinstance(obj, (Out, IncrementalOut, DirectoryOut))`
+3. Run tests to verify - these bugs often only manifest in integration tests
+
+In `get_single_output_spec_from_return`:
+```python
+# Before (broken after refactor)
+if isinstance(metadata, outputs.Out):
+    return cast("outputs.Out[Any]", metadata)
+
+# After (handles all output spec types)
+if isinstance(metadata, outputs.BaseOut):
+    return metadata
+```
+
+## Key Insight
+
+When changing a class hierarchy from inheritance to composition/siblings, `isinstance` checks are silent failure points. Unlike method calls (which raise `AttributeError` if missing), isinstance returns `False` for non-matching types without any indication that it used to match.
+
+Mitigation strategies:
+- Search for `isinstance(*, OldParent)` patterns before refactoring
+- Add explicit tests for each concrete type at API boundaries
+- Consider using structural typing (Protocols) instead of isinstance when the exact hierarchy might change

--- a/docs/solutions/2026-01-31-mro-method-override-detection.md
+++ b/docs/solutions/2026-01-31-mro-method-override-detection.md
@@ -1,0 +1,54 @@
+---
+tags: [python, introspection, fingerprinting]
+category: implementation
+module: fingerprint
+---
+
+# MRO-Based Method Override Detection
+
+## Problem
+
+When fingerprinting loader classes, we need to detect whether a method like `empty()` has been overridden by a subclass. The naive approach using identity comparison doesn't work reliably:
+
+```python
+# Naive approach - fails
+if loader.empty != Loader.empty:  # Identity comparison
+    fingerprint_method(loader.empty)
+```
+
+This fails because method objects are created fresh on each attribute access, so identity comparison is unreliable.
+
+## Solution
+
+Walk the Method Resolution Order (MRO) and check each class's `__dict__` directly:
+
+```python
+def is_method_overridden(instance, method_name: str, base_class: type) -> bool:
+    """Check if method is overridden by any class between instance and base_class."""
+    for cls in type(instance).__mro__:
+        if cls is base_class:
+            return False  # Reached base without finding override
+        if method_name in cls.__dict__:
+            return True  # Found override before reaching base
+    return False
+
+# Usage in fingerprinting:
+if isinstance(loader, Loader):
+    for cls in type(loader).__mro__:
+        if cls is Loader:
+            break
+        if "empty" in cls.__dict__:
+            manifest[f"loader:{name}:empty"] = hash_function_ast(loader.empty)
+            break
+```
+
+## Key Insight
+
+To detect method overrides in Python:
+
+1. **Don't use identity comparison** - Method objects are recreated on access
+2. **Don't use `hasattr`** - It returns True for inherited methods too
+3. **Use `cls.__dict__`** - Only contains methods defined directly on that class
+4. **Walk the MRO** - Check each class in inheritance order until reaching the base
+
+The MRO traversal ensures you detect overrides at any level of the inheritance hierarchy, not just the immediate subclass.

--- a/docs/solutions/2026-01-31-pep696-type-defaults-abc-runtime.md
+++ b/docs/solutions/2026-01-31-pep696-type-defaults-abc-runtime.md
@@ -1,0 +1,50 @@
+---
+tags: [python, typing, generics, abc]
+category: gotcha
+module: loaders
+symptoms: ["TypeError: Some type variables (W) are not listed in Generic[T]", "runtime error with type parameter defaults"]
+---
+
+# PEP 696 Type Parameter Defaults Don't Work with ABC at Runtime
+
+## Problem
+
+When implementing a generic base class with type parameter defaults (PEP 696) that inherits from `abc.ABC`, subclasses using the default fail at runtime:
+
+```python
+@dataclasses.dataclass(frozen=True)
+class Loader[W, R = W](Writer[W], Reader[R], abc.ABC):
+    """W is write type, R is read type. Defaults to symmetric (R = W)."""
+    ...
+
+# This FAILS at runtime:
+class CSV[T](Loader[T]):  # Uses default R = T
+    ...
+
+# Error:
+# TypeError: Some type variables (W) are not listed in Generic[T]
+```
+
+The error occurs because Python's ABC machinery (`abc.ABCMeta.__new__`) processes type variables before the default is applied, seeing `W` and `R` as separate unbound variables.
+
+## Solution
+
+Explicitly provide both type parameters even when they're the same:
+
+```python
+# This WORKS:
+class CSV[T](Loader[T, T]):  # Explicitly symmetric
+    ...
+
+class Text(Loader[str, str]):  # Concrete symmetric
+    ...
+```
+
+## Key Insight
+
+**PEP 696 type parameter defaults are a static typing feature only** - they work for type checkers but not for runtime introspection by metaclasses like `abc.ABCMeta`. When combining generics with ABCs, always explicitly specify all type parameters in subclass definitions, even if the values are redundant.
+
+This affects any pattern where:
+1. A base class uses `class Foo[A, B = A]` with defaults
+2. The base class inherits from `abc.ABC` (directly or indirectly)
+3. Subclasses try to use the default with `class Bar(Foo[X])`

--- a/docs/solutions/2026-01-31-pep696-type-parameter-defaults.md
+++ b/docs/solutions/2026-01-31-pep696-type-parameter-defaults.md
@@ -1,0 +1,60 @@
+---
+tags: [python, generics, typing, python-3.13]
+category: design
+module: loaders
+---
+
+# PEP 696 Type Parameter Defaults for Asymmetric Generics
+
+## Problem
+
+When designing a `Loader` class that can both read and write data, most loaders are symmetric (same type for read and write), but some are asymmetric (e.g., write a matplotlib `Figure`, read back as `np.ndarray`).
+
+The naive approach requires two type parameters for all loaders:
+```python
+class Loader[W, R](Writer[W], Reader[R]): ...
+
+# Every loader needs both params, even symmetric ones:
+class CSV(Loader[DataFrame, DataFrame]): ...  # Verbose
+class JSON(Loader[dict, dict]): ...           # Redundant
+```
+
+This is verbose for the common symmetric case.
+
+## Solution
+
+Use PEP 696 (Python 3.13+) type parameter defaults:
+
+```python
+class Loader[W, R = W](Writer[W], Reader[R]):
+    """Bidirectional loader. R defaults to W for symmetric loaders."""
+    def empty(self) -> R:
+        raise NotImplementedError(f"{type(self).__name__} doesn't support empty()")
+```
+
+Usage becomes clean for both cases:
+
+```python
+# Symmetric - single type param uses default (R = W)
+class CSV(Loader[DataFrame]):
+    def save(self, data: DataFrame, path: Path) -> None: ...
+    def load(self, path: Path) -> DataFrame: ...
+
+# Asymmetric - explicit both types
+class PngImage(Loader[Figure, np.ndarray]):
+    """Write matplotlib Figure, read back as numpy array."""
+    def save(self, data: Figure, path: Path) -> None: ...
+    def load(self, path: Path) -> np.ndarray: ...
+```
+
+## Key Insight
+
+PEP 696 type parameter defaults (`R = W`) provide a clean solution for the "usually the same, sometimes different" pattern in generic types. This avoids:
+
+1. Verbose type aliases (`type SymmetricLoader[T] = Loader[T, T]`)
+2. Runtime type inference hacks
+3. Forcing all users to specify redundant type parameters
+
+The syntax `class Foo[A, B = A]` works in Python 3.13+ and type checkers like basedpyright/pyright support it fully.
+
+**Parameter ordering matters:** Put the "usually defaulted" parameter second. Here, `W` (write type) comes first because the dataflow is save(W) -> file -> load() -> R, and most users think about what they're writing first.

--- a/docs/solutions/2026-01-31-python-list-dict-invariance-with-protocols.md
+++ b/docs/solutions/2026-01-31-python-list-dict-invariance-with-protocols.md
@@ -1,0 +1,72 @@
+---
+tags: [python, typing, protocols, generics]
+category: gotcha
+module: outputs
+symptoms: ["Type parameter '_T@list' is invariant", "list[Subclass] not assignable to list[BaseClass]", "Consider switching from 'list' to 'Sequence'"]
+---
+
+# Python List/Dict Invariance with Protocols
+
+## Problem
+
+When introducing a `BaseOut` Protocol as a common interface for `Out`, `DirectoryOut`, and `IncrementalOut`, type errors appeared at multiple call sites:
+
+```python
+# In RegistryStageInfo TypedDict
+outs: list[Out[Any]]  # Contains Out instances
+
+# In WorkerStageInfo TypedDict
+outs: list[BaseOut]  # Expects BaseOut Protocol
+
+# Error when passing RegistryStageInfo.outs to WorkerStageInfo:
+# "list[Out[Any]]" is not assignable to "list[BaseOut]"
+# Type parameter "_T@list" is invariant
+```
+
+Similarly with dicts:
+```python
+out_specs: dict[str, Out[Any]]  # Source
+out_specs: dict[str, BaseOut]   # Target
+
+# Error: "dict[str, Out[Any]]" is not assignable to "dict[str, BaseOut]"
+# Type parameter "_VT@dict" is invariant
+```
+
+## Root Cause
+
+Python's `list` and `dict` are **invariant** in their type parameters, not covariant. This means even if `Out` satisfies the `BaseOut` Protocol, `list[Out]` is not a subtype of `list[BaseOut]`.
+
+The reason is type safety: a `list[BaseOut]` could have a `DirectoryOut` appended to it, but a `list[Out]` cannot safely accept a `DirectoryOut`.
+
+## Solution
+
+Two approaches work:
+
+### 1. Use Covariant Types (Sequence/Mapping)
+
+For read-only access, use covariant container types:
+```python
+from typing import Sequence, Mapping
+
+outs: Sequence[BaseOut]  # Covariant - accepts list[Out]
+out_specs: Mapping[str, BaseOut]  # Covariant in values
+```
+
+### 2. Unify the Types
+
+If all code paths construct and consume the same concrete types, use a consistent type throughout:
+```python
+# Both TypedDicts use the same type
+outs: list[BaseOut]
+out_specs: dict[str, BaseOut]
+```
+
+This was the chosen solution - changing `RegistryStageInfo` to use `BaseOut` since it can contain any output type (`Out`, `DirectoryOut`, `IncrementalOut`).
+
+## Key Insight
+
+When introducing a base Protocol/ABC for a type hierarchy, audit all container usages. Lists and dicts of the old type won't automatically work where the new base type is expected. Either:
+1. Switch to covariant containers (`Sequence`, `Mapping`) for read-only access
+2. Update all container types to use the base type consistently
+
+The type checker's error message "Consider switching from 'list' to 'Sequence'" is a helpful hint, but unifying the types may be cleaner when mutation is needed.

--- a/docs/solutions/2026-01-31-type-narrowing-with-isinstance.md
+++ b/docs/solutions/2026-01-31-type-narrowing-with-isinstance.md
@@ -1,0 +1,48 @@
+---
+tags: [python, typing, basedpyright, refactoring]
+category: implementation
+module: loaders, stage_def
+symptoms: ["Cannot access attribute for class", "reportAttributeAccessIssue"]
+---
+
+# Type Narrowing with isinstance for Mixed Base Classes
+
+## Problem
+
+During a refactor splitting `Loader[T]` into separate `Reader[R]` and `Writer[W]` base classes, some code paths needed to call methods only available on the full `Loader` class (which implements both reading and writing).
+
+For example, `FuncDepSpec.loader` was typed as `Reader[Any]` because dependencies are read. However, when an `IncrementalOut` is used as an input dependency, it provides a full `Loader` (not just a `Reader`), and the code needs to call `.empty()` which only exists on `Loader`:
+
+```python
+# FuncDepSpec.loader is typed as Reader[Any]
+# But .empty() only exists on Loader
+return spec.loader.empty()  # Type error: Cannot access attribute "empty" for class "Reader[Any]"
+```
+
+## Solution
+
+Use `isinstance` checks to narrow the type from the broader interface to the specific class that has the method:
+
+```python
+if not spec.creates_dep_edge and not full_path.exists():
+    # IncrementalOut as input: file doesn't exist yet (first run)
+    # IncrementalOut provides a full Loader (not just Reader), so narrow the type
+    if isinstance(spec.loader, loaders.Loader):
+        return spec.loader.empty()
+    raise RuntimeError(f"Loader for '{name}' does not support empty() for missing files")
+```
+
+This pattern:
+1. Preserves the broad type in the interface (`Reader[Any]`)
+2. Narrows to the specific type only where the extra capability is needed
+3. Provides a clear error path if the assumption is violated at runtime
+
+## Key Insight
+
+When splitting a broad interface into narrower ones, some code paths legitimately need the full interface. Rather than:
+- Widening the type everywhere (loses type safety)
+- Adding the method to the narrow interface (pollutes the interface)
+
+Use runtime `isinstance` checks to narrow the type locally. This documents the assumption explicitly and fails clearly if violated.
+
+This is especially useful when the type hierarchy has constraints (like dataclass limitations preventing traditional inheritance) that force you to use broader union types in signatures.

--- a/docs/solutions/2026-02-01-ast-function-bodies-need-statement.md
+++ b/docs/solutions/2026-02-01-ast-function-bodies-need-statement.md
@@ -1,0 +1,67 @@
+---
+tags: [python, ast, code-generation]
+category: gotcha
+module: fingerprint
+symptoms: ["SyntaxError when generating code", "invalid AST", "empty function body error"]
+---
+
+# AST Manipulation: Function Bodies Require at Least One Statement
+
+## Problem
+
+When manipulating Python AST for fingerprinting (stripping docstrings, removing decorators, normalizing functions), the resulting function body can become empty. Python's grammar requires function bodies to contain at least one statement:
+
+```python
+def normalize_ast(node: ast.AST) -> ast.AST:
+    """Remove docstrings for stable AST comparison."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        # Check if first statement is a docstring
+        if (node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)):
+            node.body = node.body[1:]  # Remove docstring
+            # BUG: If function was ONLY a docstring, body is now empty!
+```
+
+A docstring-only function:
+
+```python
+def placeholder():
+    """This function intentionally does nothing."""
+```
+
+After stripping the docstring, `node.body` becomes an empty list. When you try to compile or unparse this AST, Python raises an error because function bodies cannot be empty.
+
+## Solution
+
+After any operation that removes statements from a function/class body, check if the body is empty and add `ast.Pass()` as a placeholder:
+
+```python
+def normalize_ast(node: ast.AST) -> ast.AST:
+    """Remove docstrings for stable AST comparison."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if (node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)):
+            node.body = node.body[1:]
+            # Ensure body is never empty (functions must have non-empty body)
+            if not node.body:
+                node.body = [ast.Pass()]
+
+    for child in ast.iter_child_nodes(node):
+        normalize_ast(child)
+
+    return node
+```
+
+This applies to any AST manipulation that removes statements:
+- Stripping docstrings
+- Removing decorator logic
+- Filtering out certain statement types
+- Any transformation that could leave a body empty
+
+## Key Insight
+
+Python's grammar requires all compound statements (`def`, `class`, `if`, `for`, `while`, `try`, `with`) to have non-empty bodies. When manipulating AST, always guard against creating empty bodies by inserting `ast.Pass()` as a syntactically valid no-op placeholder.

--- a/docs/solutions/2026-02-01-atomic-writes-track-fd-closure.md
+++ b/docs/solutions/2026-02-01-atomic-writes-track-fd-closure.md
@@ -1,0 +1,149 @@
+---
+tags: [python, filesystem, atomicity]
+category: gotcha
+module: storage
+symptoms: ["ResourceWarning: unclosed file", "file descriptor leak", "atomic write fails silently"]
+---
+
+# Atomic Writes: Track File Descriptor Closure with `mkstemp()`
+
+## Problem
+
+When implementing atomic writes using the `tempfile.mkstemp()` + rename pattern, the file descriptor returned by `mkstemp()` must be explicitly closed before the rename. Failing to track fd closure leads to resource leaks:
+
+```python
+import os
+import tempfile
+
+def save_atomically(path, data):
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    with os.fdopen(fd, "w") as f:
+        f.write(data)
+    os.rename(tmp_path, path)
+```
+
+This looks correct, but has a subtle bug: if an exception occurs between `mkstemp()` and `os.fdopen()`, the file descriptor leaks. The `os.fdopen()` call takes ownership of the fd and will close it when the file object is garbage collected, but if we never reach that line, the fd remains open.
+
+Additionally, in exception handlers we need to avoid double-closing the fd:
+
+```python
+def save_atomically(path, data):
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+        os.rename(tmp_path, path)
+    except Exception:
+        os.close(fd)  # Bug: fd already closed by os.fdopen()!
+        os.unlink(tmp_path)
+        raise
+```
+
+This double-closes the fd, which can close an unrelated file descriptor that was allocated in the meantime (file descriptors are reused).
+
+## Solution
+
+Track whether the fd has been closed to handle both cases correctly:
+
+```python
+import contextlib
+import os
+import pathlib
+import tempfile
+
+def atomic_write(dest: pathlib.Path, write_fn):
+    """Atomically write using temp file + rename."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dest.parent, suffix=".tmp")
+    tmp = pathlib.Path(tmp_path)
+    fd_closed = False
+    try:
+        write_fn(fd)
+        fd_closed = True  # write_fn took ownership via os.fdopen
+        tmp.replace(dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    finally:
+        # Only close if write_fn didn't (e.g., exception before os.fdopen)
+        if not fd_closed:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+```
+
+For simpler cases where you don't delegate to a callback, use a sentinel value:
+
+```python
+async def download_atomically(url: str, local_path: pathlib.Path) -> None:
+    """Download file atomically."""
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=local_path.parent, prefix=".download_")
+    move_succeeded = False
+    try:
+        await stream_to_fd(url, fd)
+        os.close(fd)
+        fd = -1  # Mark as closed
+        shutil.move(tmp_path, local_path)
+        move_succeeded = True
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if not move_succeeded and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+```
+
+For context manager patterns where `os.fdopen()` is called in a `with` statement:
+
+```python
+@contextlib.contextmanager
+def atomic_write_ctx(output_path: pathlib.Path):
+    """Context manager for atomic file writes."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=output_path.parent, suffix=".tmp")
+    try:
+        yield fd
+        os.rename(tmp_path, output_path)
+    except BaseException:
+        # Close fd if still open (fdopen may not have been called)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+# Usage - os.fdopen takes ownership of fd
+with atomic_write_ctx(output_path) as fd, os.fdopen(fd, "w") as f:
+    yaml.dump(data, f)
+```
+
+For the special case where you just need a temp file path (not writing to fd directly):
+
+```python
+def copy_to_cache(src: pathlib.Path, cache_path: pathlib.Path) -> None:
+    """Atomically copy file to cache."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
+    tmp = pathlib.Path(tmp_path)
+    try:
+        os.close(fd)  # Close immediately - we just needed the unique path
+        shutil.copy2(src, tmp_path)
+        os.chmod(tmp_path, 0o444)
+        tmp.replace(cache_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+```
+
+## Key Insight
+
+`tempfile.mkstemp()` returns both a file descriptor AND a path, and you are responsible for closing the fd. The three ownership patterns are:
+
+| Pattern | Who Closes fd | Tracking Needed |
+|---------|---------------|-----------------|
+| `os.fdopen(fd, ...)` | The file object | Yes - track if fdopen was reached |
+| Direct `os.write(fd, ...)` / `os.close(fd)` | Your code | Yes - track if close was called |
+| Immediate close (need path only) | Your code, immediately | No - close before try block |
+
+The fd is a scarce resource. Each process has a limit (often 1024 by default), and leaked fds accumulate until you hit "Too many open files". The leak is silent until it causes mysterious failures elsewhere in the program.
+
+Always ask: "If an exception occurs at any line, will the fd be closed exactly once?" If the answer is unclear, add explicit tracking.

--- a/docs/solutions/2026-02-01-circular-imports-extract-shared-types.md
+++ b/docs/solutions/2026-02-01-circular-imports-extract-shared-types.md
@@ -1,0 +1,97 @@
+---
+tags: [python, imports, architecture]
+category: design
+module: types
+symptoms: ["ImportError: cannot import name", "circular import detected", "partially initialized module"]
+---
+
+# Circular Imports: Extract Shared Types to a Separate Module
+
+## Problem
+
+When two modules import from each other, Python raises an `ImportError`:
+
+```python
+# module_a.py
+from module_b import SomeType
+
+class ResultA:
+    data: SomeType
+
+# module_b.py
+from module_a import ResultA  # ImportError: cannot import name 'ResultA'
+
+class SomeType:
+    result: ResultA
+```
+
+This commonly happens when:
+1. A registry module imports stage types, and stage modules import from the registry
+2. An executor module imports result types defined alongside the functions that produce them
+3. Two modules have legitimate bidirectional data flow relationships
+
+The error message varies by Python version and import timing:
+- `ImportError: cannot import name 'X' from partially initialized module 'Y'`
+- `AttributeError: module 'Y' has no attribute 'X'`
+
+## Solution
+
+Extract shared type definitions to a dedicated module that has no dependencies on the importing modules:
+
+```python
+# types.py - no imports from module_a or module_b
+class SomeType:
+    result: "ResultA"  # Forward reference as string
+
+class ResultA:
+    data: SomeType
+
+# module_a.py
+from types import ResultA, SomeType
+# ... uses ResultA
+
+# module_b.py
+from types import ResultA, SomeType
+# ... uses SomeType
+```
+
+In Pivot, this is `pivot/types.py`, which contains:
+- TypedDicts (StageResult, LockData, HashInfo, etc.)
+- Enums (StageStatus, OnError, ChangeType, etc.)
+- Type aliases (OutputHash, StageFunc, etc.)
+- TypeGuard functions for type narrowing
+
+The key property: `types.py` imports only from the standard library and typing modules, never from other Pivot modules (except under `TYPE_CHECKING` for type hints only).
+
+```python
+# pivot/types.py
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from pivot.run_history import RunCacheEntry  # Only for type hints
+
+class DeferredWrites(TypedDict):
+    run_cache_entry: "RunCacheEntry"  # String annotation avoids runtime import
+```
+
+## Key Insight
+
+Circular imports are a symptom of tangled dependencies. The fix isn't import tricks (lazy imports, inline imports)—it's restructuring the dependency graph.
+
+The pattern:
+1. **Identify the shared types** that create the cycle
+2. **Extract them to a leaf module** with no internal dependencies
+3. **Both original modules import from the leaf**
+
+This transforms a cycle (`A -> B -> A`) into a tree (`A -> types <- B`).
+
+For type hints that would create import cycles, use `TYPE_CHECKING` blocks:
+```python
+if TYPE_CHECKING:
+    from heavy_module import ExpensiveClass
+
+def process(item: "ExpensiveClass") -> None:  # String annotation
+    ...
+```
+
+The string annotation defers resolution to type-checking time, avoiding runtime import.

--- a/docs/solutions/2026-02-01-cross-process-tests-use-file-state.md
+++ b/docs/solutions/2026-02-01-cross-process-tests-use-file-state.md
@@ -1,0 +1,123 @@
+---
+tags: [python, testing, multiprocessing]
+category: gotcha
+module: tests
+symptoms: ["test assertions fail despite code running", "shared state not updated", "list appears empty in assertions"]
+---
+
+# Cross-Process Tests: Use File-Based State, Not Shared Lists
+
+## Problem
+
+When testing code that runs in worker processes (via `ProcessPoolExecutor`, loky, or similar), you cannot use Python lists or other mutable objects to collect results from workers. Each process gets its own copy of the data structure, so modifications in the worker process are invisible to the test.
+
+```python
+# BROKEN: execution_count will always be 0 in test assertions
+execution_count = [0]
+
+def stage_that_runs_in_worker():
+    execution_count[0] += 1  # Increments a COPY, not the original
+    Path("output.txt").write_text("done")
+
+def test_stage_runs_exactly_once():
+    # Submit to process pool...
+    executor.submit(stage_that_runs_in_worker)
+    future.result()
+
+    assert execution_count[0] == 1  # FAILS: still 0!
+```
+
+This happens because:
+
+1. **Spawn context** (default on macOS, loky's default): Child process starts fresh, imports the module, and gets a new `execution_count = [0]`
+2. **Fork context** (traditional Linux): Child process copies parent's memory, including `execution_count`, but subsequent modifications are copy-on-write
+
+Either way, the parent's list never sees the child's modifications.
+
+## Solution
+
+Use file-based state that persists across process boundaries:
+
+```python
+def stage_that_runs_in_worker(counter_file: Path):
+    count = int(counter_file.read_text()) if counter_file.exists() else 0
+    counter_file.write_text(str(count + 1))
+    Path("output.txt").write_text("done")
+
+def test_stage_runs_exactly_once(tmp_path: Path):
+    counter_file = tmp_path / "counter.txt"
+
+    # Submit to process pool...
+    executor.submit(stage_that_runs_in_worker, counter_file)
+    future.result()
+
+    assert counter_file.read_text() == "1"  # Works!
+```
+
+For more complex state, use appropriate IPC mechanisms:
+
+| State Type | Mechanism |
+|------------|-----------|
+| Simple counter | File with integer |
+| Execution log | File with one line per call |
+| Structured data | JSON file |
+| Real-time communication | `multiprocessing.Manager().Queue()` |
+| Shared primitive values | `multiprocessing.Value()` |
+
+### Pattern: Counter File for Execution Tracking
+
+From `tests/execution/test_executor_worker.py`:
+
+```python
+def test_execute_stage_reruns_when_fingerprint_changes(
+    worker_env: Path, output_queue: mp.Queue[OutputMessage], tmp_path: Path
+) -> None:
+    """Worker reruns stage when code fingerprint changes."""
+    (tmp_path / "input.txt").write_text("data")
+    counter = tmp_path / "counter.txt"
+
+    def stage_func_v1() -> None:
+        count = int(counter.read_text()) if counter.exists() else 0
+        counter.write_text(str(count + 1))
+
+    # First run
+    result1 = executor.execute_stage("test_stage", stage_info_v1, worker_env, output_queue)
+    assert result1["status"] == "ran"
+    assert counter.read_text() == "1"
+
+    # Second run with different fingerprint
+    result2 = executor.execute_stage("test_stage", stage_info_v2, worker_env, output_queue)
+    assert result2["status"] == "ran"
+    assert counter.read_text() == "2"
+```
+
+### When Lists DO Work (Same-Process Calls)
+
+If you're testing worker logic directly without going through the process pool, lists work fine:
+
+```python
+def test_worker_function_directly(tmp_path: Path):
+    """Direct call - no subprocess, so list mutation works."""
+    execution_count = [0]
+
+    def stage_func() -> None:
+        execution_count[0] += 1
+        (tmp_path / "output.txt").write_text(f"output {execution_count[0]}")
+
+    # Direct call - NOT submitted to process pool
+    worker.execute_stage("test_stage", stage_info, worker_env, output_queue)
+
+    assert execution_count[0] == 1  # Works because same process
+```
+
+This pattern appears in `tests/execution/test_execution_modes.py` for tests that call `worker.execute_stage()` directly. These tests verify worker logic without the overhead of inter-process communication. However, if you need to test the full pipeline including process pool submission, you must use file-based state.
+
+## Key Insight
+
+Python multiprocessing creates isolated memory spaces. Any state verification across process boundaries must use:
+
+1. **Filesystem** - files, directories (simplest, most reliable)
+2. **Manager objects** - `Manager().Queue()`, `Manager().dict()` (for real-time IPC)
+3. **Shared memory** - `Value()`, `Array()` (for primitives only)
+
+Never rely on in-memory Python objects to share state between parent and child processes. The test process and worker processes live in separate memory spaces with no automatic synchronization.

--- a/docs/solutions/2026-02-01-engine-is-context-manager.md
+++ b/docs/solutions/2026-02-01-engine-is-context-manager.md
@@ -1,0 +1,107 @@
+---
+tags: [python, context-manager, resource-management]
+category: gotcha
+module: engine
+symptoms: ["output not flushed", "resources not released", "hanging process on exit"]
+---
+
+# Engine is a Context Manager
+
+## Problem
+
+Instantiating `Engine` directly and calling methods on it without using the context manager protocol can leave resources unreleased:
+
+```python
+# Wrong - resources not cleaned up
+engine = Engine(pipeline=pipeline)
+engine.add_sink(ConsoleSink(console))
+engine.add_source(OneShotSource(stages=["train"], force=True, reason="cli"))
+engine.run(exit_on_completion=True)
+# If an exception occurs above, sinks are never closed
+# Even without exception, no guarantee close() runs
+```
+
+Consequences:
+1. **Output not flushed** - ConsoleSink may have buffered output that never reaches the terminal
+2. **TUI termination signal not sent** - TuiSink sends `None` to signal completion; skipping this leaves the TUI hanging
+3. **File handles leaked** - Sinks that write to files may leave them unclosed
+4. **Process hangs on exit** - Background threads or queues may block process termination
+
+## Solution
+
+Always use `Engine` as a context manager with `with` statement:
+
+```python
+from pivot.engine.engine import Engine
+from pivot.engine import sinks, sources
+
+with Engine(pipeline=pipeline) as engine:
+    engine.add_sink(sinks.ConsoleSink(console))
+    engine.add_source(sources.OneShotSource(stages=["train"], force=True, reason="cli"))
+    engine.run(exit_on_completion=True)
+# __exit__ called here, even on exception
+```
+
+The `__exit__` method calls `engine.close()`, which iterates through all registered sinks and closes each one:
+
+```python
+def close(self) -> None:
+    """Close all sinks and clean up resources."""
+    for sink in self._sinks:
+        try:
+            sink.close()
+        except Exception:
+            _logger.exception("Sink %s failed to close", sink)
+```
+
+Exceptions from individual sinks are logged but do not prevent other sinks from being closed.
+
+### Watch Mode
+
+For watch mode (long-running), the pattern is identical:
+
+```python
+with Engine(pipeline=pipeline) as engine:
+    engine.add_sink(sinks.TuiSink(tui_queue, run_id))
+    engine.add_source(sources.FilesystemSource(watch_paths))
+    engine.run(exit_on_completion=False)  # Blocks until shutdown signal
+# Sinks closed on exit, even if interrupted
+```
+
+### Testing
+
+In tests, use the context manager to ensure cleanup between test cases:
+
+```python
+def test_stage_execution(test_pipeline: Pipeline) -> None:
+    with Engine(pipeline=test_pipeline) as engine:
+        collector = sinks.ResultCollectorSink()
+        engine.add_sink(collector)
+        engine.add_source(sources.OneShotSource(stages=None, force=True, reason="test"))
+        engine.run(exit_on_completion=True)
+
+        assert collector.results["my_stage"]["status"] == "ran"
+```
+
+## Key Insight
+
+Context managers guarantee cleanup regardless of how the block exits. Python's `with` statement calls `__exit__` on:
+- Normal completion
+- `return` from within the block
+- Exceptions (caught or uncaught)
+- `sys.exit()` calls
+
+Without the context manager, you must manually call `close()` in a `finally` block, which is error-prone:
+
+```python
+# Manual cleanup is fragile
+engine = Engine(pipeline=pipeline)
+try:
+    engine.add_sink(sink)
+    engine.run(exit_on_completion=True)
+finally:
+    engine.close()  # Easy to forget
+```
+
+The context manager encapsulates this pattern, making correct usage the default.
+

--- a/docs/solutions/2026-02-01-incremental-out-uses-copy-mode.md
+++ b/docs/solutions/2026-02-01-incremental-out-uses-copy-mode.md
@@ -1,0 +1,75 @@
+---
+tags: [python, caching, filesystem, incremental]
+category: design
+module: outputs
+symptoms: ["cache corruption", "unexpected file modifications", "stale data in cache"]
+---
+
+# IncrementalOut Uses COPY Mode for Cache Restoration
+
+## Problem
+
+`IncrementalOut` is designed for outputs that accumulate data across runs. Before each execution, the previous output is restored from cache so the stage can read, modify, and write back. However, if restored via hardlink or symlink:
+
+- **Hardlink corruption**: Modifying the restored file also modifies the cached version (they share the same inode), destroying the historical snapshot
+- **Symlink failure**: Symlinks to read-only cache files can't be written to at all
+
+```python
+# Scenario with hardlink restoration (WRONG):
+# 1. Cache has "database.txt" with hash abc123
+# 2. Restore creates hardlink: database.txt -> cache/ab/c123
+# 3. Stage appends to database.txt
+# 4. PROBLEM: cache/ab/c123 is now corrupted with new data
+# 5. Any stage that skipped and needs to restore abc123 gets wrong content
+```
+
+## Solution
+
+`IncrementalOut` always uses `CheckoutMode.COPY` when restoring from cache:
+
+```python
+def _prepare_outputs_for_execution(
+    stage_outs: Sequence[outputs.BaseOut],
+    lock_data: LockData | None,
+    files_cache_dir: pathlib.Path,
+) -> None:
+    for out in stage_outs:
+        path = pathlib.Path(cast("str", out.path))
+
+        if isinstance(out, outputs.IncrementalOut):
+            cache.remove_output(path)  # Clear stale state
+            out_hash = output_hashes.get(str(out.path))
+            if out_hash:
+                # COPY mode: creates independent writable file
+                restored = cache.restore_from_cache(
+                    path, out_hash, files_cache_dir, cache.CheckoutMode.COPY
+                )
+                if not restored:
+                    raise exceptions.CacheRestoreError(...)
+        else:
+            # Regular Out: just delete before run
+            cache.remove_output(path)
+```
+
+The `CheckoutMode.COPY` ensures:
+1. The restored file is a true copy with its own inode
+2. Modifications don't affect the cached version
+3. The file is writable (mode 0o644 vs cache's 0o444)
+
+## Why Not Hardlink/Symlink for Regular Outputs?
+
+Regular `Out` uses hardlink/symlink because outputs are typically replaced atomically, not modified in place. The save-to-cache flow is:
+
+1. Stage writes new file
+2. Pivot hashes and copies to cache
+3. Pivot replaces original with hardlink/symlink to cache
+
+This is safe because step 1 creates a fresh file (not modifying the linked one).
+
+## Key Insight
+
+Cache integrity depends on immutability: once a file is in cache, its content must never change. Hardlinks and symlinks provide efficient space sharing precisely because they point to the same content. For incremental outputs that need modification, copying is the only safe option. The performance cost of copying is acceptable because:
+
+1. Incremental outputs are typically small (caches, indices, accumulators)
+2. The alternative (cache corruption) has catastrophic consequences
+3. The copy happens once per stage execution, not per file access

--- a/docs/solutions/2026-02-01-lambda-fingerprinting-non-deterministic.md
+++ b/docs/solutions/2026-02-01-lambda-fingerprinting-non-deterministic.md
@@ -1,0 +1,109 @@
+---
+tags: [python, fingerprinting, lambda, caching]
+category: gotcha
+module: fingerprint
+symptoms: ["stages re-run every session", "fingerprint changes without code changes", "cache invalidation on restart"]
+---
+
+# Lambda Fingerprinting Is Non-Deterministic
+
+## Problem
+
+Lambdas defined inline (especially those created via `eval()`, `exec()`, or in interactive sessions) often lack retrievable source code. When `inspect.getsource()` fails, the fingerprinting system falls back to `id(func)`, which is a memory address that changes every interpreter session.
+
+```python
+# This lambda has no recoverable source file
+dynamic_lambda = eval("lambda x: x * 2")
+
+# Fingerprinting falls back to id(func)
+hash1 = fingerprint.hash_function_ast(dynamic_lambda)
+
+# After restart, id() returns different value
+# hash2 != hash1  -- stage re-runs unnecessarily
+```
+
+The fallback path in `fingerprint._compute_function_hash()`:
+
+```python
+try:
+    source = inspect.getsource(func)
+except (OSError, TypeError):
+    if hasattr(func, "__code__"):
+        # Uses marshal.dumps(__code__) - deterministic within same session
+        return xxhash.xxh64(marshal.dumps(func.__code__)).hexdigest()
+    # KNOWN ISSUE: id(func) is non-deterministic across runs
+    return xxhash.xxh64(str(id(func)).encode()).hexdigest()
+```
+
+Even when `__code__` exists (most lambdas have it), the `marshal.dumps(__code__)` approach is only deterministic **within** a session. Across interpreter restarts, the serialized code object may differ due to:
+
+1. Memory layout changes affecting object identity
+2. Code object internals that vary by interpreter session
+3. Different compilation paths for dynamically created code
+
+Lambdas defined in actual source files (like `my_lambda = lambda x: x * 2` in a `.py` file) **do** have source available and fingerprint correctly. The issue affects dynamically created lambdas.
+
+## Solution
+
+Use named module-level functions instead of lambdas in stage definitions:
+
+```python
+from typing import Annotated
+import pandas as pd
+from pivot import Dep, Out
+from pivot.loaders import CSV
+from pivot.pipeline import Pipeline
+
+# GOOD: Named module-level function has stable fingerprint
+def process_data(
+    data: Annotated[pd.DataFrame, Dep("input.csv", CSV())],
+) -> Annotated[pd.DataFrame, Out("output.csv", CSV())]:
+    return data.dropna()
+
+pipeline = Pipeline("my_pipeline")
+pipeline.register(process_data)
+```
+
+**Key requirement:** Stage functions must be module-level named functions, not lambdas or closures. This ensures `inspect.getsource()` can retrieve the source code for deterministic fingerprinting.
+
+For Pydantic model defaults, use named functions for `default_factory`:
+
+```python
+# BAD: Lambda default_factory
+class Params(pydantic.BaseModel):
+    items: list[str] = pydantic.Field(default_factory=lambda: ["a", "b"])
+
+# GOOD: Named function default_factory
+def default_items():
+    return ["a", "b"]
+
+class Params(pydantic.BaseModel):
+    items: list[str] = pydantic.Field(default_factory=default_items)
+```
+
+For callbacks and transformations passed to stages:
+
+```python
+# BAD: Inline lambda in stage parameter
+def train(
+    params: TrainParams,
+    transform: Callable = lambda x: x.lower(),  # Unstable
+):
+    ...
+
+# GOOD: Module-level named function
+def default_transform(x):
+    return x.lower()
+
+def train(
+    params: TrainParams,
+    transform: Callable = default_transform,  # Stable
+):
+    ...
+```
+
+## Key Insight
+
+Python's `inspect.getsource()` needs a filename and line numbers to retrieve source code. Lambdas created dynamically (via `eval`, `exec`, or interactive REPL) don't have this metadata, forcing fingerprinting to fall back to non-deterministic hashing. Named functions defined in source files always have this metadata, making their fingerprints stable across interpreter sessions.
+
+The broader principle: anything that participates in fingerprinting must be defined in a way that makes its source recoverable. This means module-level definitions in `.py` files, not inline constructs in dynamic contexts.

--- a/docs/solutions/2026-02-01-lmdb-extend-with-prefixes.md
+++ b/docs/solutions/2026-02-01-lmdb-extend-with-prefixes.md
@@ -1,0 +1,112 @@
+---
+tags: [python, lmdb, database, architecture]
+category: design
+module: storage
+symptoms: ["state scattered across files", "inconsistent state updates", "complex state management"]
+---
+
+# LMDB for All State: Extend StateDB with Prefixes
+
+## Problem
+
+A build system needs to track multiple types of state: file hashes for change detection, generation counters for outputs, dependency relationships between stages, run history, and run cache entries. The naive approach creates separate storage for each:
+
+```python
+# Scattered state - each concern in a separate file/database
+hash_cache = HashCache("hashes.db")
+generation_db = GenerationDB("generations.db")
+dep_tracker = DependencyTracker("deps.json")
+run_history = RunHistoryDB("runs.db")
+```
+
+This causes problems:
+
+1. **Non-atomic updates** - After a stage runs, you need to update generations, record dependencies, and write run cache. If the process crashes between writes, state becomes inconsistent.
+
+2. **Complex cleanup** - Garbage collection must coordinate across multiple stores to avoid dangling references.
+
+3. **Multiple file handles** - Each database needs its own connection management, increasing resource usage and complexity.
+
+4. **Testing burden** - Tests must mock or manage multiple storage backends.
+
+## Solution
+
+Use a single LMDB database with key prefixes to namespace different data types:
+
+```python
+# Key prefixes for different entry types
+_HASH_PREFIX = b"hash:"      # File hash entries
+_GEN_PREFIX = b"gen:"        # Output generation counters
+_DEP_PREFIX = b"dep:"        # Stage dependency generations
+_REMOTE_PREFIX = b"remote:"  # Remote index entries
+_RUN_PREFIX = b"run:"        # Run history entries
+_RUNCACHE_PREFIX = b"runcache:"  # Run cache for skip detection
+_FP_PREFIX = b"fp:"          # AST fingerprint cache
+```
+
+Each data type gets methods that use the appropriate prefix:
+
+```python
+def _make_key_file_hash(path: pathlib.Path) -> bytes:
+    return _HASH_PREFIX + str(path.resolve()).encode()
+
+def _make_key_output_generation(path: pathlib.Path) -> bytes:
+    return _GEN_PREFIX + os.path.normpath(path.absolute()).encode()
+
+def _make_key_dep_generation(stage_name: str, dep_path: str) -> bytes:
+    return _DEP_PREFIX + f"{stage_name}:{dep_path}".encode()
+```
+
+Atomic multi-type updates happen in a single transaction:
+
+```python
+def apply_deferred_writes(
+    self,
+    stage_name: str,
+    output_paths: list[str],
+    deferred: DeferredWrites,
+) -> None:
+    """Apply all deferred writes in a single atomic transaction."""
+    with self._env.begin(write=True) as txn:
+        # Dependency generations
+        if "dep_generations" in deferred:
+            for dep_path, gen in deferred["dep_generations"].items():
+                key = _make_key_dep_generation(stage_name, dep_path)
+                txn.put(key, struct.pack(">Q", gen))
+
+        # Output generations (increment)
+        for path_str in output_paths:
+            key = _make_key_output_generation(pathlib.Path(path_str))
+            value = txn.get(key)
+            current = struct.unpack(">Q", value)[0] if value else 0
+            txn.put(key, struct.pack(">Q", current + 1))
+
+        # Run cache
+        if "run_cache_input_hash" in deferred:
+            key = _RUNCACHE_PREFIX + f"{stage_name}:{...}".encode()
+            txn.put(key, run_history.serialize_to_bytes(...))
+```
+
+Prefix-scoped iteration enables efficient cleanup and queries:
+
+```python
+def get_dep_generations(self, stage_name: str) -> dict[str, int] | None:
+    """Get all dependency generations for a stage using cursor iteration."""
+    prefix = _DEP_PREFIX + stage_name.encode() + b":"
+    results = dict[str, int]()
+    with self._env.begin() as txn:
+        cursor = txn.cursor()
+        if cursor.set_range(prefix):  # Position at first matching key
+            for key, value in cursor:
+                if not key.startswith(prefix):
+                    break  # Past our prefix range
+                dep_path = key[len(prefix):].decode()
+                results[dep_path] = struct.unpack(">Q", value)[0]
+    return results if results else None
+```
+
+## Key Insight
+
+LMDB's sorted key-value model makes prefix namespacing efficient: `cursor.set_range(prefix)` jumps directly to the first matching key, and iteration stops when keys no longer match the prefix. This gives you the benefits of separate logical databases (isolation, scoped queries) with the benefits of a single physical database (atomic cross-namespace transactions, single file handle, unified backup).
+
+When adding new state types to a system, prefer extending an existing key-value store with a new prefix over creating a new database. The consistency guarantees of atomic transactions across all state types outweigh the apparent cleanliness of separate storage.

--- a/docs/solutions/2026-02-01-loky-cannot-pickle-mp-queue.md
+++ b/docs/solutions/2026-02-01-loky-cannot-pickle-mp-queue.md
@@ -1,0 +1,85 @@
+---
+tags: [python, multiprocessing, loky, pickling]
+category: gotcha
+module: executor
+symptoms: ["PicklingError", "can't pickle Queue", "worker process fails to start"]
+---
+
+# loky Cannot Pickle `mp.Queue()` - Use Manager Queues
+
+## Problem
+
+When using loky's process pool executor, passing a `multiprocessing.Queue()` to worker functions fails with a pickling error:
+
+```python
+import multiprocessing as mp
+from loky import get_reusable_executor
+
+queue = mp.Queue()  # Direct Queue instance
+
+def worker(q):
+    q.put("result")
+
+executor = get_reusable_executor()
+future = executor.submit(worker, queue)  # PicklingError!
+```
+
+The error occurs because `mp.Queue()` contains OS-level resources (file descriptors, semaphores, locks) that cannot be serialized and sent to another process. loky serializes function arguments using cloudpickle/pickle to transfer them to worker processes, and these OS resources have no meaningful serialized representation.
+
+This differs from the standard `concurrent.futures.ProcessPoolExecutor` behavior because loky uses a "spawn" context and serializes everything explicitly, while the standard executor may use "fork" which shares memory.
+
+## Solution
+
+Use `multiprocessing.Manager().Queue()` instead, which creates a proxy object that can be pickled:
+
+```python
+import multiprocessing as mp
+from loky import get_reusable_executor
+
+# Create a Manager (spawns a server process)
+manager = mp.Manager()
+queue = manager.Queue()  # Proxy object - picklable
+
+def worker(q):
+    q.put("result")
+
+executor = get_reusable_executor()
+future = executor.submit(worker, queue)
+future.result()  # Works!
+```
+
+For explicit spawn context (recommended for consistency):
+
+```python
+spawn_ctx = mp.get_context("spawn")
+local_manager = spawn_ctx.Manager()
+output_queue = local_manager.Queue()
+```
+
+The Manager creates a separate server process that owns the actual queue. The `manager.Queue()` returns a proxy object that communicates with this server via IPC. The proxy is just a lightweight handle that can be pickled and sent to workers.
+
+## Key Insight
+
+The fundamental difference:
+
+| Type | What It Is | Picklable? |
+|------|-----------|------------|
+| `mp.Queue()` | Direct queue with OS resources (pipes, locks) | No |
+| `manager.Queue()` | Proxy to queue in Manager server process | Yes |
+
+When designing multiprocessing systems with loky:
+
+1. **Any object passed to workers must be picklable** - this includes queues, events, and shared state
+2. **Manager objects add latency** - IPC to the manager server, but this is usually negligible compared to the work being done
+3. **Manager lifecycle matters** - keep the manager alive as long as workers need the queue
+
+In Pivot, the engine creates a Manager-based queue for collecting output messages from worker processes:
+
+```python
+# From src/pivot/engine/engine.py
+spawn_ctx = mp.get_context("spawn")
+local_manager = spawn_ctx.Manager()
+output_queue: mp.Queue[OutputMessage] = local_manager.Queue()
+```
+
+This allows workers to send log output and status messages back to the coordinator process for display in the TUI.

--- a/docs/solutions/2026-02-01-loky-cpu-count-respects-cgroups.md
+++ b/docs/solutions/2026-02-01-loky-cpu-count-respects-cgroups.md
@@ -1,0 +1,124 @@
+---
+tags: [python, multiprocessing, containers, cgroups]
+category: gotcha
+module: executor
+symptoms: ["OOM in containers", "too many workers spawned", "container CPU throttling"]
+---
+
+# Use loky.cpu_count() for Container-Aware Worker Limits
+
+## Problem
+
+`os.cpu_count()` returns the host machine's CPU count, ignoring container resource limits:
+
+```python
+import os
+
+# On a 64-core host with container limited to 4 CPUs:
+os.cpu_count()  # Returns 64, not 4
+```
+
+This causes multiprocessing code to spawn far more workers than the container can handle:
+
+1. **CPU throttling** - Container exceeds its CPU quota, scheduler throttles all processes
+2. **OOM kills** - Each worker consumes memory; 64 workers on a 4-CPU container exhausts RAM
+3. **Cascading failures** - Throttled workers time out, triggering retries that make it worse
+
+The issue is pervasive in containerized environments (Docker, Kubernetes, CI runners) where cgroups v1/v2 limit CPU shares or cores.
+
+```python
+# Naive approach - spawns too many workers in containers
+from concurrent.futures import ProcessPoolExecutor
+import os
+
+with ProcessPoolExecutor(max_workers=os.cpu_count()) as pool:
+    # On 4-CPU container: spawns 64 workers, gets throttled/killed
+    results = pool.map(heavy_compute, data)
+```
+
+## Solution
+
+Use `loky.cpu_count()` which reads cgroup CPU limits:
+
+```python
+import loky
+
+def compute_max_workers(stage_count: int, override: int | None = None) -> int:
+    """Compute worker count respecting container limits."""
+    cpu_count = loky.cpu_count() or 1  # Container-aware
+    max_workers = override if override is not None else cpu_count
+    return max(1, min(max_workers, stage_count))
+```
+
+loky inspects multiple cgroup interfaces:
+
+1. **cgroups v2** (`/sys/fs/cgroup/cpu.max`) - Modern unified hierarchy
+2. **cgroups v1** (`/sys/fs/cgroup/cpu/cpu.cfs_quota_us`) - Legacy hierarchy
+3. **Fallback** - `os.cpu_count()` when not in a cgroup
+
+This works transparently across:
+- Docker with `--cpus=4` or `--cpu-quota`
+- Kubernetes CPU limits (`resources.limits.cpu`)
+- systemd slices with CPU quotas
+- CI runners (GitHub Actions, GitLab CI) with resource limits
+
+### Verifying Container Limits
+
+To debug CPU limit detection:
+
+```python
+import loky
+import os
+
+print(f"os.cpu_count(): {os.cpu_count()}")
+print(f"loky.cpu_count(): {loky.cpu_count()}")
+
+# Check cgroup directly (Linux)
+try:
+    # cgroups v2
+    with open("/sys/fs/cgroup/cpu.max") as f:
+        quota, period = f.read().strip().split()
+        if quota != "max":
+            print(f"cgroup v2 limit: {int(quota) / int(period)} CPUs")
+except FileNotFoundError:
+    pass
+
+try:
+    # cgroups v1
+    with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as f:
+        quota = int(f.read().strip())
+    with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as f:
+        period = int(f.read().strip())
+    if quota > 0:
+        print(f"cgroup v1 limit: {quota / period} CPUs")
+except FileNotFoundError:
+    pass
+```
+
+### Alternative: joblib
+
+If you're using joblib directly (not through Pivot), it also handles cgroups:
+
+```python
+from joblib import cpu_count
+
+# Returns container-aware count
+workers = cpu_count()
+```
+
+Both loky and joblib use similar detection logic since loky is joblib's process backend.
+
+## Key Insight
+
+Container resource limits are enforced by the kernel, not visible to userspace syscalls like `sysconf(_SC_NPROCESSORS_ONLN)` that `os.cpu_count()` uses. Applications must actively read cgroup interfaces to discover their actual limits.
+
+This is a common source of container misbehavior:
+
+| Environment | `os.cpu_count()` | `loky.cpu_count()` | Workers Spawned |
+|-------------|------------------|---------------------|-----------------|
+| Bare metal (8 cores) | 8 | 8 | 8 (correct) |
+| Docker `--cpus=2` | 8 | 2 | 8 vs 2 |
+| K8s `limits.cpu: 500m` | 64 | 1 | 64 vs 1 |
+| GitHub Actions | 2-4 | 2-4 | Usually correct |
+
+The principle: **never trust `os.cpu_count()` in code that might run in containers**. Use container-aware libraries (loky, joblib) or read cgroups directly.

--- a/docs/solutions/2026-02-01-loky-reusable-executor-warm-workers.md
+++ b/docs/solutions/2026-02-01-loky-reusable-executor-warm-workers.md
@@ -1,0 +1,123 @@
+---
+tags: [python, multiprocessing, loky, performance]
+category: implementation
+module: executor
+symptoms: ["slow stage execution", "worker startup overhead", "process pool recreation"]
+---
+
+# loky Reusable Executor for Warm Worker Pools
+
+## Problem
+
+Creating a new `ProcessPoolExecutor` for each pipeline run incurs significant startup overhead:
+
+1. **Process spawning** - Each new worker requires `fork()` or `spawn()`, which takes 50-200ms per process
+2. **Import time** - Workers must re-import heavy libraries (numpy, pandas, scikit-learn) on every spawn
+3. **Connection setup** - IPC channels between coordinator and workers require handshaking
+
+For iterative development workflows (edit-run-edit-run), this overhead compounds: a 5-worker pool might add 500ms+ to every execution, even for stages that complete in milliseconds.
+
+```python
+# Naive approach - creates new pool every time
+def run_stages():
+    with ProcessPoolExecutor(max_workers=4) as executor:
+        # Pool created here, workers spawn...
+        executor.submit(stage_func)
+        # Pool destroyed here, workers die
+```
+
+## Solution
+
+Use `loky.get_reusable_executor()` which maintains a singleton worker pool across calls:
+
+```python
+import loky
+
+def create_executor(max_workers: int) -> Executor:
+    """Get reusable loky executor - workers persist across calls."""
+    return loky.get_reusable_executor(max_workers=max_workers)
+```
+
+The key behaviors:
+
+1. **First call** - Creates worker pool, spawns processes
+2. **Subsequent calls** - Returns the existing pool if compatible (same `max_workers`)
+3. **Workers stay alive** - Between stage executions, workers idle but remain ready
+4. **Imports cached** - Heavy libraries imported once per worker lifetime, not per stage
+
+### Pre-warming Workers
+
+To ensure workers are ready before the first real task, submit no-op functions:
+
+```python
+def _noop() -> None:
+    """Module-level function for pickling."""
+    pass
+
+def _warm_workers(pool: loky.ProcessPoolExecutor, count: int) -> None:
+    """Submit no-ops to establish worker channels."""
+    futures = [pool.submit(_noop) for _ in range(count)]
+    for f in futures:
+        f.result()
+
+def prepare_workers(stage_count: int, max_workers: int | None = None) -> int:
+    """Pre-warm loky worker pool before TUI startup."""
+    workers = compute_max_workers(stage_count, max_workers)
+    pool = loky.get_reusable_executor(max_workers=workers)
+    _warm_workers(pool, workers)
+    return workers
+```
+
+Pre-warming is important when using a TUI: Textual inherits file descriptors at startup, and loky workers created after TUI initialization can inherit TUI's PTY descriptors, causing display corruption.
+
+### Killing Workers for Code Reload
+
+In watch mode, code changes require fresh workers with updated imports:
+
+```python
+def restart_workers(stage_count: int, max_workers: int | None = None) -> int:
+    """Kill existing workers and spawn fresh ones."""
+    workers = compute_max_workers(stage_count, max_workers)
+    pool = loky.get_reusable_executor(max_workers=workers, kill_workers=True)
+    _warm_workers(pool, workers)
+    return workers
+```
+
+The `kill_workers=True` flag terminates existing workers before creating new ones, ensuring updated code is loaded.
+
+### Cleanup on Exit
+
+Register an atexit handler to prevent orphaned workers:
+
+```python
+import atexit
+import functools
+
+def _cleanup_worker_pool() -> None:
+    """Kill loky worker pool on process exit."""
+    with contextlib.suppress(Exception):
+        loky.get_reusable_executor(max_workers=1, kill_workers=True)
+
+@functools.cache  # Single registration across threads
+def _ensure_cleanup_registered() -> None:
+    atexit.register(_cleanup_worker_pool)
+```
+
+## Key Insight
+
+The standard library's `ProcessPoolExecutor` is designed for batch workloads where pool creation is amortized over many tasks. For iterative workflows with frequent re-runs, the per-run overhead dominates.
+
+`loky.get_reusable_executor()` inverts this by treating the worker pool as long-lived infrastructure rather than per-invocation ephemera:
+
+| Aspect | Standard ProcessPoolExecutor | loky Reusable Executor |
+|--------|------------------------------|------------------------|
+| Pool lifetime | Per `with` block | Process lifetime |
+| Worker spawn | Every run | Once (or on resize/kill) |
+| Import overhead | Every worker spawn | Once per worker lifetime |
+| Idle workers | Terminated | Wait for next task |
+
+The tradeoff is memory: idle workers consume RAM. For pipelines where iteration speed matters more than memory footprint, warm workers provide significant latency reduction.
+
+### Why Not threading?
+
+Python's GIL serializes CPU-bound work in threads. Stages that do NumPy/pandas computation release the GIL and benefit from threads, but pure Python stages (file I/O, string processing) would run sequentially. Process pools provide true parallelism regardless of workload type.

--- a/docs/solutions/2026-02-01-path-overlap-detection-use-trie.md
+++ b/docs/solutions/2026-02-01-path-overlap-detection-use-trie.md
@@ -1,0 +1,77 @@
+---
+tags: [python, paths, data-structures, trie]
+category: implementation
+module: trie
+symptoms: ["false positive path overlaps", "directory vs file path confusion", "incorrect dependency detection"]
+---
+
+# Path Overlap Detection Requires Trie, Not String Matching
+
+## Problem
+
+When detecting overlapping output paths (e.g., one stage outputs a directory `data/` while another outputs a file `data/file.csv`), naive string prefix matching produces incorrect results:
+
+```python
+# Naive approach - WRONG
+def paths_overlap(a: str, b: str) -> bool:
+    return a.startswith(b) or b.startswith(a)
+
+paths_overlap("data/train.csv", "data/")  # True - correct
+paths_overlap("data/train.csv", "data/t")  # True - FALSE POSITIVE!
+```
+
+The problem: `"data/train.csv".startswith("data/t")` is `True`, but `data/t` is not a parent directory of `data/train.csv`. String matching doesn't understand path component boundaries.
+
+Similarly, `data-backup/` would falsely overlap with `data/` because `"data-backup/".startswith("data")` is `True` at the character level.
+
+## Solution
+
+Use pygtrie's `Trie` with path components (from `Path.parts`) as keys. The trie naturally handles component boundaries because each path segment is a separate key element:
+
+```python
+import pathlib
+from pygtrie import Trie
+
+def build_output_trie(outputs: list[tuple[str, str]]) -> Trie[tuple[str, str]]:
+    """Build trie mapping output paths to (stage_name, path) tuples."""
+    trie: Trie[tuple[str, str]] = Trie()
+
+    for stage_name, path in outputs:
+        key = pathlib.Path(path).parts  # ("data", "train.csv")
+
+        # Check for exact duplicate
+        if key in trie:
+            existing_stage, _ = trie[key]
+            raise OutputDuplicationError(f"'{path}' produced by both '{stage_name}' and '{existing_stage}'")
+
+        # Check if new output is parent of existing outputs
+        if trie.has_subtrie(key):
+            child_stage, child_path = next(iter(trie.values(prefix=key)))
+            raise OverlappingOutputPathsError(f"'{path}' overlaps with child '{child_path}'")
+
+        # Check if new output is child of existing output
+        prefix_item = trie.shortest_prefix(key)
+        if prefix_item is not None and prefix_item.value is not None:
+            parent_stage, parent_path = prefix_item.value
+            raise OverlappingOutputPathsError(f"'{path}' overlaps with parent '{parent_path}'")
+
+        trie[key] = (stage_name, path)
+
+    return trie
+```
+
+With path components as keys:
+- `("data", "train.csv")` does NOT have `("data", "t")` as a prefix
+- `("data-backup",)` does NOT have `("data",)` as a prefix
+- `("data", "file.csv")` DOES have `("data",)` as a prefix (correct overlap detection)
+
+## Key Insight
+
+Path relationships are defined by **component boundaries**, not character positions. A trie with `Path.parts` as keys inherently enforces component-level matching because each path segment becomes a distinct node in the trie structure.
+
+The pygtrie library provides efficient O(k) operations where k is the number of path components:
+- `has_subtrie(key)` - check if key is a prefix of any stored path
+- `shortest_prefix(key)` - find if any stored path is a prefix of key
+- Standard dict operations for exact matches
+
+This is used in Pivot's `src/pivot/trie.py` to validate that stage outputs don't overlap (preventing one stage from clobbering another's outputs).

--- a/docs/solutions/2026-02-01-single-underscore-functions-are-tracked.md
+++ b/docs/solutions/2026-02-01-single-underscore-functions-are-tracked.md
@@ -1,0 +1,60 @@
+---
+tags: [python, fingerprinting, naming-conventions]
+category: gotcha
+module: fingerprint
+symptoms: ["unexpected re-runs when private function changes", "confusion about what gets fingerprinted"]
+---
+
+# Single Underscore Functions ARE Tracked in Fingerprints
+
+## Problem
+
+When a private helper function (prefixed with single underscore `_`) changes, stages that call it re-run. This surprises developers who assume "private" means "not tracked."
+
+```python
+def _normalize_data(df: DataFrame) -> DataFrame:
+    """Private helper - changes here WILL trigger re-runs."""
+    return df.dropna()  # Any change here invalidates dependent stages
+
+def train(
+    params: TrainParams,
+    data: Annotated[DataFrame, Dep("input.csv", CSV())],
+) -> Annotated[DataFrame, Out("output.csv", CSV())]:
+    return _normalize_data(data)
+```
+
+Changing `_normalize_data` (even just whitespace outside strings) causes `train` to re-run because the helper's AST is included in `train`'s fingerprint.
+
+## Solution
+
+This is intentional, not a bug. Pivot's fingerprinting correctly tracks single-underscore functions because they affect behavior.
+
+The filtering logic in `fingerprint.py` explicitly only skips **dunders** (double-underscore names like `__name__`, `__init__`):
+
+```python
+# From _process_closure_values()
+if skip_dunders and name.startswith("__"):
+    continue  # Only filters dunders, not single-underscore
+```
+
+Dunders are filtered because:
+- `__name__`, `__doc__`, `__module__` are metadata, not behavior
+- `__init__` on builtins/stdlib types is not user code
+- These are injected by Python, not explicitly referenced in your code
+
+Single-underscore functions (`_helper`, `_normalize`, `_validate`) are tracked because:
+- They contain implementation logic that affects outputs
+- Changing them should invalidate caches (correct behavior)
+- "Private" is a convention for API consumers, not a signal about code impact
+
+**If you don't want a helper tracked**, move it to a separate module that isn't imported by your stage. But this is rarely the right choice - if changing the helper changes your output, you want re-runs.
+
+## Key Insight
+
+Python's underscore prefix conventions have no bearing on fingerprinting. The single underscore (`_func`) is an API hint meaning "internal, don't call directly" - it says nothing about whether code changes matter.
+
+Pivot tracks all user code that could affect stage outputs:
+- Single underscore (`_helper`) = **tracked** (implementation detail that matters)
+- Double underscore dunder (`__name__`) = **not tracked** (Python-injected metadata)
+
+If a function is in your stage's closure and could affect the result, it should be fingerprinted. The naming convention doesn't change that.

--- a/docs/solutions/2026-02-01-stage-functions-must-be-module-level.md
+++ b/docs/solutions/2026-02-01-stage-functions-must-be-module-level.md
@@ -1,0 +1,113 @@
+---
+tags: [python, typing, multiprocessing, pickling]
+category: gotcha
+module: registry
+symptoms: ["NameError in get_type_hints", "cannot pickle local object", "KeyError in type resolution"]
+---
+
+# Stage Functions and TypedDicts Must Be Module-Level
+
+## Problem
+
+Pivot's stage definition system fails when stage functions or their return TypedDicts are defined inside other functions. Two mechanisms break:
+
+**1. Type hint resolution fails:**
+
+```python
+def create_pipeline():
+    class TrainOutputs(TypedDict):
+        model: Annotated[Path, Out("model.pkl", Pickle())]
+
+    def train() -> TrainOutputs:  # NameError when resolving hints
+        ...
+```
+
+`get_type_hints()` resolves forward references by looking up names in `func.__module__`'s namespace. For nested definitions, `TrainOutputs` exists only in the enclosing function's local scope, not the module's global namespace. When Pivot calls `get_type_hints(train)`, it searches `sys.modules[train.__module__].__dict__` and fails to find `TrainOutputs`.
+
+The actual error from `_get_type_hints_safe()` in `stage_def.py`:
+
+```
+Failed to resolve type hints for train: name 'TrainOutputs' is not defined
+```
+
+**2. Multiprocessing pickling fails:**
+
+```python
+def create_pipeline():
+    def train():  # Cannot pickle - not importable
+        return {"model": model_data}
+
+    registry.register("train", train)
+```
+
+loky (Pivot's process pool) serializes functions by reference: `module_name.function_name`. For a nested function, there's no importable path - you can't do `from mymodule import create_pipeline.<locals>.train`. cloudpickle attempts to serialize the bytecode, but this often fails for closures that reference outer-scope variables.
+
+```
+_pickle.PicklingError: Can't pickle <function create_pipeline.<locals>.train>:
+it's not found as mymodule.create_pipeline.<locals>.train
+```
+
+## Solution
+
+Define all stage functions and their return TypedDicts at module level:
+
+```python
+# stages/train.py
+
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot import loaders, outputs
+from pivot.stage_def import StageParams
+
+# TypedDict at module level - resolvable by get_type_hints()
+class TrainOutputs(TypedDict):
+    model: Annotated[Path, outputs.Out("model.pkl", loaders.Pickle())]
+    metrics: Annotated[dict[str, float], outputs.Out("metrics.json", loaders.JSON())]
+
+class TrainParams(StageParams):
+    learning_rate: float = 0.01
+    epochs: int = 100
+
+# Function at module level - picklable by reference
+def train(
+    params: TrainParams,
+    data: Annotated[pd.DataFrame, Dep("data.csv", loaders.CSV())],
+) -> TrainOutputs:
+    model = fit_model(data, params.learning_rate, params.epochs)
+    return TrainOutputs(
+        model=model,
+        metrics={"accuracy": 0.95},
+    )
+```
+
+For test files, the same rule applies:
+
+```python
+# tests/test_stages.py
+
+# Module-level TypedDict for test stage output
+class _TestOutputs(TypedDict):
+    result: Annotated[str, outputs.Out("result.txt", loaders.Text())]
+
+# Module-level test stage function
+def _test_stage() -> _TestOutputs:
+    return _TestOutputs(result="test output")
+
+def test_stage_execution():
+    # Use the module-level definitions in tests
+    manifest = fingerprint.get_stage_fingerprint(_test_stage)
+    assert "result.txt" in str(manifest)
+```
+
+## Key Insight
+
+Python's `get_type_hints()` does name resolution at call time, not definition time. It looks up type names in the function's `__module__` namespace, which for nested definitions doesn't include local class definitions. Similarly, multiprocessing pickles functions by their importable path (`module.name`), which doesn't exist for closures.
+
+The rule is simple: **if Pivot needs to introspect or serialize it, define it at module level**. This includes:
+
+- Stage functions
+- Return TypedDicts
+- Custom loaders
+- StageParams subclasses
+
+Factory functions that dynamically create stages are incompatible with Pivot's architecture. If you need parameterized stages, use `StageParams` with configuration, not factory patterns.

--- a/docs/solutions/2026-02-01-statedb-path-strategies.md
+++ b/docs/solutions/2026-02-01-statedb-path-strategies.md
@@ -1,0 +1,100 @@
+---
+tags: [python, paths, database, caching]
+category: design
+module: storage
+symptoms: ["duplicate cache entries", "generation lookup misses", "symlink path confusion"]
+---
+
+# StateDB Path Strategies: `resolve()` for Hashes, `normpath()` for Generations
+
+## Problem
+
+Pivot's StateDB stores two types of path-keyed data with fundamentally different requirements:
+
+1. **File hash cache** - Maps paths to content hashes for skip detection
+2. **Generation counters** - Tracks how many times each output has been produced
+
+Using the same path resolution strategy for both causes subtle bugs:
+
+```python
+# Project structure after stage execution:
+# output.csv -> .pivot/cache/abc123/output.csv  (symlink to cache)
+
+# If we use resolve() for both:
+path = Path("output.csv")
+path.resolve()  # Returns .pivot/cache/abc123/output.csv
+
+# Hash lookup: CORRECT - deduplicates symlinks pointing to same file
+# Generation lookup: WRONG - key changes every time hash changes!
+```
+
+The generation counter key would change from `gen:output.csv` to `gen:.pivot/cache/abc123/output.csv` after the first run, then to `gen:.pivot/cache/def456/output.csv` after the content changes. Each run creates a "new" output path as far as generation tracking is concerned.
+
+Conversely, using `normpath()` for hash lookups:
+
+```python
+# Two symlinks to same physical file:
+# data/input.csv -> /shared/datasets/sales.csv
+# archive/sales.csv -> /shared/datasets/sales.csv
+
+# If we use normpath() for hash lookups:
+path1 = Path("data/input.csv")      # normpath: data/input.csv
+path2 = Path("archive/sales.csv")   # normpath: archive/sales.csv
+
+# We compute and store the same hash TWICE - wasted work
+```
+
+## Solution
+
+Use different path resolution strategies based on the semantic meaning of the lookup:
+
+```python
+def _make_key_file_hash(path: pathlib.Path) -> bytes:
+    """Create LMDB key for file hash entry (follows symlinks for physical deduplication).
+
+    Uses resolve() to follow symlinks because hash caching is about physical file identity.
+    Multiple symlinks pointing to the same file should share one cached hash.
+    """
+    return _HASH_PREFIX + str(path.resolve()).encode()
+
+
+def _make_key_output_generation(path: pathlib.Path) -> bytes:
+    """Create LMDB key for output generation entry (preserves symlinks for logical path tracking).
+
+    Uses normpath(absolute()), NOT resolve(), because Pivot outputs become symlinks
+    to cache after execution. resolve() would follow these symlinks to cache paths
+    that change per-run. We track the LOGICAL path the user declared.
+    """
+    return _GEN_PREFIX + os.path.normpath(path.absolute()).encode()
+```
+
+The key difference:
+
+| Strategy | Function | Purpose | Example |
+|----------|----------|---------|---------|
+| `resolve()` | File hash lookup | Physical identity dedup | Symlinks to same file share one hash |
+| `normpath(absolute())` | Generation tracking | Logical path identity | `output.csv` stays `output.csv` even when symlinked to cache |
+
+In practice for Pivot:
+
+```python
+# After stage execution, output.csv is a symlink:
+# output.csv -> .pivot/cache/abc123/output.csv
+
+# Hash lookup (resolve):
+hash_key = "hash:/home/user/project/.pivot/cache/abc123/output.csv"
+# Correct! If another file links here, they share the cached hash.
+
+# Generation lookup (normpath):
+gen_key = "gen:/home/user/project/output.csv"
+# Correct! Tracks the declared output path, not where it points.
+```
+
+## Key Insight
+
+Path resolution strategy must match the **semantic meaning** of the operation:
+
+- **Content-addressed lookups** (hashes) care about **physical identity** - use `resolve()` to follow symlinks and deduplicate
+- **Logical path lookups** (generations, dependencies) care about **declared identity** - use `normpath()` to preserve the path as the user/system specified it
+
+This is why Pivot outputs become symlinks to the cache: it allows the same physical content to be reused across runs while maintaining stable logical paths for tracking. The two path strategies work together to make this transparent.

--- a/docs/solutions/2026-02-01-test-helpers-must-be-module-level.md
+++ b/docs/solutions/2026-02-01-test-helpers-must-be-module-level.md
@@ -1,0 +1,84 @@
+---
+tags: [python, testing, fingerprinting, closures]
+category: gotcha
+module: fingerprint
+symptoms: ["fingerprint doesn't detect import changes", "test helper imports not tracked", "stage helper function changes not triggering re-runs"]
+---
+
+# Test Helpers Must Be Module-Level for Fingerprinting
+
+## Problem
+
+When helper functions are defined inline inside test functions, `inspect.getclosurevars()` cannot see their module-level imports. This causes fingerprinting to miss import dependencies, so changes to imported modules don't trigger stage re-runs.
+
+```python
+import math
+
+def test_fingerprint_tracking():
+    # BROKEN: math won't appear in getclosurevars() result
+    def inline_helper():
+        return math.pi * 2
+
+    manifest = fingerprint.get_stage_fingerprint(inline_helper)
+    # manifest won't contain math module - changes to math usage undetected!
+```
+
+The issue stems from how Python closures work. `getclosurevars()` returns:
+- `globals`: Names from the function's `__globals__` that are referenced in the code
+- `nonlocals`: Variables from enclosing scopes captured in `__closure__`
+
+For an inline function, `math` is in the *test function's* globals, not the inline function's direct globals. The inline function's `__globals__` points to the module's global namespace, but `getclosurevars()` only reports names actually referenced by the function's bytecode - and `math` appears to be referenced through the outer scope.
+
+## Solution
+
+Define helper functions at module level with a `_helper_` prefix:
+
+```python
+import math
+
+# Module level - getclosurevars() properly captures math reference
+def _helper_uses_math():
+    return math.pi * 2
+
+def test_fingerprint_tracking():
+    manifest = fingerprint.get_stage_fingerprint(_helper_uses_math)
+    # manifest contains mod:math.pi - changes detected correctly
+```
+
+For test files, follow this pattern:
+
+```python
+# tests/test_my_feature.py
+
+import pandas as pd
+from pivot import fingerprint
+
+# --- Module-level helper functions ---
+# These must be at module level to properly capture imports in closures
+
+def _helper_process_dataframe():
+    """Helper that uses pandas."""
+    return pd.DataFrame({"a": [1, 2, 3]})
+
+def _helper_transform_data(df):
+    """Helper that transforms data."""
+    return df.dropna()
+
+# --- Tests ---
+
+def test_dataframe_processing():
+    manifest = fingerprint.get_stage_fingerprint(_helper_process_dataframe)
+    # pandas usage is now tracked in the fingerprint
+    assert any("pd" in key or "pandas" in key for key in manifest)
+```
+
+## Key Insight
+
+`getclosurevars()` inspects a function's direct references, not transitive ones through enclosing scopes. Inline functions inherit their module's `__globals__` dict, but the closure inspection only captures what the function's bytecode directly references.
+
+For fingerprinting to work correctly:
+1. Helper functions must be defined at module level
+2. Imports they use must also be at module level (no lazy imports inside functions)
+3. Use `_helper_` prefix to distinguish test helpers from actual test functions
+
+This is why Pivot's CLAUDE.md mandates: "Stage functions, output TypedDicts, and custom loaders must be module-level" - the same principle applies to any code that needs accurate fingerprinting.

--- a/docs/solutions/2026-02-01-yaml-library-choice-ruamel-vs-pyyaml.md
+++ b/docs/solutions/2026-02-01-yaml-library-choice-ruamel-vs-pyyaml.md
@@ -1,0 +1,116 @@
+---
+tags: [python, yaml, configuration]
+category: design
+module: config
+symptoms: ["comments lost after config update", "yaml formatting changed unexpectedly"]
+---
+
+# YAML Library Choice: ruamel.yaml vs PyYAML
+
+## Problem
+
+When a CLI tool reads, modifies, and writes a YAML config file, users lose their carefully formatted comments and whitespace:
+
+```yaml
+# User's original config.yaml
+cache:
+  # Use hardlinks for speed on local filesystem
+  checkout_mode: [hardlink, symlink, copy]
+
+  # Override default cache location for this project
+  dir: /fast-storage/cache
+```
+
+After running `pivot config set cache.dir /new/path`:
+
+```yaml
+cache:
+  checkout_mode:
+  - hardlink
+  - symlink
+  - copy
+  dir: /new/path
+```
+
+The comments vanish. Flow-style lists become block-style. Users reasonably expect a config tool to preserve their formatting.
+
+PyYAML (`yaml.safe_load()`) parses YAML into plain Python dicts, discarding comments and formatting metadata. When you dump the dict back, you get PyYAML's default formatting with no memory of the original structure.
+
+## Solution
+
+Use **ruamel.yaml** for files users will edit (config files), and **PyYAML** for read-only parsing (pipeline definitions, lock files, data files):
+
+```python
+# EDITABLE CONFIG - preserve comments and formatting
+import ruamel.yaml
+
+def edit_config(path: Path) -> None:
+    yaml = ruamel.yaml.YAML(typ="rt")  # Round-trip mode
+
+    with path.open() as f:
+        data = yaml.load(f)  # Preserves structure
+
+    data["cache"]["dir"] = "/new/path"
+
+    with path.open("w") as f:
+        yaml.dump(data, f)  # Comments and formatting intact
+```
+
+```python
+# READ-ONLY DATA - simplicity and speed preferred
+import yaml
+from pivot import yaml_config
+
+def load_pipeline(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.load(f, Loader=yaml_config.Loader)
+```
+
+The `yaml_config.Loader` prefers `CSafeLoader` (C extension) for performance, falling back to `SafeLoader` when libyaml is unavailable:
+
+```python
+# src/pivot/yaml_config.py
+try:
+    Loader = yaml.CSafeLoader
+    Dumper = yaml.CSafeDumper
+except AttributeError:
+    Loader = yaml.SafeLoader
+    Dumper = yaml.SafeDumper
+```
+
+### Where Each Library Is Used in Pivot
+
+| Library | Module | Purpose |
+|---------|--------|---------|
+| ruamel.yaml | `config/io.py` | User config (preserves comments) |
+| ruamel.yaml | `dvc_import.py` | Generated pivot.yaml (clean formatting) |
+| PyYAML | `pipeline/yaml.py` | pivot.yaml parsing (read-only) |
+| PyYAML | `storage/lock.py` | Lock file parsing |
+| PyYAML | `loaders.py` | YAML data loader |
+| PyYAML | `parameters.py` | params.yaml files |
+| PyYAML | `show/metrics.py` | Metrics YAML files |
+| PyYAML | CLI modules | Completion, doctor diagnostics |
+
+### Round-Trip Mode Specifics
+
+ruamel.yaml's `typ="rt"` (round-trip) mode preserves:
+
+- Comments (inline and block)
+- Key ordering
+- Flow vs block style (`[a, b]` vs multi-line lists)
+- Blank lines
+- Quote style on strings
+
+```python
+yaml = ruamel.yaml.YAML(typ="rt")
+yaml.default_flow_style = False  # Explicit for new keys
+```
+
+## Key Insight
+
+The choice between YAML libraries depends on the file's lifecycle:
+
+- **User-edited files**: Use ruamel.yaml. Preserving comments respects user investment in documenting their configuration.
+- **Machine-generated/read-only files**: Use PyYAML. Simpler API, faster parsing (with C extension), no need for round-trip overhead.
+
+The performance difference is negligible for typical config file sizes. The user experience difference is significant: losing comments feels like data loss, even though the semantic content is preserved.

--- a/docs/tutorial/parameters.md
+++ b/docs/tutorial/parameters.md
@@ -18,8 +18,10 @@ from typing import Annotated, TypedDict
 
 import pandas
 from pivot import loaders, outputs
-from pivot.registry import REGISTRY
+from pivot.pipeline import Pipeline
 from pivot.stage_def import StageParams
+
+pipeline = Pipeline("my_pipeline")
 
 
 # ... preprocess function stays the same ...
@@ -69,8 +71,8 @@ def train(
 
 
 # Register stages
-REGISTRY.register(preprocess)
-REGISTRY.register(train)
+pipeline.register(preprocess)
+pipeline.register(train)
 ```
 
 Note the changes:

--- a/skills/pivot-stages/SKILL.md
+++ b/skills/pivot-stages/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: pivot-stages
+description: Use when writing Pivot pipeline stages, seeing annotation errors (Dep, Out, Annotated), loader mismatches, "cannot pickle" errors, DirectoryOut validation failures, or IncrementalOut path mismatches
+---
+
+# Writing Pivot Stages
+
+## Overview
+
+Pivot stages are pure Python functions declaring file I/O via type annotations. The framework handles loading, saving, caching, and DAG construction.
+
+**Core principle:** Annotations handle all file I/O. Functions receive pre-loaded data and return data to be saved.
+
+## Imports
+
+```python
+from typing import Annotated, TypedDict
+from pivot.outputs import Dep, Out, Metric, Plot, PlaceholderDep, IncrementalOut, DirectoryOut
+from pivot.loaders import CSV, JSON, JSONL, YAML, Text, Pickle, PathOnly, MatplotlibFigure
+from pivot.stage_def import StageParams
+from pivot.pipeline import Pipeline
+```
+
+## Stage Anatomy
+
+```python
+class MyParams(StageParams):
+    threshold: float = 0.5
+
+class MyOutputs(TypedDict):
+    result: Annotated[pd.DataFrame, Out("output.csv", CSV())]
+    metrics: Annotated[dict, Metric("metrics.json")]
+
+def my_stage(
+    params: MyParams,
+    data: Annotated[pd.DataFrame, Dep("input.csv", CSV())],
+) -> MyOutputs:
+    filtered = data[data["score"] > params.threshold]
+    return {"result": filtered, "metrics": {"count": len(filtered)}}
+
+pipeline = Pipeline("my_pipeline")
+pipeline.register(my_stage, params=MyParams(threshold=0.3))
+```
+
+**Single output:** Annotate return directly instead of TypedDict:
+
+```python
+def transform(
+    data: Annotated[pd.DataFrame, Dep("input.csv", CSV())],
+) -> Annotated[pd.DataFrame, Out("output.csv", CSV())]:
+    return data.dropna()
+```
+
+## Loaders
+
+| Loader | Type | Options | `empty()` |
+|--------|------|---------|-----------|
+| `CSV()` | DataFrame | `index_col`, `sep`, `dtype` | Yes |
+| `JSON()` | dict/list | `indent=2`, `empty_factory=dict` | Yes |
+| `JSONL()` | list[dict] | — | Yes |
+| `YAML()` | dict/list | `empty_factory=dict` | Yes |
+| `Text()` | str | — | Yes |
+| `Pickle()` | Any | `protocol` | No |
+| `PathOnly()` | Path | — | No |
+| `MatplotlibFigure()` | Figure | `dpi=150`, `bbox_inches`, `transparent` | No |
+
+**Loaders with `empty()` support** are required for `IncrementalOut`.
+
+## Output Types
+
+| Type | Default Cache | Git-Tracked | Use Case |
+|------|---------------|-------------|----------|
+| `Out` | True | No | Standard outputs |
+| `Metric` | False | Yes | Small JSON metrics (path must end `.json`) |
+| `Plot` | True | No | Visualizations |
+| `IncrementalOut` | True | No | Builds on previous run's output |
+| `DirectoryOut` | True | No | Dynamic set of files in directory |
+
+## Multi-File Dependencies/Outputs
+
+```python
+# Variable-length list (count can change between runs)
+shards: Annotated[list[pd.DataFrame], Dep(["a.csv", "b.csv"], CSV())]
+
+# Fixed-length tuple (exact count enforced)
+pair: Annotated[tuple[pd.DataFrame, pd.DataFrame], Dep(("x.csv", "y.csv"), CSV())]
+```
+
+## IncrementalOut
+
+Previous output restored from cache before stage runs. Use for append-only state:
+
+```python
+class CacheOutputs(TypedDict):
+    cache: Annotated[dict, IncrementalOut("cache.json", JSON())]
+
+def incremental_stage(
+    cache: Annotated[dict | None, IncrementalOut("cache.json", JSON())],  # Input
+) -> CacheOutputs:
+    existing = cache or {}
+    existing["new_key"] = "value"
+    return {"cache": existing}
+```
+
+**Rules:** Same path in input and output annotations. Loader must support `empty()`.
+
+## DirectoryOut
+
+For dynamic file sets determined at runtime:
+
+```python
+class TaskOutputs(TypedDict):
+    results: Annotated[dict[str, dict], DirectoryOut("results/", JSON())]
+
+def process_tasks(...) -> TaskOutputs:
+    return {"results": {
+        "task_a.json": {"accuracy": 0.95},
+        "task_b.json": {"accuracy": 0.87},
+    }}
+```
+
+**Rules:**
+- Path must end with `/`
+- Keys must have extensions, no path traversal (`../`), no absolute paths
+- Dict must be non-empty
+
+## PlaceholderDep
+
+Dependency with no default path—must be overridden at registration:
+
+```python
+def compare(
+    baseline: Annotated[pd.DataFrame, PlaceholderDep(CSV())],
+) -> CompareOutputs: ...
+
+pipeline.register(compare, dep_path_overrides={"baseline": "model_a/results.csv"})
+```
+
+## Matplotlib Plots
+
+Plots require all three parts in the annotation:
+
+```python
+Annotated[
+    matplotlib.figure.Figure,              # 1. The type (must be Figure, not Axes)
+    Plot("plots/my_plot.png",              # 2. The output type (Plot, not Out)
+         MatplotlibFigure(dpi=150))        # 3. The loader (required, handles save/close)
+]
+```
+
+**Full example:**
+
+```python
+import matplotlib.figure
+import matplotlib.pyplot as plt
+
+class PlotOutputs(TypedDict):
+    plot: Annotated[matplotlib.figure.Figure, Plot("plots/my_plot.png", MatplotlibFigure())]
+
+def make_plot(
+    data: Annotated[pd.DataFrame, Dep("input.csv", CSV())],
+) -> PlotOutputs:
+    fig, ax = plt.subplots()
+    ax.plot(data["x"], data["y"])
+    return {"plot": fig}  # Return Figure, not Axes. Framework saves and closes.
+```
+
+## Path Overrides
+
+```python
+pipeline.register(my_stage, name="my_stage@v2", out_path_overrides={"result": "v2/output.csv"})
+```
+
+## Critical Rules
+
+1. **All paths relative to project root** — not relative to stage file
+2. **No manual file I/O** — no `pd.read_csv()`, `to_csv()`, `open()` in stage body
+3. **File paths in annotations, not params** — `StageParams` for config only
+4. **Stages must be module-level functions** — lambdas/closures fail pickling
+5. **TypedDict outputs must be module-level** — not defined inside functions
+
+## Running Stages
+
+```bash
+pivot repro                  # Run entire pipeline (DAG-aware)
+pivot repro my_stage         # Run my_stage AND all dependencies
+pivot repro --dry-run        # Validate DAG without executing
+
+pivot run my_stage           # Run ONLY my_stage (no dependency resolution)
+```
+
+## Testing
+
+Pass data directly (annotations are bypassed):
+
+```python
+def test_my_stage():
+    result = my_stage(
+        params=MyParams(threshold=0.5),
+        data=pd.DataFrame({"score": [0.3, 0.7, 0.9]}),
+    )
+    assert len(result["result"]) == 2
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `cannot pickle` | Closure/lambda as stage | Move to module-level function |
+| `PlaceholderDep requires override` | Missing path | Add `dep_path_overrides` |
+| `IncrementalOut path mismatch` | Input/output paths differ | Use same path in both annotations |
+| `DirectoryOut path must end with '/'` | Missing trailing slash | Add `/` to path |
+| `DirectoryOut key must have extension` | Key like `"task_a"` | Use `"task_a.json"` |
+| `loader is required` | `Out("file.json")` without loader | Add loader: `Out("file.json", JSON())` |
+| `TypedDict field missing Out annotation` | Field without `Out`/`Metric`/`Plot` | Add annotation to all fields |
+
+## Checklist
+
+- [ ] No manual file I/O in stage function
+- [ ] No file paths in `StageParams`
+- [ ] All Dep/Out paths relative to project root
+- [ ] Stage is module-level function (not closure)
+- [ ] TypedDict outputs defined at module level
+- [ ] Ran `pivot run` and verified outputs exist

--- a/src/pivot/executor/CLAUDE.md
+++ b/src/pivot/executor/CLAUDE.md
@@ -1,0 +1,38 @@
+# Pivot Executor - Development Guidelines
+
+Workers execute in separate processes via `loky.get_reusable_executor()`.
+
+## WorkerStageInfo Contract
+
+`WorkerStageInfo` (TypedDict at `worker.py`) is the coordinator-to-worker contract:
+
+| Field | Purpose |
+|-------|---------|
+| `func` | Stage function (must be picklable) |
+| `fingerprint` | Code manifest for change detection |
+| `deps` | Input dependency paths |
+| `outs` | Output specs (`BaseOut` instances) |
+| `project_root` | Absolute path to project root |
+| `state_dir` | Absolute path to `.pivot/` directory |
+
+## Path Derivation
+
+Workers derive all paths from `project_root` and `state_dir` in `WorkerStageInfo`:
+- `state_db_path = stage_info["state_dir"] / "state.db"`
+- Workers `chdir(project_root)` before execution
+
+Do not assume paths from `cache_dir` location—it's passed separately to `execute_stage()`.
+
+## Nested Parallelism
+
+Stages using joblib/scikit-learn with `n_jobs > 1` create nested multiprocessing, causing `resource_tracker` race conditions between Pivot's loky pool and joblib's nested pool.
+
+**Default:** Threading backend (`parallel_config(backend="threading")`). Safe for NumPy/pandas workloads that release the GIL.
+
+**Override:** Set `PIVOT_NESTED_PARALLELISM=processes` to use loky with memmapping disabled.
+
+## Pickling Requirements
+
+- Stage functions must be **module-level** (not lambdas, closures, or `__main__` definitions)
+- Output TypedDicts and custom loaders must also be module-level
+- See `docs/solutions/` for loky pickling gotchas

--- a/src/pivot/outputs.py
+++ b/src/pivot/outputs.py
@@ -65,7 +65,7 @@ class PlaceholderDep(Generic[T]):  # noqa: UP046 - basedpyright doesn't support 
         ) -> CompareOutputs:
             ...
 
-        REGISTRY.register(
+        pipeline.register(
             compare,
             dep_path_overrides={
                 "baseline": "model_a/results.csv",

--- a/src/pivot/storage/CLAUDE.md
+++ b/src/pivot/storage/CLAUDE.md
@@ -1,0 +1,36 @@
+# Pivot Storage - Development Guidelines
+
+LMDB-backed state database for caching and skip detection.
+
+## Skip Detection Algorithm
+
+Three-tier algorithm for deciding whether to skip stage execution:
+
+1. **O(1) generation tracking** - `worker.can_skip_via_generation()` checks if generation counter matches
+2. **O(n) lock file comparison** - Compare fingerprint + params + dependency hashes
+3. **Run cache lookup** - Check if input hash matches a cached run
+
+## StateDB Key Prefixes
+
+StateDB uses key prefixes for namespacing. Current prefixes in `state_db.py`:
+
+| Prefix | Purpose |
+|--------|---------|
+| `hash:` | Content hashes |
+| `gen:` | Generation counters |
+| `dep:` | Dependency tracking |
+
+**When adding new state types**, define a new prefix constant and document it here.
+
+## LMDB Specifics
+
+- Single writer, multiple readers
+- Transactions are mandatory—use context managers
+- Map size must be set upfront (we use 1GB default)
+- Keys and values are bytes—use consistent encoding
+
+## Path Storage
+
+All paths stored in the database must be **relative** to ensure portability across machines and correct cache behavior.
+
+See `docs/solutions/2026-02-01-statedb-path-strategies.md` for path handling patterns.


### PR DESCRIPTION
## Summary

- Add Claude Code plugin structure so users can install the pivot-stages skill via `claude plugins add https://github.com/sjawhar/pivot`
- Add `pivot-stages` skill for writing Pivot pipeline stages (loaders, annotations, output types)
- Add 25+ solution docs capturing institutional knowledge (loky pickling, typing patterns, LMDB usage, etc.)
- Add module-level CLAUDE.md files for `executor/` and `storage/`
- Update CLI documentation with run/repro command details
- Include reader-writer split brainstorm and plan docs

## Plugin Installation

After merge, users can install the skill with:
```bash
claude plugins add https://github.com/sjawhar/pivot
```

The `pivot:pivot-stages` skill will then be available when writing stages.