### PR TITLE
fix(plugin): add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "pivot",
+  "description": "Skills for writing Pivot pipeline stages",
+  "owner": {
+    "name": "Sami Jawhar",
+    "email": "sami@sjawhar.me"
+  },
+  "plugins": [
+    {
+      "name": "pivot",
+      "description": "Skills for writing Pivot pipeline stages - file I/O annotations, loaders, and output types",
+      "version": "0.1.0",
+      "source": "./"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `marketplace.json` to `.claude-plugin/` directory so the plugin can be discovered when users run:

```bash
claude plugins add https://github.com/sjawhar/pivot
```

The previous PR only had `plugin.json` but the plugin system also needs `marketplace.json` to list available plugins.