### PR TITLE
feat(pipeline): add pipeline-scoped path resolution

### DIFF
--- a/docs/plans/2026-02-02-pipeline-scoped-paths.md
+++ b/docs/plans/2026-02-02-pipeline-scoped-paths.md
@@ -1,0 +1,327 @@
+# Pipeline-Scoped Path Resolution
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow stage annotations to use simple relative paths that resolve relative to the pipeline's root directory, enabling shared stage functions across pipelines without verbose path overrides.
+
+**Architecture:** Paths in annotations are resolved relative to `pipeline.root` at registration time in `Pipeline.register()`, then passed to the registry as overrides. Cross-pipeline references use `../` to traverse up.
+
+**Tech Stack:** Python pathlib, existing `pivot.project` utilities
+
+**Future work:** Cross-pipeline dependency resolution with auto-discovery (#323)
+
+---
+
+## Background
+
+Currently, annotation paths are project-relative:
+```python
+# In eval_pipeline/horizon/pipeline.py
+Dep("eval_pipeline/horizon/data/raw.csv", CSV())  # Full path required
+```
+
+When reusing stages across pipelines, verbose `dep_path_overrides` are needed:
+```python
+# In eval_pipeline/ga_paper/pipeline.py
+pipeline.register(
+    shared_stage,
+    dep_path_overrides={"data": "eval_pipeline/ga_paper/data/raw.csv"},
+)
+```
+
+## Proposed Behavior
+
+Paths resolve relative to the pipeline's root directory (inferred from the directory containing `pipeline.py`):
+
+```python
+# eval_pipeline/horizon/pipeline.py
+pipeline = Pipeline("horizon")  # root inferred from __file__ → eval_pipeline/horizon/
+
+def compute_weights(
+    data: Annotated[DataFrame, Dep("data/raw.csv", CSV())]
+) -> Annotated[DataFrame, Out("data/weights.csv", CSV())]:
+    ...
+
+pipeline.register(compute_weights)
+# Dep → eval_pipeline/horizon/data/raw.csv (project-relative)
+# Out → eval_pipeline/horizon/data/weights.csv (project-relative)
+```
+
+Cross-pipeline references use `../`:
+```python
+# eval_pipeline/ga_paper/pipeline.py
+pipeline = Pipeline("ga_paper")
+
+def analyze(
+    weights: Annotated[DataFrame, Dep("../horizon/data/weights.csv", CSV())],
+) -> ...:
+    ...
+```
+
+Absolute paths are passed through unchanged:
+```python
+Dep("/shared/datasets/common.csv", CSV())  # Absolute: used as-is
+```
+
+Path overrides (`dep_path_overrides`, `out_path_overrides`) are also pipeline-relative:
+```python
+pipeline.register(
+    shared_stage,
+    dep_path_overrides={"data": "custom/input.csv"},  # → eval_pipeline/horizon/custom/input.csv
+)
+```
+
+---
+
+## Implementation
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Resolution location | `Pipeline.register()` | Keeps feature contained; registry/stage_def unchanged |
+| Path validation timing | After normalization | Allows `../` in input; validates resolved project-relative path |
+| Annotation extraction | Reuse existing `get_dep_specs_from_signature()` | Avoids duplicate parsing logic |
+| Windows path support | Yes (`PureWindowsPath`) | Handles paths from Windows tools/configs |
+
+### Critical: Path Validation Order
+
+The existing `path_policy.validate_path_syntax()` rejects `..` traversal. To allow `../` in annotations while still validating the final path:
+
+1. **Input:** `../horizon/data/weights.csv` (pipeline-relative, contains `..`)
+2. **Normalize:** Resolve relative to pipeline root, collapse `..`
+3. **Result:** `eval_pipeline/horizon/data/weights.csv` (project-relative, no `..`)
+4. **Validate:** Run `path_policy` checks on the normalized result
+
+This order allows `../` traversal while ensuring the final path is safe.
+
+---
+
+### Task 1: Extend `project.normalize_path()`
+
+**Files:**
+- Modify: `src/pivot/project.py`
+- Test: `tests/test_project.py`
+
+Add optional `base` parameter and Windows path normalization:
+
+```python
+def normalize_path(path: str | pathlib.Path, base: pathlib.Path | None = None) -> pathlib.Path:
+    """Make path absolute from base (default: project root), preserving symlinks.
+
+    Accepts both Unix (/) and Windows (\\) path separators.
+    """
+    from pathlib import PureWindowsPath
+
+    if base is None:
+        base = get_project_root()
+
+    # Normalize Windows paths to POSIX (handles both \\ and /)
+    p = pathlib.Path(PureWindowsPath(os.fspath(path)).as_posix())
+
+    abs_path = p.absolute() if p.is_absolute() else (base / p).absolute()
+    return pathlib.Path(os.path.normpath(abs_path))
+```
+
+**Tests:**
+- `test_normalize_path_with_custom_base` - relative path resolved from custom base
+- `test_normalize_path_windows_backslash` - `foo\\bar` → `foo/bar`
+- `test_normalize_path_mixed_separators` - `foo\\bar/baz` → `foo/bar/baz`
+- `test_normalize_path_preserves_symlinks` - symlink path kept, not target
+- `test_normalize_path_collapses_dotdot` - `foo/../bar` → `bar`
+
+---
+
+### Task 2: Add path resolution to `Pipeline.register()`
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1:** Add `_resolve_path()` method:
+
+```python
+def _resolve_path(self, annotation_path: str) -> str:
+    """Convert pipeline-relative path to project-relative.
+
+    Validation happens AFTER normalization to allow ../ traversal.
+    """
+    from pivot import project
+    from pivot.config import path_policy
+
+    # Absolute paths: normalize but keep absolute
+    if annotation_path.startswith("/") or annotation_path.startswith("\\"):
+        resolved = project.normalize_path(annotation_path).as_posix()
+    else:
+        # Relative paths: resolve from pipeline root → project-relative
+        abs_path = project.normalize_path(annotation_path, base=self.root)
+        resolved = project.to_relative_path(abs_path)
+
+    # Validate the RESOLVED path (after ../ is collapsed)
+    if error := path_policy.validate_path_syntax(resolved):
+        raise ValueError(f"Invalid path '{annotation_path}': {error}")
+
+    return resolved
+
+
+def _resolve_out_override(self, override: registry.OutOverrideInput) -> registry.OutOverride:
+    """Resolve path in an output override, preserving other options.
+
+    Handles both simple path strings and OutOverride dicts.
+    """
+    if isinstance(override, str | pathlib.Path):
+        return registry.OutOverride(path=self._resolve_path(str(override)))
+
+    # OutOverride dict: resolve path, preserve cache option
+    result = registry.OutOverride(path=self._resolve_path(str(override["path"])))
+    if "cache" in override:
+        result["cache"] = override["cache"]
+    return result
+```
+
+**Step 2:** Update `register()` to resolve paths:
+
+```python
+def register(
+    self,
+    func: StageFunc,
+    *,
+    name: str | None = None,
+    params: registry.ParamsArg = None,
+    mutex: list[str] | None = None,
+    variant: str | None = None,
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+    out_path_overrides: Mapping[str, registry.OutOverrideInput] | None = None,
+) -> None:
+    """Register a stage with this pipeline.
+
+    Paths in annotations and overrides are resolved relative to pipeline root.
+    """
+    from pivot import stage_def
+
+    stage_name = name or func.__name__
+
+    # 1. Extract annotation paths using existing functions
+    dep_specs = stage_def.get_dep_specs_from_signature(func, None)
+
+    # Handle both TypedDict returns and single-output returns
+    out_specs = stage_def.get_output_specs_from_return(func, stage_name)
+    if not out_specs:
+        single_out = stage_def.get_single_output_spec_from_return(func)
+        if single_out is not None:
+            out_specs = {"return": single_out}
+
+    # 2. Resolve ALL annotation paths relative to pipeline root
+    resolved_deps = {name: self._resolve_path(spec.path) for name, spec in dep_specs.items()}
+    resolved_outs = {name: self._resolve_out_override(spec.path) for name, spec in out_specs.items()}
+
+    # 3. Apply explicit overrides (also pipeline-relative)
+    if dep_path_overrides:
+        for dep_name, path in dep_path_overrides.items():
+            resolved_deps[dep_name] = self._resolve_path(str(path))
+    if out_path_overrides:
+        for out_name, override in out_path_overrides.items():
+            resolved_outs[out_name] = self._resolve_out_override(override)
+
+    # 4. Pass all as overrides to registry
+    self._registry.register(
+        func=func,
+        name=name,
+        params=params,
+        mutex=mutex,
+        variant=variant,
+        dep_path_overrides=resolved_deps,
+        out_path_overrides=resolved_outs,
+        state_dir=self.state_dir,
+    )
+```
+
+**Tests:**
+- `test_register_resolves_relative_to_pipeline_root`
+- `test_register_cross_pipeline_dep_with_dotdot`
+- `test_register_absolute_path_unchanged`
+- `test_register_windows_path_normalized`
+- `test_register_overrides_are_pipeline_relative`
+- `test_register_validates_after_normalization` - `../foo` allowed, but escaping project root rejected
+- `test_register_single_output_stage` - non-TypedDict return type resolved correctly
+- `test_register_out_override_with_cache_option` - `OutOverride` dict preserves `cache` flag
+
+---
+
+### Task 3: Integration tests
+
+**Files:**
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Tests:**
+- `test_dag_connects_cross_pipeline_deps` - DAG edges correct when using `../`
+- `test_dag_missing_dep_raises` - validation catches missing deps
+- `test_included_pipeline_paths_resolve_correctly` - `include()` works with scoped paths
+- `test_lockfile_contains_project_relative_paths` - lock files use project-relative
+
+---
+
+### Task 4: Update documentation
+
+**Files:**
+- Modify: `docs/reference/pipelines.md`
+
+Add section on path resolution:
+- Paths relative to pipeline root (inferred from file location, like DVC)
+- Cross-pipeline references with `../`
+- Absolute paths
+- Windows path support
+- Path overrides are also pipeline-relative
+
+---
+
+## Path Storage Summary
+
+| Location | Format |
+|----------|--------|
+| Annotations (source) | Pipeline-relative (`data/raw.csv`) |
+| RegistryStageInfo | Project-relative (`horizon/data/raw.csv`) |
+| Lock files | Project-relative (`horizon/data/raw.csv`) |
+| WorkerStageInfo | Project-relative (derived from `project_root`) |
+| Execution | Absolute (resolved at runtime) |
+
+## Symlink Handling
+
+Symlinks are preserved, not followed (using `os.path.normpath`, not `Path.resolve()`):
+- `horizon/data` → `/mnt/shared/data` (symlink)
+- `Dep("data/file.csv")` stores `horizon/data/file.csv`
+- NOT `/mnt/shared/data/file.csv`
+
+This allows symlinks pointing outside the project root.
+
+**Note:** Existing `path_policy.py` does resolve symlinks for escape validation. The plan's approach (preserve in storage) and existing validation (resolve for security) serve different purposes and are compatible.
+
+## Interaction with `include()`
+
+`Pipeline.include()` deep-copies `RegistryStageInfo` objects from the source pipeline. Since path resolution happens at registration time (before `include()` is called), included stages retain their already-resolved paths.
+
+```python
+# horizon/pipeline.py
+horizon.register(make_weights)  # Dep("data/raw.csv") → horizon/data/raw.csv
+
+# main/pipeline.py
+main.include(horizon)  # Copies stage with paths already resolved
+# make_weights still reads from horizon/data/raw.csv
+```
+
+Cross-pipeline references from stages in the including pipeline use `../` as normal:
+```python
+# main/pipeline.py
+main.register(
+    analyze,  # Dep("../horizon/weights.csv") → horizon/weights.csv
+)
+```
+
+**Future consideration:** Path overrides at include time (see #322).
+
+## Not In Scope
+
+- Cross-pipeline DAG auto-discovery (see #323)
+- `DirectoryOut` cross-pipeline semantics
+- Caching implications (unchanged - paths are project-relative)
+- Path overrides at `include()` time (tracked separately)

--- a/docs/plans/2026-02-03-lazy-pipeline-resolution.md
+++ b/docs/plans/2026-02-03-lazy-pipeline-resolution.md
@@ -1,0 +1,1112 @@
+# Lazy Pipeline Dependency Resolution
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable pipelines to automatically discover and include stages from parent pipelines when dependencies are unresolved locally.
+
+**Architecture:** When `build_dag()` finds an unresolved dependency, traverse up the directory tree looking for `pipeline.py` files, load each parent pipeline, find the stage that produces the needed artifact, and include it (plus transitive dependencies). This is lazy loading - the project DAG is unchanged, we just don't load all of it upfront.
+
+**Tech Stack:** Python 3.13+, networkx, pytest
+
+---
+
+## Task 1: Add Parent Pipeline Discovery Function
+
+**Files:**
+- Create: `src/pivot/pipeline/discovery.py` (new module for pipeline discovery utilities)
+- Test: `tests/pipeline/test_discovery.py`
+
+**Step 1: Write the failing test for directory traversal**
+
+```python
+# tests/pipeline/test_discovery.py
+from __future__ import annotations
+
+import pathlib
+
+from pivot.pipeline import discovery
+
+
+def test_find_parent_pipeline_files_finds_pipeline_in_parent(tmp_path: pathlib.Path) -> None:
+    """Should find pipeline.py in parent directories."""
+    # Create directory structure:
+    # tmp_path/
+    #   pipeline.py
+    #   sub/
+    #     child/
+    #       pipeline.py  <- start here
+    (tmp_path / "pipeline.py").touch()
+    child_dir = tmp_path / "sub" / "child"
+    child_dir.mkdir(parents=True)
+    (child_dir / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_files(child_dir, stop_at=tmp_path))
+
+    # Should find parent's pipeline.py (not child's own)
+    assert result == [tmp_path / "pipeline.py"]
+
+
+def test_find_parent_pipeline_files_stops_at_boundary(tmp_path: pathlib.Path) -> None:
+    """Should stop traversal at specified boundary."""
+    # Create pipeline.py above the stop boundary
+    above_boundary = tmp_path / "above"
+    above_boundary.mkdir()
+    (above_boundary / "pipeline.py").touch()
+
+    project_root = above_boundary / "project"
+    project_root.mkdir()
+    (project_root / "pipeline.py").touch()
+
+    child = project_root / "sub"
+    child.mkdir()
+    (child / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_files(child, stop_at=project_root))
+
+    # Should find project root's pipeline.py but not above
+    assert result == [project_root / "pipeline.py"]
+
+
+def test_find_parent_pipeline_files_returns_multiple_in_order(tmp_path: pathlib.Path) -> None:
+    """Should return all parent pipeline.py files, closest first."""
+    (tmp_path / "pipeline.py").touch()
+    mid = tmp_path / "mid"
+    mid.mkdir()
+    (mid / "pipeline.py").touch()
+    child = mid / "child"
+    child.mkdir()
+    (child / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_files(child, stop_at=tmp_path))
+
+    # Closest parent first
+    assert result == [mid / "pipeline.py", tmp_path / "pipeline.py"]
+
+
+def test_find_parent_pipeline_files_skips_own_directory(tmp_path: pathlib.Path) -> None:
+    """Should not include pipeline.py from the start directory itself."""
+    (tmp_path / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_files(tmp_path, stop_at=tmp_path.parent))
+
+    assert result == []
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py -v`
+Expected: FAIL with "ModuleNotFoundError" or "ImportError"
+
+**Step 3: Write minimal implementation**
+
+```python
+# src/pivot/pipeline/discovery.py
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Iterator
+
+PIPELINE_PY_NAME = "pipeline.py"
+
+
+def find_parent_pipeline_files(
+    start_dir: pathlib.Path,
+    stop_at: pathlib.Path,
+) -> Iterator[pathlib.Path]:
+    """Find pipeline.py files in parent directories.
+
+    Traverses up from start_dir (exclusive) to stop_at (inclusive),
+    yielding each pipeline.py found. Closest parents are yielded first.
+
+    Args:
+        start_dir: Directory to start from (its pipeline.py is NOT included).
+        stop_at: Stop traversal at this directory (inclusive).
+
+    Yields:
+        Paths to pipeline.py files found in parent directories.
+    """
+    current = start_dir.resolve()
+    stop_at = stop_at.resolve()
+
+    # Move to parent (don't include start_dir's own pipeline.py)
+    current = current.parent
+
+    while True:
+        pipeline_file = current / PIPELINE_PY_NAME
+        if pipeline_file.exists():
+            yield pipeline_file
+
+        # Stop if we've reached the boundary
+        if current == stop_at:
+            break
+
+        # Stop if we've reached filesystem root
+        if current.parent == current:
+            break
+
+        current = current.parent
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add find_parent_pipeline_files for lazy resolution"
+```
+
+---
+
+## Task 2: Add Parent Pipeline Loading Function
+
+**Files:**
+- Modify: `src/pivot/pipeline/discovery.py`
+- Test: `tests/pipeline/test_discovery.py`
+
+**Step 1: Write the failing test for loading parent pipeline**
+
+```python
+# Add to tests/pipeline/test_discovery.py
+from pivot.pipeline.pipeline import Pipeline
+
+
+def test_load_parent_pipeline_loads_valid_pipeline(
+    tmp_path: pathlib.Path, mocker
+) -> None:
+    """Should load and return Pipeline from pipeline.py file."""
+    from pivot import project
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Create a pipeline.py with a simple pipeline
+    pipeline_code = '''
+from pivot.pipeline import Pipeline
+
+pipeline = Pipeline("parent")
+'''
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
+
+    assert result is not None
+    assert result.name == "parent"
+
+
+def test_load_parent_pipeline_returns_none_for_no_pipeline_var(
+    tmp_path: pathlib.Path, mocker
+) -> None:
+    """Should return None if pipeline.py doesn't define 'pipeline' variable."""
+    from pivot import project
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Create a pipeline.py without pipeline variable
+    (tmp_path / "pipeline.py").write_text("x = 1\n")
+
+    result = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
+
+    assert result is None
+
+
+def test_load_parent_pipeline_caches_loaded_pipelines(
+    tmp_path: pathlib.Path, mocker
+) -> None:
+    """Should cache loaded pipelines to avoid re-parsing."""
+    from pivot import project
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    pipeline_code = '''
+from pivot.pipeline import Pipeline
+
+pipeline = Pipeline("cached")
+'''
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+
+    # Load twice
+    result1 = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
+    result2 = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
+
+    # Should return same object (cached)
+    assert result1 is result2
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py::test_load_parent_pipeline_loads_valid_pipeline -v`
+Expected: FAIL with "AttributeError" (function doesn't exist)
+
+**Step 3: Write minimal implementation**
+
+```python
+# Add to src/pivot/pipeline/discovery.py
+import runpy
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pivot.pipeline.pipeline import Pipeline
+
+# Cache for loaded parent pipelines (path -> Pipeline)
+_parent_pipeline_cache: dict[pathlib.Path, Pipeline | None] = {}
+
+
+def load_parent_pipeline(pipeline_path: pathlib.Path) -> Pipeline | None:
+    """Load a Pipeline from a pipeline.py file.
+
+    Results are cached to avoid re-parsing the same file multiple times.
+
+    Args:
+        pipeline_path: Path to pipeline.py file.
+
+    Returns:
+        Pipeline instance if file defines 'pipeline' variable, None otherwise.
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    resolved = pipeline_path.resolve()
+    if resolved in _parent_pipeline_cache:
+        return _parent_pipeline_cache[resolved]
+
+    try:
+        module_dict = runpy.run_path(str(resolved), run_name="_pivot_parent_pipeline")
+    except Exception:
+        _parent_pipeline_cache[resolved] = None
+        return None
+
+    pipeline = module_dict.get("pipeline")
+    if pipeline is not None and isinstance(pipeline, Pipeline):
+        _parent_pipeline_cache[resolved] = pipeline
+        return pipeline
+
+    _parent_pipeline_cache[resolved] = None
+    return None
+
+
+def clear_parent_pipeline_cache() -> None:
+    """Clear the parent pipeline cache (for testing)."""
+    _parent_pipeline_cache.clear()
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py::test_load_parent_pipeline_loads_valid_pipeline tests/pipeline/test_discovery.py::test_load_parent_pipeline_returns_none_for_no_pipeline_var tests/pipeline/test_discovery.py::test_load_parent_pipeline_caches_loaded_pipelines -v`
+Expected: PASS
+
+**Step 5: Add fixture to clear cache between tests**
+
+```python
+# Add to tests/pipeline/test_discovery.py at top
+import pytest
+
+@pytest.fixture(autouse=True)
+def clear_discovery_cache() -> None:
+    """Clear parent pipeline cache before each test."""
+    discovery.clear_parent_pipeline_cache()
+```
+
+**Step 6: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add load_parent_pipeline with caching"
+```
+
+---
+
+## Task 3: Add Producer Search in Parent Pipeline
+
+**Files:**
+- Modify: `src/pivot/pipeline/discovery.py`
+- Test: `tests/pipeline/test_discovery.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/pipeline/test_discovery.py
+from typing import Annotated
+from pathlib import Path
+
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+
+def test_find_producer_in_pipeline_finds_matching_stage(
+    tmp_path: pathlib.Path, mocker
+) -> None:
+    """Should find stage that produces the requested path."""
+    from pivot import project
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Create pipeline with a stage that produces output.txt
+    pipeline = Pipeline("test", root=tmp_path)
+
+    class Output(TypedDict):
+        data: Annotated[Path, Out("output.txt", loaders.PathOnly())]
+
+    def producer() -> Output:
+        return Output(data=Path("output.txt"))
+
+    pipeline.register(producer)
+
+    # Search for the producer of output.txt (absolute path)
+    abs_path = str(tmp_path / "output.txt")
+    result = discovery.find_producer_in_pipeline(pipeline, abs_path)
+
+    assert result == "producer"
+
+
+def test_find_producer_in_pipeline_returns_none_if_not_found(
+    tmp_path: pathlib.Path, mocker
+) -> None:
+    """Should return None if no stage produces the path."""
+    from pivot import project
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    pipeline = Pipeline("test", root=tmp_path)
+
+    result = discovery.find_producer_in_pipeline(pipeline, "/nonexistent/path.txt")
+
+    assert result is None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_finds_matching_stage -v`
+Expected: FAIL with "AttributeError"
+
+**Step 3: Write minimal implementation**
+
+```python
+# Add to src/pivot/pipeline/discovery.py
+def find_producer_in_pipeline(pipeline: Pipeline, dep_path: str) -> str | None:
+    """Find stage in pipeline that produces the given path.
+
+    Args:
+        pipeline: Pipeline to search.
+        dep_path: Absolute path to look for as an output.
+
+    Returns:
+        Stage name if found, None otherwise.
+    """
+    for stage_name in pipeline.list_stages():
+        stage_info = pipeline.get(stage_name)
+        if dep_path in stage_info["outs_paths"]:
+            return stage_name
+    return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_finds_matching_stage tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_returns_none_if_not_found -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add find_producer_in_pipeline"
+```
+
+---
+
+## Task 4: Add resolve_from_parents Method to Pipeline
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/pipeline/test_pipeline.py
+from typing import Annotated, TypedDict
+from pathlib import Path
+
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+
+def test_pipeline_resolve_from_parents_includes_producer(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should include producer stage from parent pipeline when dependency unresolved."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Parent pipeline at project root
+    parent = Pipeline("parent", root=tmp_path)
+
+    class ProducerOutput(TypedDict):
+        data: Annotated[Path, Out("shared/data.txt", loaders.PathOnly())]
+
+    def producer() -> ProducerOutput:
+        Path("shared/data.txt").write_text("data")
+        return ProducerOutput(data=Path("shared/data.txt"))
+
+    parent.register(producer)
+
+    # Save parent pipeline to file
+    parent_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("parent")
+
+class ProducerOutput(TypedDict):
+    data: Annotated[Path, Out("shared/data.txt", loaders.PathOnly())]
+
+def producer() -> ProducerOutput:
+    Path("shared/data.txt").write_text("data")
+    return ProducerOutput(data=Path("shared/data.txt"))
+
+pipeline.register(producer)
+'''
+    (tmp_path / "pipeline.py").write_text(parent_code)
+
+    # Child pipeline in subdirectory
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    child = Pipeline("child", root=child_dir)
+
+    class ConsumerOutput(TypedDict):
+        result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
+
+    def consumer(
+        data: Annotated[Path, Dep("shared/data.txt", loaders.PathOnly())]
+    ) -> ConsumerOutput:
+        return ConsumerOutput(result=Path("result.txt"))
+
+    child.register(consumer)
+
+    # Resolve should find producer in parent
+    child.resolve_from_parents()
+
+    assert "producer" in child.list_stages()
+    assert "consumer" in child.list_stages()
+
+
+def test_pipeline_resolve_from_parents_includes_transitive_deps(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should include transitive dependencies from parent pipeline."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Parent pipeline with chain: stage_a -> stage_b
+    parent_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+pipeline = Pipeline("parent")
+
+class StageAOutput(TypedDict):
+    a: Annotated[Path, Out("a.txt", loaders.PathOnly())]
+
+def stage_a() -> StageAOutput:
+    return StageAOutput(a=Path("a.txt"))
+
+class StageBOutput(TypedDict):
+    b: Annotated[Path, Out("b.txt", loaders.PathOnly())]
+
+def stage_b(a: Annotated[Path, Dep("a.txt", loaders.PathOnly())]) -> StageBOutput:
+    return StageBOutput(b=Path("b.txt"))
+
+pipeline.register(stage_a)
+pipeline.register(stage_b)
+'''
+    (tmp_path / "pipeline.py").write_text(parent_code)
+
+    # Child depends on b.txt (which depends on a.txt)
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    child = Pipeline("child", root=child_dir)
+
+    class ConsumerOutput(TypedDict):
+        c: Annotated[Path, Out("c.txt", loaders.PathOnly())]
+
+    def consumer(
+        b: Annotated[Path, Dep("b.txt", loaders.PathOnly())]
+    ) -> ConsumerOutput:
+        return ConsumerOutput(c=Path("c.txt"))
+
+    child.register(consumer)
+
+    child.resolve_from_parents()
+
+    # Should include both stage_a and stage_b
+    assert "stage_a" in child.list_stages()
+    assert "stage_b" in child.list_stages()
+    assert "consumer" in child.list_stages()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer -v`
+Expected: FAIL with "AttributeError: 'Pipeline' object has no attribute 'resolve_from_parents'"
+
+**Step 3: Write minimal implementation**
+
+```python
+# Add to src/pivot/pipeline/pipeline.py
+
+# Add import at top
+from pivot.pipeline import discovery as pipeline_discovery
+
+# Add method to Pipeline class
+def resolve_from_parents(self) -> None:
+    """Resolve unresolved dependencies by searching parent pipelines.
+
+    For each dependency that has no local producer:
+    1. Traverse up directory tree looking for pipeline.py files
+    2. Load each parent pipeline and search for a stage producing the dependency
+    3. Include that stage (and recursively resolve its dependencies)
+
+    Dependencies that exist on disk or have no producer anywhere are left as-is
+    (treated as external inputs).
+
+    Raises:
+        PipelineConfigError: If multiple parent pipelines produce the same artifact.
+    """
+    project_root = project.get_project_root()
+
+    # Build local outputs map
+    local_outputs = set[str]()
+    for stage_name in self.list_stages():
+        stage_info = self.get(stage_name)
+        local_outputs.update(stage_info["outs_paths"])
+
+    # Find unresolved dependencies
+    unresolved = set[str]()
+    for stage_name in self.list_stages():
+        stage_info = self.get(stage_name)
+        for dep_path in stage_info["deps_paths"]:
+            if dep_path not in local_outputs:
+                unresolved.add(dep_path)
+
+    # Resolve from parents
+    self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
+
+
+def _resolve_deps_from_parents(
+    self,
+    unresolved: set[str],
+    local_outputs: set[str],
+    project_root: pathlib.Path,
+) -> None:
+    """Recursively resolve dependencies from parent pipelines."""
+    if not unresolved:
+        return
+
+    # Find parent pipeline files
+    parent_files = list(pipeline_discovery.find_parent_pipeline_files(self.root, project_root))
+    if not parent_files:
+        return  # No parents to search
+
+    newly_included = list[str]()
+
+    for dep_path in list(unresolved):
+        # Skip if file exists on disk (external input)
+        if pathlib.Path(dep_path).exists():
+            unresolved.discard(dep_path)
+            continue
+
+        # Search parent pipelines for producer
+        for parent_file in parent_files:
+            parent = pipeline_discovery.load_parent_pipeline(parent_file)
+            if parent is None:
+                continue
+
+            producer_name = pipeline_discovery.find_producer_in_pipeline(parent, dep_path)
+            if producer_name is None:
+                continue
+
+            # Check for duplicate producer (error condition)
+            if producer_name in self._registry.list_stages():
+                # Already included, dependency resolved
+                unresolved.discard(dep_path)
+                break
+
+            # Include the producer stage
+            import copy
+            stage_info = copy.deepcopy(parent.get(producer_name))
+            self._registry.add_existing(stage_info)
+            newly_included.append(producer_name)
+            local_outputs.update(stage_info["outs_paths"])
+            unresolved.discard(dep_path)
+
+            # Add producer's dependencies to unresolved
+            for producer_dep in stage_info["deps_paths"]:
+                if producer_dep not in local_outputs:
+                    unresolved.add(producer_dep)
+
+            logger.debug(f"Included stage '{producer_name}' from parent pipeline '{parent.name}'")
+            break
+
+    # Recurse if we added stages with new dependencies
+    if newly_included and unresolved:
+        self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_transitive_deps -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): add resolve_from_parents for lazy dependency resolution"
+```
+
+---
+
+## Task 5: Integrate resolve_from_parents into build_dag
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/pipeline/test_pipeline.py
+def test_pipeline_build_dag_auto_resolves_from_parents(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """build_dag should automatically resolve dependencies from parents."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # Parent pipeline
+    parent_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("parent")
+
+class ProducerOutput(TypedDict):
+    data: Annotated[Path, Out("data.txt", loaders.PathOnly())]
+
+def producer() -> ProducerOutput:
+    return ProducerOutput(data=Path("data.txt"))
+
+pipeline.register(producer)
+'''
+    (tmp_path / "pipeline.py").write_text(parent_code)
+
+    # Child pipeline
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    child = Pipeline("child", root=child_dir)
+
+    class ConsumerOutput(TypedDict):
+        result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
+
+    def consumer(
+        data: Annotated[Path, Dep("data.txt", loaders.PathOnly())]
+    ) -> ConsumerOutput:
+        return ConsumerOutput(result=Path("result.txt"))
+
+    child.register(consumer)
+
+    # build_dag should auto-resolve
+    dag = child.build_dag(validate=True)
+
+    assert "producer" in dag.nodes
+    assert "consumer" in dag.nodes
+    assert dag.has_edge("consumer", "producer")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_build_dag_auto_resolves_from_parents -v`
+Expected: FAIL with "DependencyNotFoundError" (producer not included)
+
+**Step 3: Modify build_dag to call resolve_from_parents**
+
+```python
+# Modify build_dag in src/pivot/pipeline/pipeline.py
+def build_dag(self, validate: bool = True) -> DiGraph[str]:
+    """Build DAG from registered stages.
+
+    Automatically resolves unresolved dependencies by searching parent
+    pipelines (lazy dependency resolution).
+
+    Args:
+        validate: If True, validate that all dependencies exist
+
+    Returns:
+        NetworkX DiGraph with stages as nodes and dependencies as edges
+
+    Raises:
+        CyclicGraphError: If graph contains cycles
+        DependencyNotFoundError: If dependency doesn't exist (when validate=True)
+    """
+    # Auto-resolve from parents before building DAG
+    self.resolve_from_parents()
+    return self._registry.build_dag(validate=validate)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_build_dag_auto_resolves_from_parents -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): auto-resolve from parents in build_dag"
+```
+
+---
+
+## Task 6: Add Error for Multiple Producers
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Modify: `src/pivot/pipeline/yaml.py` (add new exception)
+- Test: `tests/pipeline/test_pipeline.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/pipeline/test_pipeline.py
+def test_pipeline_resolve_from_parents_errors_on_multiple_producers(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should error if multiple parent pipelines produce the same artifact."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    # First parent at project root
+    parent1_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("parent1")
+
+class Output(TypedDict):
+    data: Annotated[Path, Out("shared.txt", loaders.PathOnly())]
+
+def producer1() -> Output:
+    return Output(data=Path("shared.txt"))
+
+pipeline.register(producer1)
+'''
+    (tmp_path / "pipeline.py").write_text(parent1_code)
+
+    # Second parent at mid level
+    mid_dir = tmp_path / "mid"
+    mid_dir.mkdir()
+    parent2_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("parent2")
+
+class Output(TypedDict):
+    data: Annotated[Path, Out("shared.txt", loaders.PathOnly())]
+
+def producer2() -> Output:
+    return Output(data=Path("shared.txt"))
+
+pipeline.register(producer2)
+'''
+    (mid_dir / "pipeline.py").write_text(parent2_code)
+
+    # Child pipeline
+    child_dir = mid_dir / "child"
+    child_dir.mkdir()
+    child = Pipeline("child", root=child_dir)
+
+    class ConsumerOutput(TypedDict):
+        result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
+
+    def consumer(
+        data: Annotated[Path, Dep("shared.txt", loaders.PathOnly())]
+    ) -> ConsumerOutput:
+        return ConsumerOutput(result=Path("result.txt"))
+
+    child.register(consumer)
+
+    from pivot.pipeline.yaml import PipelineConfigError
+
+    with pytest.raises(PipelineConfigError, match="Multiple parent pipelines produce"):
+        child.resolve_from_parents()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_errors_on_multiple_producers -v`
+Expected: FAIL (no error raised, or wrong error)
+
+**Step 3: Update implementation to detect multiple producers**
+
+```python
+# Update _resolve_deps_from_parents in src/pivot/pipeline/pipeline.py
+def _resolve_deps_from_parents(
+    self,
+    unresolved: set[str],
+    local_outputs: set[str],
+    project_root: pathlib.Path,
+) -> None:
+    """Recursively resolve dependencies from parent pipelines."""
+    if not unresolved:
+        return
+
+    parent_files = list(pipeline_discovery.find_parent_pipeline_files(self.root, project_root))
+    if not parent_files:
+        return
+
+    newly_included = list[str]()
+
+    for dep_path in list(unresolved):
+        if pathlib.Path(dep_path).exists():
+            unresolved.discard(dep_path)
+            continue
+
+        # Find all producers across all parents
+        producers_found: list[tuple[str, Pipeline]] = []
+        for parent_file in parent_files:
+            parent = pipeline_discovery.load_parent_pipeline(parent_file)
+            if parent is None:
+                continue
+
+            producer_name = pipeline_discovery.find_producer_in_pipeline(parent, dep_path)
+            if producer_name is not None:
+                producers_found.append((producer_name, parent))
+
+        # Error if multiple producers
+        if len(producers_found) > 1:
+            producer_names = [f"'{name}' in '{p.name}'" for name, p in producers_found]
+            raise PipelineConfigError(
+                f"Multiple parent pipelines produce '{dep_path}': {', '.join(producer_names)}. "
+                f"This indicates a malformed project DAG."
+            )
+
+        if not producers_found:
+            continue  # No producer found, leave as external input
+
+        producer_name, parent = producers_found[0]
+
+        if producer_name in self._registry.list_stages():
+            unresolved.discard(dep_path)
+            continue
+
+        import copy
+        stage_info = copy.deepcopy(parent.get(producer_name))
+        self._registry.add_existing(stage_info)
+        newly_included.append(producer_name)
+        local_outputs.update(stage_info["outs_paths"])
+        unresolved.discard(dep_path)
+
+        for producer_dep in stage_info["deps_paths"]:
+            if producer_dep not in local_outputs:
+                unresolved.add(producer_dep)
+
+        logger.debug(f"Included stage '{producer_name}' from parent pipeline '{parent.name}'")
+
+    if newly_included and unresolved:
+        self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_errors_on_multiple_producers -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(pipeline): error on multiple producers in lazy resolution"
+```
+
+---
+
+## Task 7: Add Integration Test with Real Execution
+
+**Files:**
+- Test: `tests/integration/test_lazy_resolution.py`
+
+**Step 1: Write integration test**
+
+```python
+# tests/integration/test_lazy_resolution.py
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from pivot.cli import cli
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def lazy_resolution_project(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a project with parent/child pipeline structure."""
+    # Initialize git repo
+    (tmp_path / ".git").mkdir()
+
+    # Parent pipeline at root
+    parent_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("parent")
+
+class ProducerOutput(TypedDict):
+    data: Annotated[Path, Out("data/output.txt", loaders.PathOnly())]
+
+def producer() -> ProducerOutput:
+    Path("data").mkdir(exist_ok=True)
+    Path("data/output.txt").write_text("produced data")
+    return ProducerOutput(data=Path("data/output.txt"))
+
+pipeline.register(producer)
+'''
+    (tmp_path / "pipeline.py").write_text(parent_code)
+
+    # Child pipeline in subdirectory
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    child_code = '''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+pipeline = Pipeline("child")
+
+class ConsumerOutput(TypedDict):
+    result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
+
+def consumer(
+    data: Annotated[Path, Dep("data/output.txt", loaders.PathOnly())]
+) -> ConsumerOutput:
+    content = data.read_text()
+    Path("result.txt").write_text(f"consumed: {content}")
+    return ConsumerOutput(result=Path("result.txt"))
+
+pipeline.register(consumer)
+'''
+    (child_dir / "pipeline.py").write_text(child_code)
+
+    return tmp_path
+
+
+def test_lazy_resolution_repro_from_child(
+    lazy_resolution_project: pathlib.Path,
+) -> None:
+    """Running repro from child directory should auto-include parent stages."""
+    runner = CliRunner()
+    child_dir = lazy_resolution_project / "child"
+
+    with runner.isolated_filesystem(temp_dir=lazy_resolution_project):
+        # Change to child directory
+        import os
+        os.chdir(child_dir)
+
+        result = runner.invoke(cli, ["repro"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "producer" in result.output or "consumer" in result.output
+
+    # Verify outputs exist
+    assert (lazy_resolution_project / "data" / "output.txt").exists()
+    assert (child_dir / "result.txt").exists()
+    assert (child_dir / "result.txt").read_text() == "consumed: produced data"
+```
+
+**Step 2: Run integration test**
+
+Run: `uv run pytest tests/integration/test_lazy_resolution.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+jj describe -m "test: add integration test for lazy pipeline resolution"
+```
+
+---
+
+## Task 8: Run Quality Checks and Final Verification
+
+**Step 1: Run all tests**
+
+Run: `uv run pytest tests/ -n auto`
+Expected: All tests pass
+
+**Step 2: Run type checker**
+
+Run: `uv run basedpyright`
+Expected: No errors
+
+**Step 3: Run linter**
+
+Run: `uv run ruff check .`
+Expected: No errors
+
+**Step 4: Run formatter**
+
+Run: `uv run ruff format .`
+Expected: Files formatted
+
+**Step 5: Final commit**
+
+```bash
+jj describe -m "feat(pipeline): lazy dependency resolution from parent pipelines
+
+When building a pipeline's DAG, unresolved dependencies are automatically
+resolved by traversing up the directory tree, loading parent pipeline.py
+files, and including stages that produce the needed artifacts.
+
+Key behaviors:
+- Closest parent pipeline is searched first
+- Transitive dependencies are recursively resolved
+- Multiple producers for the same artifact is an error
+- Files that exist on disk are treated as external inputs
+- Parent stages retain their original state_dir"
+```
+
+---
+
+## Summary
+
+This implementation adds lazy pipeline dependency resolution through:
+
+1. **`find_parent_pipeline_files()`** - Traverses up directory tree to find parent pipeline.py files
+2. **`load_parent_pipeline()`** - Loads and caches parent Pipeline instances
+3. **`find_producer_in_pipeline()`** - Searches a pipeline for a stage producing a path
+4. **`Pipeline.resolve_from_parents()`** - Main entry point that resolves unresolved deps
+5. **Integration with `build_dag()`** - Auto-resolution happens before DAG construction
+
+The design preserves existing behavior while enabling child pipelines to depend on parent pipeline outputs without explicit `include()` calls.

--- a/docs/solutions/2026-02-02-path-resolution-design-patterns.md
+++ b/docs/solutions/2026-02-02-path-resolution-design-patterns.md
@@ -1,0 +1,137 @@
+---
+date: 2026-02-02
+category: design-patterns
+tags: [pathlib, path-resolution, symlinks, cross-platform, brainstorming]
+module: pipeline
+symptoms: [verbose-paths, stage-reuse, dvc-migration]
+---
+
+# Path Resolution Design Patterns in Python
+
+## Problem
+
+When designing a pipeline framework where stages can be reused across different pipeline directories, how should paths in annotations be resolved? The goal is to allow simple relative paths like `Dep("data/raw.csv")` that resolve differently depending on which pipeline registers the stage.
+
+## Key Design Decisions
+
+### 1. Implicit vs Explicit Path Prefix
+
+**Implicit (chosen):** Infer prefix from `pipeline.root` (directory containing `pipeline.py`)
+```python
+# eval_pipeline/horizon/pipeline.py
+pipeline = Pipeline("horizon")  # root inferred from __file__
+Dep("data/raw.csv")  # → eval_pipeline/horizon/data/raw.csv
+```
+
+**Explicit alternative:** User specifies prefix manually
+```python
+pipeline = Pipeline("horizon", path_prefix="eval_pipeline/horizon/")
+```
+
+**Tradeoff:** Implicit follows DVC convention (familiar to target users) but adds "magic". Explicit is clearer but more verbose.
+
+### 2. Where Resolution Happens
+
+**Bad:** Threading `pipeline_root` through multiple layers (Pipeline → Registry → stage_def)
+- Spreads the feature across many files
+- Hard to understand and maintain
+
+**Good:** Resolve entirely in `Pipeline.register()`
+- Extract annotation paths, resolve them, pass as overrides
+- Registry and stage_def remain unchanged
+- Feature contained in one place
+
+### 3. Symlinks: resolve() vs normpath()
+
+**`Path.resolve()`:** Follows symlinks, converts to absolute
+- If `data/` is a symlink to `/mnt/external/`, the resolved path is `/mnt/external/file.csv`
+- Breaks if symlink target is outside project root
+
+**`os.path.normpath()`:** Normalizes `..` components but preserves symlinks
+- `data/file.csv` stays as the symlink path, not the target
+- Allows symlinks pointing outside project root
+
+**Chosen:** `os.path.normpath()` - store the symlink path, not the target.
+
+### 4. Windows Path Handling
+
+Python's `pathlib.Path` on Unix treats backslashes as literal characters, not separators.
+
+**Solution:** Use `PureWindowsPath` which parses both `/` and `\` as separators on any platform:
+```python
+from pathlib import PureWindowsPath
+
+def normalize_to_posix(path: str) -> str:
+    return PureWindowsPath(path).as_posix()
+
+normalize_to_posix("foo\\bar")     # → "foo/bar"
+normalize_to_posix("foo/bar")      # → "foo/bar"
+normalize_to_posix("foo\\bar/baz") # → "foo/bar/baz"
+```
+
+### 5. Path Formats at Different Layers
+
+| Layer | Format | Why |
+|-------|--------|-----|
+| Annotations | Pipeline-relative | Simple, reusable |
+| RegistryStageInfo | Project-relative | Consistent for DAG building |
+| Lock files | Project-relative | Portable, git-trackable |
+| Execution | Absolute | No ambiguity at runtime |
+
+Resolution happens once at registration time. All downstream code sees project-relative paths.
+
+## Code Patterns
+
+### Normalize path with custom base (no symlink following)
+
+```python
+import os.path
+from pathlib import Path, PureWindowsPath
+
+def normalize_path(path: str, base: Path) -> Path:
+    """Normalize path relative to base, preserving symlinks."""
+    # Handle Windows paths
+    posix_path = PureWindowsPath(path).as_posix()
+    p = Path(posix_path)
+
+    # Make absolute from base
+    abs_path = p.absolute() if p.is_absolute() else (base / p).absolute()
+
+    # Normalize .. without following symlinks
+    return Path(os.path.normpath(abs_path))
+```
+
+### Convert to project-relative
+
+```python
+def to_project_relative(abs_path: Path, project_root: Path) -> str:
+    """Convert absolute path to project-relative string."""
+    try:
+        return str(abs_path.relative_to(project_root))
+    except ValueError:
+        # Path is outside project root - return as-is or error
+        return str(abs_path)
+```
+
+## Gotchas
+
+### pathlib has no normpath equivalent
+
+`Path.resolve()` normalizes AND follows symlinks. `Path.absolute()` makes absolute but doesn't normalize `..`. There's no built-in way to normalize without following symlinks.
+
+**Workaround:** `Path(os.path.normpath(path.absolute()))`
+
+### PurePosixPath doesn't parse backslashes
+
+On Unix, `PurePosixPath("foo\\bar")` has one component `"foo\\bar"`, not two.
+
+**Solution:** Always use `PureWindowsPath` for parsing user input, then `.as_posix()` for internal use.
+
+## Prevention
+
+When designing path resolution:
+1. Decide early: implicit vs explicit prefix
+2. Keep resolution in one layer, don't thread through multiple modules
+3. Use `normpath` not `resolve` if symlinks should be preserved
+4. Test with symlinks pointing outside project root
+5. Test with Windows-style paths if accepting user input

--- a/src/pivot/project.py
+++ b/src/pivot/project.py
@@ -36,11 +36,20 @@ def resolve_path(path: str | pathlib.Path) -> pathlib.Path:
     return (get_project_root() / p).resolve()
 
 
-def normalize_path(path: str | pathlib.Path) -> pathlib.Path:
-    """Make path absolute from project root, preserving symlinks (unlike resolve())."""
-    p = pathlib.Path(os.fspath(path))
-    abs_path = p.absolute() if p.is_absolute() else (get_project_root() / p).absolute()
-    # Collapse .. components without following symlinks
+def normalize_path(path: str | pathlib.Path, base: pathlib.Path | None = None) -> pathlib.Path:
+    """Make path absolute from base (default: project root), preserving symlinks.
+
+    Accepts both Unix (/) and Windows (\\) path separators.
+    """
+    from pathlib import PureWindowsPath
+
+    if base is None:
+        base = get_project_root()
+
+    # Normalize Windows paths to POSIX (handles both \\ and /)
+    p = pathlib.Path(PureWindowsPath(os.fspath(path)).as_posix())
+
+    abs_path = p.absolute() if p.is_absolute() else (base / p).absolute()
     return pathlib.Path(os.path.normpath(abs_path))
 
 

--- a/tests/config/test_registry.py
+++ b/tests/config/test_registry.py
@@ -101,7 +101,9 @@ def _plain_stage(
 # =============================================================================
 
 
-def test_register_registers_function(test_pipeline: "Pipeline") -> None:
+def test_register_registers_function(
+    test_pipeline: "Pipeline", set_project_root: pathlib.Path
+) -> None:
     """Should register function when calling register_test_stage()."""
     register_test_stage(_process_with_dep, name="process")
 
@@ -541,7 +543,9 @@ def test_stage_duplicate_registration_raises_error(test_pipeline: "Pipeline") ->
         register_test_stage(func_two, name="my_stage")
 
 
-def test_multiple_stages_registered(test_pipeline: "Pipeline") -> None:
+def test_multiple_stages_registered(
+    test_pipeline: "Pipeline", set_project_root: pathlib.Path
+) -> None:
     """Should register multiple stages independently."""
     register_test_stage(_stage1_with_dep, name="stage1")
     register_test_stage(_stage2_with_out, name="stage2")
@@ -759,7 +763,7 @@ def test_registry_restore_preserves_metadata() -> None:
 # ==============================================================================
 
 
-def test_stageparams_work(test_pipeline: "Pipeline") -> None:
+def test_stageparams_work(test_pipeline: "Pipeline", set_project_root: pathlib.Path) -> None:
     """StageParams should work for stage parameters."""
     register_test_stage(_plain_stage, name="plain_stage", params=PlainParams())
 
@@ -773,7 +777,9 @@ def test_stageparams_work(test_pipeline: "Pipeline") -> None:
 # ==============================================================================
 
 
-def test_out_path_overrides_accepts_simple_string(test_pipeline: "Pipeline") -> None:
+def test_out_path_overrides_accepts_simple_string(
+    test_pipeline: "Pipeline", set_project_root: pathlib.Path
+) -> None:
     """out_path_overrides should accept simple strings, not just dicts with path key."""
 
     def my_stage() -> _OutputTxt:
@@ -786,7 +792,9 @@ def test_out_path_overrides_accepts_simple_string(test_pipeline: "Pipeline") -> 
     assert info["out_specs"]["output"].path == "override.txt"
 
 
-def test_out_path_overrides_accepts_dict_with_options(test_pipeline: "Pipeline") -> None:
+def test_out_path_overrides_accepts_dict_with_options(
+    test_pipeline: "Pipeline", set_project_root: pathlib.Path
+) -> None:
     """out_path_overrides should accept dicts with path and options."""
 
     def my_stage2() -> _OutputTxt:
@@ -802,7 +810,9 @@ def test_out_path_overrides_accepts_dict_with_options(test_pipeline: "Pipeline")
     assert info["out_specs"]["output"].cache is False
 
 
-def test_out_path_overrides_accepts_list_paths(test_pipeline: Pipeline) -> None:
+def test_out_path_overrides_accepts_list_paths(
+    test_pipeline: Pipeline, set_project_root: pathlib.Path
+) -> None:
     """out_path_overrides should accept list paths for multi-file outputs."""
 
     class MultiOutput(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,11 @@ def test_pipeline(tmp_path: pathlib.Path) -> Generator[pipeline_mod.Pipeline]:
 
     Also sets up the module-level test pipeline in helpers.py so that
     register_test_stage() works without explicit pipeline parameter.
+
+    Note: This fixture does NOT mock the project root. Tests that register
+    stages with path annotations should either:
+    1. Use mock_discovery fixture (which mocks project root)
+    2. Or explicitly mock project._project_root_cache themselves
     """
     import helpers
 

--- a/tests/core/test_explain.py
+++ b/tests/core/test_explain.py
@@ -683,7 +683,7 @@ def test_get_pipeline_explanations_upstream_propagation(
     pipeline = test_pipeline
 
     with contextlib.chdir(tmp_path):
-        pathlib.Path(".git").mkdir()
+        pathlib.Path(".git").mkdir(exist_ok=True)
         pathlib.Path("input.txt").write_text("data")
 
         # Register and run initial pipeline

--- a/tests/core/test_pipeline_config.py
+++ b/tests/core/test_pipeline_config.py
@@ -1647,8 +1647,13 @@ def test_load_pipeline_from_yaml_creates_pipeline(simple_pipeline: pathlib.Path)
     assert result.root == simple_pipeline
 
 
-def test_load_pipeline_from_yaml_uses_pipeline_name(tmp_path: pathlib.Path) -> None:
+def test_load_pipeline_from_yaml_uses_pipeline_name(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """load_pipeline_from_yaml should use 'pipeline' field for name if present."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
+
     # Create a simple stage module
     stages_py = tmp_path / "stages.py"
     stages_py.write_text(
@@ -1680,8 +1685,13 @@ stages:
     assert result.name == "my_custom_name"
 
 
-def test_load_pipeline_from_yaml_defaults_to_directory_name(tmp_path: pathlib.Path) -> None:
+def test_load_pipeline_from_yaml_defaults_to_directory_name(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """load_pipeline_from_yaml should default name to parent directory."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
+
     # Create a subdirectory to test directory name extraction
     subdir = tmp_path / "my_project"
     subdir.mkdir()

--- a/tests/engine/test_agent_rpc.py
+++ b/tests/engine/test_agent_rpc.py
@@ -461,7 +461,7 @@ async def test_rpc_run_invalid_stage_returns_error(
 ) -> None:
     """RPC run with invalid stage name returns descriptive error."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
     (tmp_path / ".pivot").mkdir()
 
     from pivot.pipeline.pipeline import Pipeline

--- a/tests/integration/test_rpc_queries.py
+++ b/tests/integration/test_rpc_queries.py
@@ -43,7 +43,7 @@ def send_rpc(
 @pytest.fixture
 def serve_pipeline(tmp_path: pathlib.Path) -> Generator[pathlib.Path]:
     """Start a minimal pipeline in serve mode, yield socket path."""
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
     (tmp_path / ".pivot").mkdir()
 
     # Use pipeline.py only (not pivot.yaml) to avoid ambiguity error

--- a/tests/integration/test_serve_mode.py
+++ b/tests/integration/test_serve_mode.py
@@ -57,7 +57,7 @@ async def test_socket_creation_and_permissions(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     register_test_stage(_helper_noop, name="test_stage")
 
@@ -166,7 +166,7 @@ async def test_agent_rpc_handler_stages_query(
 ) -> None:
     """AgentRpcHandler.handle_query returns stages correctly."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     register_test_stage(_helper_noop, name="stage_a")
     register_test_stage(_helper_noop, name="stage_b")
@@ -218,7 +218,7 @@ async def test_socket_handles_chunked_messages(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     # Need to create engine first to create handler, then create source with handler
     async with Engine(pipeline=test_pipeline) as engine:
@@ -335,7 +335,7 @@ def test_serve_mode_cli_responds_to_status_query(
     """
 
     # Create minimal project structure with a valid pipeline
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
     (tmp_path / ".pivot").mkdir()
     pipeline_code = """\
 import pathlib
@@ -438,7 +438,7 @@ async def test_rpc_source_without_handler_returns_method_not_found(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     # Create source WITHOUT handler (mimics current _run_serve_mode bug)
     rpc_source = AgentRpcSource(socket_path=socket_path, handler=None)
@@ -483,7 +483,7 @@ async def test_rpc_source_with_handler_returns_status(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     async with Engine(pipeline=test_pipeline) as engine:
         # Create source WITH handler (correct implementation)
@@ -536,7 +536,7 @@ async def test_event_buffer_integration_with_engine(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     register_test_stage(_helper_noop, name="test_stage")
 
@@ -578,7 +578,7 @@ async def test_event_buffer_polling_during_execution(
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
     monkeypatch.chdir(tmp_path)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     def _slow_stage(params: None) -> dict[str, str]:
         """Stage that takes time to execute."""

--- a/tests/integration/test_unified_execution.py
+++ b/tests/integration/test_unified_execution.py
@@ -54,7 +54,7 @@ def minimal_pipeline(
     monkeypatch.chdir(tmp_path)
 
     # Create git directory (required for project root detection)
-    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
     return test_pipeline
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -116,8 +116,11 @@ def test_pipeline_name_validation_invalid_patterns() -> None:
 # Stage registration tests
 
 
-def test_pipeline_register_stage(tmp_path: pathlib.Path) -> None:
+def test_pipeline_register_stage(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """Pipeline.register should register a stage with the pipeline's state_dir."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p = Pipeline("test", root=tmp_path)
     p.register(_simple_stage, name="my_stage")
 
@@ -126,8 +129,11 @@ def test_pipeline_register_stage(tmp_path: pathlib.Path) -> None:
     assert info["state_dir"] == tmp_path / ".pivot"
 
 
-def test_pipeline_stages_isolated(tmp_path: pathlib.Path) -> None:
+def test_pipeline_stages_isolated(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """Two pipelines can have stages with the same name."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p1 = Pipeline("pipeline1", root=tmp_path / "p1")
     p2 = Pipeline("pipeline2", root=tmp_path / "p2")
 
@@ -157,12 +163,17 @@ def _stage_with_invalid_output_missing_annotation() -> _InvalidOutputMissingAnno
     return _InvalidOutputMissingAnnotation(result=pathlib.Path("result.txt"))
 
 
-def test_pipeline_register_missing_annotation_fails(tmp_path: pathlib.Path) -> None:
+def test_pipeline_register_missing_annotation_fails(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Pipeline.register fails when output TypedDict field missing Annotated wrapper.
 
     Critical for catching user errors where they forget Annotated[] on TypedDict fields.
     This prevents silent registration of stages that won't work at runtime.
     """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p = Pipeline("test", root=tmp_path)
 
     with pytest.raises(exceptions.StageDefinitionError, match="without Out annotations"):
@@ -284,8 +295,13 @@ def test_pipeline_build_dag_detects_cycles(tmp_path: pathlib.Path, mocker: Mocke
 # =============================================================================
 
 
-def test_pipeline_snapshot_captures_current_state(tmp_path: pathlib.Path) -> None:
+def test_pipeline_snapshot_captures_current_state(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """snapshot() should capture current registry state for rollback."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p = Pipeline("test", root=tmp_path)
     p.register(_simple_stage, name="stage1")
 
@@ -296,8 +312,11 @@ def test_pipeline_snapshot_captures_current_state(tmp_path: pathlib.Path) -> Non
     assert snap["stage1"]["func"] == _simple_stage
 
 
-def test_pipeline_restore_replaces_state(tmp_path: pathlib.Path) -> None:
+def test_pipeline_restore_replaces_state(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """restore() should replace registry state from snapshot."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p = Pipeline("test", root=tmp_path)
     p.register(_simple_stage, name="stage1")
 
@@ -316,8 +335,11 @@ def test_pipeline_restore_replaces_state(tmp_path: pathlib.Path) -> None:
     assert "stage_a" not in p.list_stages()
 
 
-def test_pipeline_clear_removes_all_stages(tmp_path: pathlib.Path) -> None:
+def test_pipeline_clear_removes_all_stages(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """clear() should remove all registered stages."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     p = Pipeline("test", root=tmp_path)
     p.register(_simple_stage, name="stage1")
     p.register(_stage_a, name="stage_a")
@@ -334,8 +356,11 @@ def test_pipeline_clear_removes_all_stages(tmp_path: pathlib.Path) -> None:
 # =============================================================================
 
 
-def test_pipeline_include_copies_stages(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_copies_stages(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """include() should copy all stages from the included pipeline."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -346,8 +371,13 @@ def test_pipeline_include_copies_stages(tmp_path: pathlib.Path) -> None:
     assert "sub_stage" in main.list_stages()
 
 
-def test_pipeline_include_preserves_state_dir(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_preserves_state_dir(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Included stages should keep their original state_dir."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -359,12 +389,17 @@ def test_pipeline_include_preserves_state_dir(tmp_path: pathlib.Path) -> None:
     assert info["state_dir"] == tmp_path / "sub" / ".pivot"
 
 
-def test_pipeline_include_preserves_state_dir_transitively(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_preserves_state_dir_transitively(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Transitive inclusion should preserve original state_dir through multiple levels.
 
     When A includes B and B includes C, C's stages in A should retain C's state_dir.
     Critical for ensuring lock files and state.db remain in correct locations.
     """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     # Level 1: Base pipeline
     base = Pipeline("base", root=tmp_path / "base")
     base.register(_simple_stage, name="base_stage")
@@ -387,8 +422,13 @@ def test_pipeline_include_preserves_state_dir_transitively(tmp_path: pathlib.Pat
     assert intermediate_info["state_dir"] == tmp_path / "intermediate" / ".pivot"
 
 
-def test_pipeline_include_name_collision_raises(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_name_collision_raises(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """include() should raise PipelineConfigError on stage name collision."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -399,8 +439,13 @@ def test_pipeline_include_name_collision_raises(tmp_path: pathlib.Path) -> None:
         main.include(sub)
 
 
-def test_pipeline_include_collision_transitive(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_collision_transitive(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Name collision should be detected even in transitively included stages."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     main.register(_simple_stage, name="train")
 
@@ -417,11 +462,16 @@ def test_pipeline_include_collision_transitive(tmp_path: pathlib.Path) -> None:
         main.include(sub)
 
 
-def test_pipeline_include_collision_is_atomic(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_collision_is_atomic(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Include should be atomic: collision should not partially add stages.
 
     Important for preventing registry corruption when include() fails partway through.
     """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     main.register(_simple_stage, name="conflict")
 
@@ -438,8 +488,11 @@ def test_pipeline_include_collision_is_atomic(tmp_path: pathlib.Path) -> None:
     assert set(main.list_stages()) == initial_stages
 
 
-def test_pipeline_include_empty_pipeline(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_empty_pipeline(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """include() with empty pipeline should be a no-op."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     main.register(_simple_stage, name="existing")
 
@@ -450,8 +503,11 @@ def test_pipeline_include_empty_pipeline(tmp_path: pathlib.Path) -> None:
     assert set(main.list_stages()) == {"existing"}
 
 
-def test_pipeline_include_self_raises(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_self_raises(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """Including a pipeline into itself should raise."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     main.register(_simple_stage, name="stage")
 
@@ -459,8 +515,13 @@ def test_pipeline_include_self_raises(tmp_path: pathlib.Path) -> None:
         main.include(main)
 
 
-def test_pipeline_include_same_pipeline_twice_raises(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_same_pipeline_twice_raises(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Including the same pipeline twice should raise on collision."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
     sub.register(_simple_stage, name="sub_stage")
@@ -471,8 +532,13 @@ def test_pipeline_include_same_pipeline_twice_raises(tmp_path: pathlib.Path) -> 
         main.include(sub)
 
 
-def test_pipeline_include_multiple_different_pipelines(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_multiple_different_pipelines(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Including multiple different pipelines should work."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub1 = Pipeline("sub1", root=tmp_path / "sub1")
     sub2 = Pipeline("sub2", root=tmp_path / "sub2")
@@ -486,8 +552,11 @@ def test_pipeline_include_multiple_different_pipelines(tmp_path: pathlib.Path) -
     assert set(main.list_stages()) == {"stage1", "stage2"}
 
 
-def test_pipeline_include_preserves_params(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_preserves_params(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """Included stages should keep their params."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -505,12 +574,15 @@ def test_pipeline_include_preserves_params(tmp_path: pathlib.Path) -> None:
     assert params.value == 100
 
 
-def test_pipeline_include_isolates_mutations(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_isolates_mutations(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     """Mutations to included stages shouldn't affect source pipeline.
 
     Critical for preventing action-at-a-distance bugs where modifying one
     pipeline unexpectedly affects another.
     """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -524,8 +596,13 @@ def test_pipeline_include_isolates_mutations(tmp_path: pathlib.Path) -> None:
     assert "test_mutex" not in sub.get("stage")["mutex"]
 
 
-def test_pipeline_include_is_independent_copy(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_is_independent_copy(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Stages are copied at include time; subsequent changes don't propagate."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -568,16 +645,29 @@ def test_pipeline_include_invalidates_dag_cache(
 def test_pipeline_include_dag_connects_across_pipelines(
     tmp_path: pathlib.Path, mocker: MockerFixture
 ) -> None:
-    """DAG should connect main stage depending on included sub-pipeline stage."""
+    """DAG should connect main stage depending on included sub-pipeline stage.
+
+    When including a sub-pipeline, cross-pipeline dependencies work because:
+    - Producer in sub outputs sub/a.txt (relative to project root)
+    - Consumer in main can reference sub/a.txt to depend on it
+    """
     mocker.patch.object(project, "_project_root_cache", tmp_path)
     (tmp_path / ".git").mkdir()
 
     main = Pipeline("main", root=tmp_path)
     sub = Pipeline("sub", root=tmp_path / "sub")
 
+    # Producer outputs a.txt (resolved to sub/a.txt project-relative)
     sub.register(_stage_a, name="producer")
     main.include(sub)
-    main.register(_stage_b, name="consumer")
+
+    # Consumer needs to reference sub/a.txt (the producer's actual output path)
+    # Use dep_path_overrides to point to the correct path
+    main.register(
+        _stage_b,
+        name="consumer",
+        dep_path_overrides={"data": "sub/a.txt"},  # Reference producer's output
+    )
 
     dag = main.build_dag(validate=True)
 
@@ -587,8 +677,13 @@ def test_pipeline_include_dag_connects_across_pipelines(
     assert dag.has_edge("consumer", "producer")
 
 
-def test_pipeline_include_preserves_all_metadata(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_preserves_all_metadata(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Included stages should preserve all metadata fields (deps, outs, mutex, variant, fingerprint)."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -616,8 +711,13 @@ def test_pipeline_include_preserves_all_metadata(tmp_path: pathlib.Path) -> None
     assert included_info["func"] == original_info["func"]
 
 
-def test_pipeline_include_isolates_nested_mutations(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_isolates_nested_mutations(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Deep copy should isolate mutations to nested structures (params object)."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     sub = Pipeline("sub", root=tmp_path / "sub")
 
@@ -643,8 +743,13 @@ def test_pipeline_include_isolates_nested_mutations(tmp_path: pathlib.Path) -> N
     assert included_params.value == original_params.value == 100
 
 
-def test_pipeline_include_multiple_collisions_atomic(tmp_path: pathlib.Path) -> None:
+def test_pipeline_include_multiple_collisions_atomic(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
     """Multiple collisions should still be atomic (no partial adds)."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     main = Pipeline("main", root=tmp_path / "main")
     main.register(_simple_stage, name="collide_a")
     main.register(_stage_a, name="collide_b")
@@ -661,3 +766,702 @@ def test_pipeline_include_multiple_collisions_atomic(tmp_path: pathlib.Path) -> 
 
     # Should be unchanged (safe_stage not added)
     assert set(main.list_stages()) == initial_stages
+
+
+def test_pipeline_include_deepcopy_failure_is_atomic(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Include should be atomic even when deepcopy fails mid-operation.
+
+    If deepcopy raises an exception on the Nth stage, no stages should be added.
+    """
+    import copy
+
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    main = Pipeline("main", root=tmp_path / "main")
+    sub = Pipeline("sub", root=tmp_path / "sub")
+
+    # Register 3 stages in sub
+    sub.register(_simple_stage, name="stage1")
+    sub.register(_stage_a, name="stage2")
+    sub.register(_stage_b, name="stage3")
+
+    initial_stages = set(main.list_stages())
+    deepcopy_call_count = 0
+
+    original_deepcopy = copy.deepcopy
+
+    def failing_deepcopy(obj: object) -> object:
+        nonlocal deepcopy_call_count
+        deepcopy_call_count += 1
+        if deepcopy_call_count == 2:  # Fail on second stage
+            raise RuntimeError("Simulated deepcopy failure")
+        return original_deepcopy(obj)
+
+    mocker.patch.object(copy, "deepcopy", failing_deepcopy)
+
+    with pytest.raises(RuntimeError, match="Simulated deepcopy failure"):
+        main.include(sub)
+
+    # Should be unchanged (no stages added)
+    assert set(main.list_stages()) == initial_stages
+
+
+# =============================================================================
+# Pipeline Path Resolution Tests (register() resolves paths relative to pipeline root)
+# =============================================================================
+
+
+# Helper stages for path resolution tests - defined at module level for fingerprinting
+class _PathResolutionOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("data/output.txt", loaders.PathOnly())]
+
+
+def _path_resolution_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("data/input.txt", loaders.PathOnly())],
+) -> _PathResolutionOutput:
+    return _PathResolutionOutput(result=pathlib.Path("data/output.txt"))
+
+
+def _single_output_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("input.txt", loaders.PathOnly())],
+) -> Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]:
+    return pathlib.Path("output.txt")
+
+
+class _MultiPathDepOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("merged.txt", loaders.PathOnly())]
+
+
+def _multi_path_dep_stage(
+    files: Annotated[
+        list[pathlib.Path], outputs.Dep(["data/a.txt", "data/b.txt"], loaders.PathOnly())
+    ],
+) -> _MultiPathDepOutput:
+    return _MultiPathDepOutput(result=pathlib.Path("merged.txt"))
+
+
+# Cross-pipeline dep helper (uses ../)
+class _CrossPipelineOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _cross_pipeline_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("../shared/data.csv", loaders.PathOnly())],
+) -> _CrossPipelineOutput:
+    return _CrossPipelineOutput(result=pathlib.Path("result.txt"))
+
+
+# Absolute path helper
+class _AbsolutePathOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _absolute_path_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("/data/external/file.csv", loaders.PathOnly())],
+) -> _AbsolutePathOutput:
+    return _AbsolutePathOutput(result=pathlib.Path("result.txt"))
+
+
+# Windows path helper
+class _WindowsPathOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("out/result.txt", loaders.PathOnly())]
+
+
+def _windows_path_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("data\\input.txt", loaders.PathOnly())],
+) -> _WindowsPathOutput:
+    return _WindowsPathOutput(result=pathlib.Path("out/result.txt"))
+
+
+# Escape project root helper
+class _EscapeOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _escape_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("../../outside_project.csv", loaders.PathOnly())],
+) -> _EscapeOutput:
+    return _EscapeOutput(result=pathlib.Path("result.txt"))
+
+
+# Override stage helper
+def _override_stage(
+    data: Annotated[pathlib.Path, outputs.PlaceholderDep(loaders.PathOnly())],
+) -> Annotated[pathlib.Path, outputs.Out("default_out.txt", loaders.PathOnly())]:
+    return pathlib.Path("overridden_out.txt")
+
+
+# Cache option stage helper
+def _cache_option_stage() -> Annotated[
+    pathlib.Path, outputs.Out("default.txt", loaders.PathOnly())
+]:
+    return pathlib.Path("output.txt")
+
+
+def test_register_resolves_relative_to_pipeline_root(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Paths in annotations should be resolved relative to pipeline root, not project root.
+
+    Pipeline at /project/subdir/ with annotation path "data/input.txt"
+    should resolve to /project/subdir/data/input.txt, stored as project-relative
+    "subdir/data/input.txt".
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Pipeline in subdirectory
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(_path_resolution_stage, name="my_stage")
+
+    info = p.get("my_stage")
+
+    # Dep path should be project-relative: subdir/data/input.txt
+    # (flattened deps_paths contains absolute paths after registration normalization)
+    # The deps dict should have the resolved path
+    assert "data" in info["deps"]
+    # After normalization, paths are absolute in deps_paths
+    expected_dep = str(project_root / "subdir" / "data" / "input.txt")
+    assert expected_dep in info["deps_paths"]
+
+    # Out path should also be project-relative
+    expected_out = str(project_root / "subdir" / "data" / "output.txt")
+    assert expected_out in info["outs_paths"]
+
+
+def test_register_cross_pipeline_dep_with_dotdot(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Pipeline can depend on files outside its root using ../ traversal.
+
+    Pipeline at /project/pipelines/eval/ depending on ../shared/data.csv
+    should resolve to /project/pipelines/shared/data.csv.
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Create directory structure
+    eval_pipeline = project_root / "pipelines" / "eval"
+    eval_pipeline.mkdir(parents=True)
+    shared_dir = project_root / "pipelines" / "shared"
+    shared_dir.mkdir(parents=True)
+
+    p = Pipeline("eval", root=eval_pipeline)
+    p.register(_cross_pipeline_stage, name="cross_stage")
+
+    info = p.get("cross_stage")
+
+    # Dep should resolve to pipelines/shared/data.csv (project-relative)
+    # After normalization, stored as absolute path
+    expected_dep = str(project_root / "pipelines" / "shared" / "data.csv")
+    assert expected_dep in info["deps_paths"]
+
+
+def test_register_absolute_path_unchanged(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Absolute paths should be normalized but kept absolute.
+
+    An absolute path like /data/external/file.csv should remain absolute
+    (not converted to project-relative).
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(_absolute_path_stage, name="abs_stage")
+
+    info = p.get("abs_stage")
+
+    # Absolute path should be preserved (normalized, but still absolute)
+    assert "/data/external/file.csv" in info["deps_paths"]
+
+
+def test_register_windows_path_normalized(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Windows-style paths should be normalized to POSIX format.
+
+    A path like "data\\subdir\\file.txt" should become "data/subdir/file.txt".
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(_windows_path_stage, name="win_stage")
+
+    info = p.get("win_stage")
+
+    # Paths should be normalized (no backslashes in final paths)
+    for dep_path in info["deps_paths"]:
+        assert "\\" not in dep_path, f"Backslash found in dep path: {dep_path}"
+    for out_path in info["outs_paths"]:
+        assert "\\" not in out_path, f"Backslash found in out path: {out_path}"
+
+
+def test_register_overrides_are_pipeline_relative(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """dep_path_overrides and out_path_overrides should be resolved relative to pipeline root."""
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(
+        _override_stage,
+        name="override_stage",
+        dep_path_overrides={"data": "custom/input.csv"},
+        out_path_overrides={"_single": "custom/output.csv"},
+    )
+
+    info = p.get("override_stage")
+
+    # Override paths should be resolved from pipeline root (subdir/)
+    expected_dep = str(project_root / "subdir" / "custom" / "input.csv")
+    assert expected_dep in info["deps_paths"]
+
+    expected_out = str(project_root / "subdir" / "custom" / "output.csv")
+    assert expected_out in info["outs_paths"]
+
+
+def test_register_validates_after_normalization(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Validation should happen after path normalization.
+
+    - ../foo should be allowed (collapses to valid path)
+    - But escaping project root should be rejected
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Pipeline at project root level
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+
+    # Should raise because ../../outside_project.csv from subdir/ escapes project root
+    with pytest.raises(
+        (ValueError, exceptions.InvalidPathError, exceptions.SecurityValidationError)
+    ):
+        p.register(_escape_stage, name="escape_stage")
+
+
+def test_register_single_output_stage(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Single-output stages (non-TypedDict return) should have paths resolved correctly."""
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(_single_output_stage, name="single_out")
+
+    info = p.get("single_out")
+
+    # Both dep and out should be resolved from pipeline root
+    expected_dep = str(project_root / "subdir" / "input.txt")
+    assert expected_dep in info["deps_paths"]
+
+    expected_out = str(project_root / "subdir" / "output.txt")
+    assert expected_out in info["outs_paths"]
+
+
+def test_register_out_override_with_cache_option(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """OutOverride dict with cache option should preserve the cache flag."""
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(
+        _cache_option_stage,
+        name="cache_stage",
+        out_path_overrides={"_single": {"path": "custom/output.txt", "cache": False}},
+    )
+
+    info = p.get("cache_stage")
+
+    # Output path should be resolved from pipeline root
+    expected_out = str(project_root / "subdir" / "custom" / "output.txt")
+    assert expected_out in info["outs_paths"]
+
+    # Cache option should be preserved
+    assert len(info["outs"]) == 1
+    assert info["outs"][0].cache is False
+
+
+def test_register_multi_path_dep_resolved(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Multi-path deps (list/tuple) should have each path resolved relative to pipeline root."""
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    pipeline_root = project_root / "subdir"
+    pipeline_root.mkdir()
+
+    p = Pipeline("test", root=pipeline_root)
+    p.register(_multi_path_dep_stage, name="multi_dep")
+
+    info = p.get("multi_dep")
+
+    # Both paths should be resolved from pipeline root
+    expected_a = str(project_root / "subdir" / "data" / "a.txt")
+    expected_b = str(project_root / "subdir" / "data" / "b.txt")
+
+    assert expected_a in info["deps_paths"]
+    assert expected_b in info["deps_paths"]
+
+
+# =============================================================================
+# Cross-Pipeline DAG Integration Tests
+# =============================================================================
+
+
+# Helper stages for cross-pipeline tests - defined at module level for fingerprinting
+class _SharedDataOutput(TypedDict):
+    data: Annotated[pathlib.Path, outputs.Out("data.csv", loaders.PathOnly())]
+
+
+def _shared_data_producer() -> _SharedDataOutput:
+    pathlib.Path("data.csv").write_text("shared data")
+    return _SharedDataOutput(data=pathlib.Path("data.csv"))
+
+
+class _CrossPipelineConsumerOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _cross_pipeline_consumer(
+    data: Annotated[pathlib.Path, outputs.Dep("../shared/data.csv", loaders.PathOnly())],
+) -> _CrossPipelineConsumerOutput:
+    return _CrossPipelineConsumerOutput(result=pathlib.Path("result.txt"))
+
+
+def test_dag_connects_cross_pipeline_deps(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """DAG should correctly connect stages when dependency uses ../ to reference cross-pipeline output.
+
+    When pipeline at /project/pipelines/eval/ depends on ../shared/data.csv,
+    and pipeline at /project/pipelines/shared/ produces data.csv,
+    the DAG should have an edge from consumer to producer.
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Create directory structure: pipelines/shared/ and pipelines/eval/
+    shared_root = project_root / "pipelines" / "shared"
+    shared_root.mkdir(parents=True)
+    eval_root = project_root / "pipelines" / "eval"
+    eval_root.mkdir(parents=True)
+
+    # Main pipeline at project root - will include both sub-pipelines
+    main = Pipeline("main", root=project_root)
+
+    # Shared pipeline produces data.csv (resolved to pipelines/shared/data.csv)
+    shared = Pipeline("shared", root=shared_root)
+    shared.register(_shared_data_producer, name="producer")
+
+    # Eval pipeline consumes ../shared/data.csv (resolved to pipelines/shared/data.csv)
+    eval_pipeline = Pipeline("eval", root=eval_root)
+    eval_pipeline.register(_cross_pipeline_consumer, name="consumer")
+
+    # Include both pipelines into main
+    main.include(shared)
+    main.include(eval_pipeline)
+
+    # Build DAG - should connect consumer -> producer
+    dag = main.build_dag(validate=True)
+
+    assert "producer" in dag.nodes
+    assert "consumer" in dag.nodes
+    # Edge from consumer to producer (consumer depends on producer)
+    assert dag.has_edge("consumer", "producer"), (
+        f"Expected edge consumer->producer. Edges: {list(dag.edges)}"
+    )
+
+
+def test_dag_missing_dep_raises(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """DAG validation should raise DependencyNotFoundError when dep doesn't match any output.
+
+    When a stage depends on a path that:
+    1. Is not produced by any registered stage
+    2. Does not exist on disk
+    The build_dag(validate=True) should raise DependencyNotFoundError.
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    eval_root = project_root / "pipelines" / "eval"
+    eval_root.mkdir(parents=True)
+
+    p = Pipeline("eval", root=eval_root)
+    # Consumer depends on ../shared/data.csv but no producer registered
+    p.register(_cross_pipeline_consumer, name="consumer")
+
+    # Should raise because dependency doesn't exist and no stage produces it
+    with pytest.raises(exceptions.DependencyNotFoundError) as exc_info:
+        p.build_dag(validate=True)
+
+    # Verify error message contains the missing path
+    assert "consumer" in str(exc_info.value)
+    assert "shared" in str(exc_info.value) or "data.csv" in str(exc_info.value)
+
+
+def test_included_pipeline_paths_resolve_correctly(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """When using include(), included pipeline stages should have paths already resolved.
+
+    The included stage's paths should be resolved relative to its original pipeline root,
+    not the including pipeline's root.
+    """
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Sub-pipeline in subdir/
+    sub_root = project_root / "subdir"
+    sub_root.mkdir()
+
+    sub = Pipeline("sub", root=sub_root)
+    sub.register(_path_resolution_stage, name="sub_stage")
+
+    # Main pipeline at project root
+    main = Pipeline("main", root=project_root)
+    main.include(sub)
+
+    # Get the included stage's info
+    info = main.get("sub_stage")
+
+    # Paths should be resolved from sub_root (subdir/), not main's root
+    # Dep: data/input.txt -> subdir/data/input.txt (absolute)
+    expected_dep = str(project_root / "subdir" / "data" / "input.txt")
+    assert expected_dep in info["deps_paths"], (
+        f"Expected dep path {expected_dep} in {info['deps_paths']}"
+    )
+
+    # Out: data/output.txt -> subdir/data/output.txt (absolute)
+    expected_out = str(project_root / "subdir" / "data" / "output.txt")
+    assert expected_out in info["outs_paths"], (
+        f"Expected out path {expected_out} in {info['outs_paths']}"
+    )
+
+
+def test_lockfile_contains_project_relative_paths(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Lock files should store project-relative paths, not absolute or pipeline-relative.
+
+    This test verifies that when a lock file is written, the paths stored in it
+    are relative to the project root, ensuring portability.
+    """
+    from pivot.storage import lock
+    from pivot.types import LockData
+
+    project_root = tmp_path
+    mocker.patch.object(project, "_project_root_cache", project_root)
+    (project_root / ".git").mkdir()
+
+    # Create stages dir
+    stages_dir = project_root / ".pivot" / "stages"
+    stages_dir.mkdir(parents=True)
+
+    # Create a StageLock and write data with absolute paths
+    stage_lock = lock.StageLock("test_stage", stages_dir)
+
+    # Simulate lock data with absolute paths (as used internally)
+    abs_dep = str(project_root / "subdir" / "data" / "input.txt")
+    abs_out = str(project_root / "subdir" / "data" / "output.txt")
+
+    lock_data = LockData(
+        code_manifest={"main": "abc123"},
+        params={"key": "value"},
+        dep_hashes={abs_dep: {"hash": "dep_hash_123"}},
+        output_hashes={abs_out: {"hash": "out_hash_456"}},
+        dep_generations={"producer": 1},
+    )
+
+    # Write the lock file
+    stage_lock.write(lock_data)
+
+    # Read the raw YAML to verify paths are project-relative
+    import yaml
+
+    raw_content = stage_lock.path.read_text()
+    raw_data = yaml.safe_load(raw_content)
+
+    # Deps should be project-relative (not absolute)
+    assert len(raw_data["deps"]) == 1
+    dep_path = raw_data["deps"][0]["path"]
+    assert dep_path == "subdir/data/input.txt", (
+        f"Expected project-relative path 'subdir/data/input.txt', got '{dep_path}'"
+    )
+    assert not dep_path.startswith("/"), "Dep path should not be absolute"
+
+    # Outs should be project-relative (not absolute)
+    assert len(raw_data["outs"]) == 1
+    out_path = raw_data["outs"][0]["path"]
+    assert out_path == "subdir/data/output.txt", (
+        f"Expected project-relative path 'subdir/data/output.txt', got '{out_path}'"
+    )
+    assert not out_path.startswith("/"), "Out path should not be absolute"
+
+    # Verify round-trip: read() should convert back to absolute paths
+    read_back = stage_lock.read()
+    assert read_back is not None
+    assert abs_dep in read_back["dep_hashes"]
+    assert abs_out in read_back["output_hashes"]
+
+
+# =============================================================================
+# Path Resolution Edge Case Tests
+# =============================================================================
+
+
+def test_resolve_path_rejects_empty_string(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """_resolve_path should reject empty string paths."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path)
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        p._resolve_path("")
+
+
+def test_resolve_path_rejects_whitespace_only(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """_resolve_path should reject whitespace-only paths."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path)
+
+    with pytest.raises(ValueError, match="cannot be empty or whitespace"):
+        p._resolve_path("   ")
+
+    with pytest.raises(ValueError, match="cannot be empty or whitespace"):
+        p._resolve_path("\t\n")
+
+
+def test_resolve_path_rejects_root_only_paths(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """_resolve_path should reject root-only paths like '/' or 'C:\\'."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path)
+
+    with pytest.raises(ValueError, match="cannot be a root directory"):
+        p._resolve_path("/")
+
+    with pytest.raises(ValueError, match="cannot be a root directory"):
+        p._resolve_path("\\")
+
+    # Windows drive roots
+    with pytest.raises(ValueError, match="cannot be a root directory"):
+        p._resolve_path("C:\\")
+
+    with pytest.raises(ValueError, match="cannot be a root directory"):
+        p._resolve_path("D:/")
+
+
+def test_resolve_path_handles_windows_drive_letters(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """_resolve_path should recognize Windows drive letters as absolute paths.
+
+    Windows paths like C:\\path or D:/path should be treated as absolute,
+    not joined with the pipeline root.
+    """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path / "subdir")
+
+    # Windows paths should be preserved as absolute (converted to POSIX format)
+    # Note: On Unix, these paths are still "absolute" in the sense they have a drive letter
+    resolved = p._resolve_path("C:/data/file.csv")
+    # On Unix, this becomes a path like "C:/data/file.csv" (POSIX format)
+    # The key is that it's NOT joined with pipeline root
+    assert "subdir" not in resolved, (
+        f"Windows absolute path should not be joined with pipeline root: {resolved}"
+    )
+
+    resolved = p._resolve_path("D:\\path\\to\\file.txt")
+    assert "subdir" not in resolved, (
+        f"Windows absolute path should not be joined with pipeline root: {resolved}"
+    )
+
+
+# =============================================================================
+# IncrementalOut Registration Tests
+# =============================================================================
+
+
+# Module-level helper for IncrementalOut tests
+def incremental_cache_stage(
+    existing: Annotated[
+        dict[str, str], outputs.IncrementalOut("data/cache.yaml", loaders.YAML[dict[str, str]]())
+    ],
+) -> Annotated[
+    dict[str, str], outputs.IncrementalOut("data/cache.yaml", loaders.YAML[dict[str, str]]())
+]:
+    """Stage with IncrementalOut - both input and output use same path/loader."""
+    existing["new_key"] = "new_value"
+    return existing
+
+
+def test_pipeline_register_incremental_out_stage(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Pipeline.register() should succeed for stages using IncrementalOut.
+
+    IncrementalOut paths cannot be overridden (registry rejects path overrides
+    for them), so Pipeline must NOT pass IncrementalOut paths as overrides.
+    The paths remain as specified in the annotations (normalized by registry).
+    """
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    p = Pipeline("test", root=tmp_path / "subdir")
+
+    # This should NOT raise - IncrementalOut paths are not overridden
+    p.register(incremental_cache_stage)
+
+    # Verify the stage was registered
+    assert "incremental_cache_stage" in p.list_stages()
+    info = p.get("incremental_cache_stage")
+
+    # IncrementalOut path is preserved (not resolved relative to pipeline root)
+    # Registry normalizes it to absolute based on project root
+    assert info["outs_paths"][0].endswith("data/cache.yaml")

--- a/tests/test_file_out_integration.py
+++ b/tests/test_file_out_integration.py
@@ -53,7 +53,9 @@ def _assert_file_content(path: pathlib.Path, expected: dict[str, int | bool]) ->
 
 
 def test_missing_file_restored_on_cache_hit(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cache has file. Workspace missing file. Expected: Restore file.
 
@@ -62,31 +64,33 @@ def test_missing_file_restored_on_cache_hit(
     3. Run pipeline again
     4. Assert: stage skipped (not re-run), file restored from cache
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # First run - creates and caches file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    # First run - creates and caches file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
-        assert _get_run_count() == 1
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})
+    assert _get_run_count() == 1
 
-        # Delete output file
-        output_file.unlink()
-        assert not output_file.exists(), "File should be deleted"
+    # Delete output file
+    output_file.unlink()
+    assert not output_file.exists(), "File should be deleted"
 
-        # Second run - should skip and restore from cache
-        executor.run(pipeline=test_pipeline)
+    # Second run - should skip and restore from cache
+    executor.run(pipeline=test_pipeline)
 
-        # Verify: stage did NOT re-run (counter still 1)
-        assert _get_run_count() == 1, "Stage should have skipped, not re-run"
+    # Verify: stage did NOT re-run (counter still 1)
+    assert _get_run_count() == 1, "Stage should have skipped, not re-run"
 
-        # Verify: file restored from cache (run=1, not run=2)
-        assert output_file.exists(), "File should be restored"
-        _assert_file_content(output_file, {"value": 42, "run": 1})
+    # Verify: file restored from cache (run=1, not run=2)
+    assert output_file.exists(), "File should be restored"
+    _assert_file_content(output_file, {"value": 42, "run": 1})
 
 
 @pytest.mark.parametrize(
@@ -98,9 +102,9 @@ def test_missing_file_restored_on_cache_hit(
 )
 def test_corrupted_file_restored_on_cache_hit(
     runner: click.testing.CliRunner,
-    tmp_path: pathlib.Path,
     unlink_before_corrupt: bool,
-    test_pipeline: Pipeline,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cache has correct file. Workspace has corrupted file. Expected: Restore correct file.
 
@@ -112,41 +116,45 @@ def test_corrupted_file_restored_on_cache_hit(
     3. Run pipeline again
     4. Assert: stage skipped, file restored with correct content
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # First run - creates and caches file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    # First run - creates and caches file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
-        assert _get_run_count() == 1
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})
+    assert _get_run_count() == 1
 
-        # Corrupt file - handle read-only hardlinks by unlinking first
-        if unlink_before_corrupt:
+    # Corrupt file - handle read-only hardlinks by unlinking first
+    if unlink_before_corrupt:
+        output_file.unlink()
+    else:
+        # Check if file is read-only (hardlinked), unlink if needed
+        file_mode = output_file.stat().st_mode & 0o777
+        if file_mode == 0o444:
             output_file.unlink()
-        else:
-            # Check if file is read-only (hardlinked), unlink if needed
-            file_mode = output_file.stat().st_mode & 0o777
-            if file_mode == 0o444:
-                output_file.unlink()
-        output_file.write_text('{"corrupted": true}')
-        _assert_file_content(output_file, {"corrupted": True})
+    output_file.write_text('{"corrupted": true}')
+    _assert_file_content(output_file, {"corrupted": True})
 
-        # Second run - should skip and restore correct content
-        executor.run(pipeline=test_pipeline)
+    # Second run - should skip and restore correct content
+    executor.run(pipeline=test_pipeline)
 
-        # Verify: stage did NOT re-run
-        assert _get_run_count() == 1, "Stage should have skipped, not re-run"
+    # Verify: stage did NOT re-run
+    assert _get_run_count() == 1, "Stage should have skipped, not re-run"
 
-        # Verify: file restored with correct content
-        _assert_file_content(output_file, {"value": 42, "run": 1})
+    # Verify: file restored with correct content
+    _assert_file_content(output_file, {"value": 42, "run": 1})
 
 
 def test_corrupted_file_triggers_rerun_when_cache_empty(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cache empty, workspace has corrupted file. Expected: Re-run stage.
 
@@ -156,41 +164,44 @@ def test_corrupted_file_triggers_rerun_when_cache_empty(
     4. Run pipeline again
     5. Assert: stage RE-RUN (not skipped), file regenerated with run=2
     """
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    # First run - creates and caches file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        # First run - creates and caches file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})
+    assert _get_run_count() == 1
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
-        assert _get_run_count() == 1
+    # Clear the cache
+    cache_dir = tmp_path / ".pivot/cache/files"
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+        cache_dir.mkdir(parents=True)
 
-        # Clear the cache
-        cache_dir = pathlib.Path(".pivot/cache/files")
-        if cache_dir.exists():
-            shutil.rmtree(cache_dir)
-            cache_dir.mkdir(parents=True)
+    # Corrupt file
+    output_file.unlink()
+    output_file.write_text('{"corrupted": true}')
 
-        # Corrupt file
-        output_file.unlink()
-        output_file.write_text('{"corrupted": true}')
+    # Second run - should RE-RUN because cache can't restore
+    executor.run(pipeline=test_pipeline)
 
-        # Second run - should RE-RUN because cache can't restore
-        executor.run(pipeline=test_pipeline)
+    # Verify: stage DID re-run (counter is now 2)
+    assert _get_run_count() == 2, "Stage should have re-run when cache is empty"
 
-        # Verify: stage DID re-run (counter is now 2)
-        assert _get_run_count() == 2, "Stage should have re-run when cache is empty"
-
-        # Verify: file regenerated with run=2
-        _assert_file_content(output_file, {"value": 42, "run": 2})
+    # Verify: file regenerated with run=2
+    _assert_file_content(output_file, {"value": 42, "run": 2})
 
 
 def test_perfect_match_skips_without_modification(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cache and workspace are identical. Expected: Skip without touching file.
 
@@ -198,30 +209,34 @@ def test_perfect_match_skips_without_modification(
     2. Run pipeline again without any modifications
     3. Assert: stage skipped, file unchanged
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # First run - creates and caches file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    # First run - creates and caches file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
-        assert _get_run_count() == 1
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})
+    assert _get_run_count() == 1
 
-        # Second run - should skip
-        executor.run(pipeline=test_pipeline)
+    # Second run - should skip
+    executor.run(pipeline=test_pipeline)
 
-        # Verify: stage did NOT re-run
-        assert _get_run_count() == 1, "Stage should have skipped"
+    # Verify: stage did NOT re-run
+    assert _get_run_count() == 1, "Stage should have skipped"
 
-        # File still present with correct content
-        _assert_file_content(output_file, {"value": 42, "run": 1})
+    # File still present with correct content
+    _assert_file_content(output_file, {"value": 42, "run": 1})
 
 
 def test_invalid_json_in_corrupted_file_handled_gracefully(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Corrupted file with invalid JSON is detected and restored.
 
@@ -233,34 +248,38 @@ def test_invalid_json_in_corrupted_file_handled_gracefully(
     3. Run pipeline again
     4. Assert: stage skipped, file restored (not crash during skip detection)
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # First run - creates and caches file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    # First run - creates and caches file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
-        assert _get_run_count() == 1
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})
+    assert _get_run_count() == 1
 
-        # Corrupt with invalid JSON (not parseable)
-        output_file.unlink()
-        output_file.write_text('{"invalid": json content missing closing brace')
+    # Corrupt with invalid JSON (not parseable)
+    output_file.unlink()
+    output_file.write_text('{"invalid": json content missing closing brace')
 
-        # Second run - should skip and restore (not crash)
-        executor.run(pipeline=test_pipeline)
+    # Second run - should skip and restore (not crash)
+    executor.run(pipeline=test_pipeline)
 
-        # Verify: stage did NOT re-run
-        assert _get_run_count() == 1, "Stage should have skipped, not re-run"
+    # Verify: stage did NOT re-run
+    assert _get_run_count() == 1, "Stage should have skipped, not re-run"
 
-        # Verify: file restored with valid JSON
-        _assert_file_content(output_file, {"value": 42, "run": 1})
+    # Verify: file restored with valid JSON
+    _assert_file_content(output_file, {"value": 42, "run": 1})
 
 
 def test_cache_files_are_readonly_and_properly_structured(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify cache files are created read-only with correct hash structure.
 
@@ -269,42 +288,44 @@ def test_cache_files_are_readonly_and_properly_structured(
     2. Cache files are read-only (0o444)
     3. Cache files contain correct content
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # Run pipeline to cache file
-        register_test_stage(_stage_produces_single_file_with_marker, name="produce")
-        executor.run(pipeline=test_pipeline)
+    # Run pipeline to cache file
+    register_test_stage(_stage_produces_single_file_with_marker, name="produce")
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
-        assert output_file.exists()
+    output_file = tmp_path / "output.json"
+    assert output_file.exists()
 
-        # Find cache file
-        cache_dir = pathlib.Path(".pivot/cache/files")
-        assert cache_dir.exists(), "Cache directory should exist"
+    # Find cache file
+    cache_dir = tmp_path / ".pivot/cache/files"
+    assert cache_dir.exists(), "Cache directory should exist"
 
-        # Cache should have 2-char prefix directories
-        prefix_dirs = list(cache_dir.iterdir())
-        assert len(prefix_dirs) > 0, "Cache should contain prefix directories"
+    # Cache should have 2-char prefix directories
+    prefix_dirs = list(cache_dir.iterdir())
+    assert len(prefix_dirs) > 0, "Cache should contain prefix directories"
 
-        # Find cached file
-        cached_files = list[pathlib.Path]()
-        for prefix_dir in prefix_dirs:
-            if prefix_dir.is_dir():
-                cached_files.extend(prefix_dir.iterdir())
+    # Find cached file
+    cached_files = list[pathlib.Path]()
+    for prefix_dir in prefix_dirs:
+        if prefix_dir.is_dir():
+            cached_files.extend(prefix_dir.iterdir())
 
-        assert len(cached_files) >= 1, "At least one cache file should exist"
+    assert len(cached_files) >= 1, "At least one cache file should exist"
 
-        # Check first cached file
-        cache_file = cached_files[0]
+    # Check first cached file
+    cache_file = cached_files[0]
 
-        # Verify read-only
-        cache_mode = cache_file.stat().st_mode & 0o777
-        assert cache_mode == 0o444, f"Cache file should be read-only (0o444), got {oct(cache_mode)}"
+    # Verify read-only
+    cache_mode = cache_file.stat().st_mode & 0o777
+    assert cache_mode == 0o444, f"Cache file should be read-only (0o444), got {oct(cache_mode)}"
 
-        # Verify content matches
-        cache_content = json.loads(cache_file.read_text())
-        assert cache_content == {"value": 42, "run": 1}, "Cache content should match output"
+    # Verify content matches
+    cache_content = json.loads(cache_file.read_text())
+    assert cache_content == {"value": 42, "run": 1}, "Cache content should match output"
 
 
 class _FailingStageResult(TypedDict):
@@ -321,7 +342,9 @@ def _stage_fails_after_partial_write() -> _FailingStageResult:
 
 
 def test_stage_failure_leaves_workspace_consistent(
-    runner: click.testing.CliRunner, tmp_path: pathlib.Path, test_pipeline: Pipeline
+    runner: click.testing.CliRunner,
+    mock_discovery: Pipeline,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Stage failure after partial write leaves workspace consistent.
 
@@ -331,33 +354,35 @@ def test_stage_failure_leaves_workspace_consistent(
     3. Partial output is NOT cached
     4. Subsequent runs can succeed
     """
-    with runner.isolated_filesystem(temp_dir=tmp_path):
-        pathlib.Path(".git").mkdir()
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
 
-        # Register failing stage
-        register_test_stage(_stage_fails_after_partial_write, name="failing")
+    # Register failing stage
+    register_test_stage(_stage_fails_after_partial_write, name="failing")
 
-        # First run - should complete but stage fails
-        executor.run(pipeline=test_pipeline)
+    # First run - should complete but stage fails
+    executor.run(pipeline=test_pipeline)
 
-        output_file = pathlib.Path("output.json")
+    output_file = tmp_path / "output.json"
 
-        # Lock file should NOT be created/updated on failure
-        # (lock files are only written on successful stage completion)
-        lock_file = pathlib.Path(".pivot/stages/failing.lock")
-        assert not lock_file.exists(), "Lock file should not exist after stage failure"
+    # Lock file should NOT be created/updated on failure
+    # (lock files are only written on successful stage completion)
+    lock_file = tmp_path / ".pivot/stages/failing.lock"
+    assert not lock_file.exists(), "Lock file should not exist after stage failure"
 
-        # Clean up any partial output
-        if output_file.exists():
-            output_file.unlink()
+    # Clean up any partial output
+    if output_file.exists():
+        output_file.unlink()
 
-        # Register successful stage (clear registry first to allow re-registration)
-        test_pipeline.clear()
-        register_test_stage(_stage_produces_single_file_with_marker, name="failing")
+    # Register successful stage (clear registry first to allow re-registration)
+    test_pipeline.clear()
+    register_test_stage(_stage_produces_single_file_with_marker, name="failing")
 
-        # Second run - should succeed
-        executor.run(pipeline=test_pipeline)
+    # Second run - should succeed
+    executor.run(pipeline=test_pipeline)
 
-        # Verify success
-        assert output_file.exists()
-        _assert_file_content(output_file, {"value": 42, "run": 1})
+    # Verify success
+    assert output_file.exists()
+    _assert_file_content(output_file, {"value": 42, "run": 1})

--- a/tests/test_placeholder_dep.py
+++ b/tests/test_placeholder_dep.py
@@ -84,11 +84,12 @@ async def test_placeholder_dep_e2e_execution(
 
 
 def test_placeholder_dep_reuse_function_different_overrides(
-    test_pipeline: Pipeline,
-    tmp_path: pathlib.Path,
+    mock_discovery: Pipeline,
     comparison_data: tuple[pathlib.Path, pathlib.Path],
 ) -> None:
     """Same function can be registered multiple times with different overrides."""
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
     baseline_path, experiment_path = comparison_data
 
     # Create a third dataset
@@ -172,10 +173,8 @@ def test_placeholder_dep_override_validation(
 ) -> None:
     """PlaceholderDep stage validates override paths are provided at registration."""
     # Register stage without providing required override
-    # This should raise ValidationError at registration time
-    with pytest.raises(
-        exceptions.ValidationError, match="Placeholder dependencies missing overrides"
-    ):
+    # This should raise ValueError at registration time when PlaceholderDep override is missing
+    with pytest.raises(ValueError, match="PlaceholderDep.*requires override"):
         register_test_stage(
             _compare_datasets,
             name="compare_no_override",
@@ -188,11 +187,12 @@ def test_placeholder_dep_override_validation(
 
 
 def test_placeholder_dep_multiple_stages_independent_overrides(
-    test_pipeline: Pipeline,
-    tmp_path: pathlib.Path,
+    mock_discovery: Pipeline,
     comparison_data: tuple[pathlib.Path, pathlib.Path],
 ) -> None:
     """Multiple stages using same function maintain independent override namespaces."""
+    test_pipeline = mock_discovery
+    tmp_path = test_pipeline.root
     baseline_path, experiment_path = comparison_data
 
     # Create additional files

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,87 @@
+"""Tests for pivot.project module."""
+
+import pathlib
+
+import pytest
+
+from pivot import project
+
+
+def test_normalize_path_with_custom_base(tmp_path: pathlib.Path) -> None:
+    """Relative path resolved from custom base."""
+    custom_base = tmp_path / "custom" / "base"
+    custom_base.mkdir(parents=True)
+
+    result = project.normalize_path("foo/bar.txt", base=custom_base)
+
+    assert result == custom_base / "foo" / "bar.txt"
+
+
+def test_normalize_path_windows_backslash(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows backslash paths are normalized to POSIX: foo\\bar -> foo/bar."""
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = project.normalize_path("foo\\bar")
+
+    assert result == tmp_path / "foo" / "bar"
+
+
+def test_normalize_path_mixed_separators(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mixed separators are normalized: foo\\bar/baz -> foo/bar/baz."""
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = project.normalize_path("foo\\bar/baz")
+
+    assert result == tmp_path / "foo" / "bar" / "baz"
+
+
+def test_normalize_path_preserves_symlinks(tmp_path: pathlib.Path) -> None:
+    """Symlink paths are preserved, not resolved to target."""
+    # Create actual directory and a symlink to it
+    actual_dir = tmp_path / "actual"
+    actual_dir.mkdir()
+    (actual_dir / "file.txt").write_text("content")
+
+    symlink_dir = tmp_path / "link"
+    symlink_dir.symlink_to(actual_dir)
+
+    # normalize_path should preserve the symlink path, not resolve to actual
+    result = project.normalize_path("link/file.txt", base=tmp_path)
+
+    assert result == tmp_path / "link" / "file.txt"
+    # Verify we didn't resolve to target
+    assert "actual" not in str(result)
+
+
+def test_normalize_path_collapses_dotdot(tmp_path: pathlib.Path) -> None:
+    """Parent directory references are collapsed: foo/../bar -> bar."""
+    result = project.normalize_path("foo/../bar", base=tmp_path)
+
+    assert result == tmp_path / "bar"
+
+
+def test_normalize_path_absolute_path_unchanged(tmp_path: pathlib.Path) -> None:
+    """Absolute paths are not affected by base parameter."""
+    custom_base = tmp_path / "custom"
+    custom_base.mkdir()
+    absolute_path = tmp_path / "absolute" / "path.txt"
+
+    result = project.normalize_path(absolute_path, base=custom_base)
+
+    # Should be the absolute path (normalized), not relative to custom_base
+    assert result == tmp_path / "absolute" / "path.txt"
+
+
+def test_normalize_path_default_base_is_project_root(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When base is None, project root is used (preserving existing behavior)."""
+    monkeypatch.setattr(project, "_project_root_cache", tmp_path)
+
+    result = project.normalize_path("relative/path.txt")
+
+    assert result == tmp_path / "relative" / "path.txt"

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -65,7 +65,7 @@ def test_pipeline_status_all_cached(
     test_pipeline: pipeline_mod.Pipeline,
 ) -> None:
     """All stages should show cached after successful run."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -85,7 +85,7 @@ def test_pipeline_status_some_stale(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """Stages with changed code should show stale."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -103,7 +103,7 @@ def test_pipeline_status_upstream_stale(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """Stage should be marked stale if upstream is stale."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -128,7 +128,7 @@ def test_pipeline_status_specific_stages(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """Should only return status for specified stages."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -148,7 +148,7 @@ def test_pipeline_status_specific_stages(
 
 def test_tracked_files_clean(set_project_root: pathlib.Path) -> None:
     """Tracked file should show clean when unchanged."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     data_file = set_project_root / "data.txt"
     data_file.write_text("content")
@@ -166,7 +166,7 @@ def test_tracked_files_clean(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_files_modified(set_project_root: pathlib.Path) -> None:
     """Tracked file should show modified when changed."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     data_file = set_project_root / "data.txt"
     data_file.write_text("original")
@@ -186,7 +186,7 @@ def test_tracked_files_modified(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_files_missing(set_project_root: pathlib.Path) -> None:
     """Tracked file should show missing when deleted."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     pvt_data = track.PvtData(path="data.txt", hash="abc123", size=100)
     track.write_pvt_file(set_project_root / "data.txt.pvt", pvt_data)
@@ -200,7 +200,7 @@ def test_tracked_files_missing(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_files_empty(set_project_root: pathlib.Path) -> None:
     """Should return empty list when no tracked files."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     results = status.get_tracked_files_status(set_project_root)
 
@@ -209,7 +209,7 @@ def test_tracked_files_empty(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_directory_clean(set_project_root: pathlib.Path) -> None:
     """Tracked directory should show clean when unchanged."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     data_dir = set_project_root / "data"
     data_dir.mkdir()
@@ -231,7 +231,7 @@ def test_tracked_directory_clean(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_directory_modified(set_project_root: pathlib.Path) -> None:
     """Tracked directory should show modified when contents change."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     data_dir = set_project_root / "data"
     data_dir.mkdir()
@@ -254,7 +254,7 @@ def test_tracked_directory_modified(set_project_root: pathlib.Path) -> None:
 
 def test_tracked_files_progress_callback(set_project_root: pathlib.Path) -> None:
     """Progress callback should be called with (completed, total) for each file."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
 
     # Create two tracked files
     file1 = set_project_root / "file1.txt"
@@ -437,7 +437,7 @@ def test_get_pipeline_status_uses_provided_graph(
     """get_pipeline_status uses provided graph instead of building one."""
     from pivot.engine import graph as engine_graph
 
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "test_input.txt").write_text("data")
 
     register_test_stage(_helper_test_stage, name="test_stage")
@@ -471,7 +471,7 @@ def test_get_pipeline_explanations_uses_provided_graph(
     """get_pipeline_explanations uses provided graph instead of building one."""
     from pivot.engine import graph as engine_graph
 
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "test_input.txt").write_text("data")
 
     register_test_stage(_helper_test_stage, name="test_stage")
@@ -502,7 +502,7 @@ def test_what_if_changed_single_path(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """what_if_changed returns affected stages for a single path."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -520,7 +520,7 @@ def test_what_if_changed_intermediate_path(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """what_if_changed returns only downstream stages for intermediate artifact."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -538,7 +538,7 @@ def test_what_if_changed_unknown_path(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """what_if_changed returns empty list for unknown paths."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -553,7 +553,7 @@ def test_what_if_changed_multiple_paths(
     set_project_root: pathlib.Path, test_pipeline: pipeline_mod.Pipeline
 ) -> None:
     """what_if_changed returns union of affected stages for multiple paths."""
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")
@@ -579,7 +579,7 @@ def test_what_if_changed_with_provided_graph(
     """what_if_changed uses provided graph instead of building one."""
     from pivot.engine import graph as engine_graph
 
-    (set_project_root / ".git").mkdir()
+    (set_project_root / ".git").mkdir(exist_ok=True)
     (set_project_root / "input.txt").write_text("data")
 
     register_test_stage(_helper_stage_a, name="stage_a")


### PR DESCRIPTION
## Summary

Allow stage annotations to use simple relative paths that resolve relative to the pipeline's root directory, enabling cleaner code without verbose path prefixes.

- Extend `project.normalize_path()` with `base` parameter and Windows support
- Add `_resolve_path()` family of methods to Pipeline for path resolution
- `Pipeline.register()` now resolves annotation paths relative to pipeline root
- Skip IncrementalOut from path overrides (registry rejects them)
- Cross-pipeline references work with `../` syntax

## Test plan

- [x] Unit tests for `normalize_path()` with custom base
- [x] Unit tests for `_resolve_path()` edge cases (empty, whitespace, root-only, Windows)
- [x] Integration tests for cross-pipeline deps with `../`
- [x] Test IncrementalOut stage registration succeeds
- [x] Test deepcopy failure atomicity for `Pipeline.include()`
- [x] All 3033 tests pass
- [x] basedpyright, ruff check, ruff format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)