### PR TITLE
feat(pipeline): lazy dependency resolution from parent pipelines

### DIFF
--- a/docs/plans/2026-02-03-lazy-pipeline-resolution.md
+++ b/docs/plans/2026-02-03-lazy-pipeline-resolution.md
@@ -4,426 +4,297 @@
 
 **Goal:** Enable pipelines to automatically discover and include stages from parent pipelines when dependencies are unresolved locally.
 
-**Architecture:** When `build_dag()` finds an unresolved dependency, traverse up the directory tree looking for `pipeline.py` files, load each parent pipeline, find the stage that produces the needed artifact, and include it (plus transitive dependencies). This is lazy loading - the project DAG is unchanged, we just don't load all of it upfront.
+**Architecture:** Add `resolve_from_parents()` method to Pipeline that traverses up the directory tree, loads parent pipelines, and includes stages that produce needed artifacts. Uses iterative work-queue algorithm with per-call caching (parent pipelines cached within single resolve call, discarded after).
 
 **Tech Stack:** Python 3.13+, networkx, pytest
 
 ---
 
-## Task 1: Add Parent Pipeline Discovery Function
+## Task 1: Add Parent Pipeline Path Discovery to discovery.py
 
 **Files:**
-- Create: `src/pivot/pipeline/discovery.py` (new module for pipeline discovery utilities)
-- Test: `tests/pipeline/test_discovery.py`
+- Modify: `src/pivot/discovery.py`
+- Test: `tests/test_discovery.py`
 
-**Step 1: Write the failing test for directory traversal**
+**Step 1: Write the failing test**
 
 ```python
-# tests/pipeline/test_discovery.py
-from __future__ import annotations
-
+# Add to tests/test_discovery.py
 import pathlib
 
-from pivot.pipeline import discovery
+from pivot import discovery
 
 
-def test_find_parent_pipeline_files_finds_pipeline_in_parent(tmp_path: pathlib.Path) -> None:
-    """Should find pipeline.py in parent directories."""
-    # Create directory structure:
-    # tmp_path/
-    #   pipeline.py
-    #   sub/
-    #     child/
-    #       pipeline.py  <- start here
-    (tmp_path / "pipeline.py").touch()
-    child_dir = tmp_path / "sub" / "child"
-    child_dir.mkdir(parents=True)
-    (child_dir / "pipeline.py").touch()
-
-    result = list(discovery.find_parent_pipeline_files(child_dir, stop_at=tmp_path))
-
-    # Should find parent's pipeline.py (not child's own)
-    assert result == [tmp_path / "pipeline.py"]
-
-
-def test_find_parent_pipeline_files_stops_at_boundary(tmp_path: pathlib.Path) -> None:
-    """Should stop traversal at specified boundary."""
-    # Create pipeline.py above the stop boundary
-    above_boundary = tmp_path / "above"
-    above_boundary.mkdir()
-    (above_boundary / "pipeline.py").touch()
-
-    project_root = above_boundary / "project"
-    project_root.mkdir()
-    (project_root / "pipeline.py").touch()
-
-    child = project_root / "sub"
-    child.mkdir()
-    (child / "pipeline.py").touch()
-
-    result = list(discovery.find_parent_pipeline_files(child, stop_at=project_root))
-
-    # Should find project root's pipeline.py but not above
-    assert result == [project_root / "pipeline.py"]
-
-
-def test_find_parent_pipeline_files_returns_multiple_in_order(tmp_path: pathlib.Path) -> None:
-    """Should return all parent pipeline.py files, closest first."""
+def test_find_parent_pipeline_paths_finds_pipeline_py(tmp_path: pathlib.Path) -> None:
+    """Should find pipeline.py in parent directories, closest first."""
     (tmp_path / "pipeline.py").touch()
     mid = tmp_path / "mid"
     mid.mkdir()
     (mid / "pipeline.py").touch()
     child = mid / "child"
     child.mkdir()
-    (child / "pipeline.py").touch()
 
-    result = list(discovery.find_parent_pipeline_files(child, stop_at=tmp_path))
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=tmp_path))
 
-    # Closest parent first
     assert result == [mid / "pipeline.py", tmp_path / "pipeline.py"]
 
 
-def test_find_parent_pipeline_files_skips_own_directory(tmp_path: pathlib.Path) -> None:
-    """Should not include pipeline.py from the start directory itself."""
+def test_find_parent_pipeline_paths_finds_pivot_yaml(tmp_path: pathlib.Path) -> None:
+    """Should find pivot.yaml in parent directories."""
+    (tmp_path / "pivot.yaml").touch()
+    child = tmp_path / "child"
+    child.mkdir()
+
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=tmp_path))
+
+    assert result == [tmp_path / "pivot.yaml"]
+
+
+def test_find_parent_pipeline_paths_errors_on_both(tmp_path: pathlib.Path) -> None:
+    """Should error if directory has both pipeline.py and pivot.yaml."""
+    (tmp_path / "pipeline.py").touch()
+    (tmp_path / "pivot.yaml").touch()
+    child = tmp_path / "child"
+    child.mkdir()
+
+    with pytest.raises(discovery.DiscoveryError, match="Found both"):
+        list(discovery.find_parent_pipeline_paths(child, stop_at=tmp_path))
+
+
+def test_find_parent_pipeline_paths_skips_own_directory(tmp_path: pathlib.Path) -> None:
+    """Should not include start directory's own pipeline file."""
     (tmp_path / "pipeline.py").touch()
 
-    result = list(discovery.find_parent_pipeline_files(tmp_path, stop_at=tmp_path.parent))
+    result = list(discovery.find_parent_pipeline_paths(tmp_path, stop_at=tmp_path.parent))
 
     assert result == []
 ```
 
 **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/pipeline/test_discovery.py -v`
-Expected: FAIL with "ModuleNotFoundError" or "ImportError"
-
-**Step 3: Write minimal implementation**
-
-```python
-# src/pivot/pipeline/discovery.py
-from __future__ import annotations
-
-import pathlib
-from collections.abc import Iterator
-
-PIPELINE_PY_NAME = "pipeline.py"
-
-
-def find_parent_pipeline_files(
-    start_dir: pathlib.Path,
-    stop_at: pathlib.Path,
-) -> Iterator[pathlib.Path]:
-    """Find pipeline.py files in parent directories.
-
-    Traverses up from start_dir (exclusive) to stop_at (inclusive),
-    yielding each pipeline.py found. Closest parents are yielded first.
-
-    Args:
-        start_dir: Directory to start from (its pipeline.py is NOT included).
-        stop_at: Stop traversal at this directory (inclusive).
-
-    Yields:
-        Paths to pipeline.py files found in parent directories.
-    """
-    current = start_dir.resolve()
-    stop_at = stop_at.resolve()
-
-    # Move to parent (don't include start_dir's own pipeline.py)
-    current = current.parent
-
-    while True:
-        pipeline_file = current / PIPELINE_PY_NAME
-        if pipeline_file.exists():
-            yield pipeline_file
-
-        # Stop if we've reached the boundary
-        if current == stop_at:
-            break
-
-        # Stop if we've reached filesystem root
-        if current.parent == current:
-            break
-
-        current = current.parent
-```
-
-**Step 4: Run test to verify it passes**
-
-Run: `uv run pytest tests/pipeline/test_discovery.py -v`
-Expected: PASS
-
-**Step 5: Commit**
-
-```bash
-jj describe -m "feat(pipeline): add find_parent_pipeline_files for lazy resolution"
-```
-
----
-
-## Task 2: Add Parent Pipeline Loading Function
-
-**Files:**
-- Modify: `src/pivot/pipeline/discovery.py`
-- Test: `tests/pipeline/test_discovery.py`
-
-**Step 1: Write the failing test for loading parent pipeline**
-
-```python
-# Add to tests/pipeline/test_discovery.py
-from pivot.pipeline.pipeline import Pipeline
-
-
-def test_load_parent_pipeline_loads_valid_pipeline(
-    tmp_path: pathlib.Path, mocker
-) -> None:
-    """Should load and return Pipeline from pipeline.py file."""
-    from pivot import project
-
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    # Create a pipeline.py with a simple pipeline
-    pipeline_code = '''
-from pivot.pipeline import Pipeline
-
-pipeline = Pipeline("parent")
-'''
-    (tmp_path / "pipeline.py").write_text(pipeline_code)
-
-    result = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
-
-    assert result is not None
-    assert result.name == "parent"
-
-
-def test_load_parent_pipeline_returns_none_for_no_pipeline_var(
-    tmp_path: pathlib.Path, mocker
-) -> None:
-    """Should return None if pipeline.py doesn't define 'pipeline' variable."""
-    from pivot import project
-
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    # Create a pipeline.py without pipeline variable
-    (tmp_path / "pipeline.py").write_text("x = 1\n")
-
-    result = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
-
-    assert result is None
-
-
-def test_load_parent_pipeline_caches_loaded_pipelines(
-    tmp_path: pathlib.Path, mocker
-) -> None:
-    """Should cache loaded pipelines to avoid re-parsing."""
-    from pivot import project
-
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    pipeline_code = '''
-from pivot.pipeline import Pipeline
-
-pipeline = Pipeline("cached")
-'''
-    (tmp_path / "pipeline.py").write_text(pipeline_code)
-
-    # Load twice
-    result1 = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
-    result2 = discovery.load_parent_pipeline(tmp_path / "pipeline.py")
-
-    # Should return same object (cached)
-    assert result1 is result2
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `uv run pytest tests/pipeline/test_discovery.py::test_load_parent_pipeline_loads_valid_pipeline -v`
-Expected: FAIL with "AttributeError" (function doesn't exist)
-
-**Step 3: Write minimal implementation**
-
-```python
-# Add to src/pivot/pipeline/discovery.py
-import runpy
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pivot.pipeline.pipeline import Pipeline
-
-# Cache for loaded parent pipelines (path -> Pipeline)
-_parent_pipeline_cache: dict[pathlib.Path, Pipeline | None] = {}
-
-
-def load_parent_pipeline(pipeline_path: pathlib.Path) -> Pipeline | None:
-    """Load a Pipeline from a pipeline.py file.
-
-    Results are cached to avoid re-parsing the same file multiple times.
-
-    Args:
-        pipeline_path: Path to pipeline.py file.
-
-    Returns:
-        Pipeline instance if file defines 'pipeline' variable, None otherwise.
-    """
-    from pivot.pipeline.pipeline import Pipeline
-
-    resolved = pipeline_path.resolve()
-    if resolved in _parent_pipeline_cache:
-        return _parent_pipeline_cache[resolved]
-
-    try:
-        module_dict = runpy.run_path(str(resolved), run_name="_pivot_parent_pipeline")
-    except Exception:
-        _parent_pipeline_cache[resolved] = None
-        return None
-
-    pipeline = module_dict.get("pipeline")
-    if pipeline is not None and isinstance(pipeline, Pipeline):
-        _parent_pipeline_cache[resolved] = pipeline
-        return pipeline
-
-    _parent_pipeline_cache[resolved] = None
-    return None
-
-
-def clear_parent_pipeline_cache() -> None:
-    """Clear the parent pipeline cache (for testing)."""
-    _parent_pipeline_cache.clear()
-```
-
-**Step 4: Run test to verify it passes**
-
-Run: `uv run pytest tests/pipeline/test_discovery.py::test_load_parent_pipeline_loads_valid_pipeline tests/pipeline/test_discovery.py::test_load_parent_pipeline_returns_none_for_no_pipeline_var tests/pipeline/test_discovery.py::test_load_parent_pipeline_caches_loaded_pipelines -v`
-Expected: PASS
-
-**Step 5: Add fixture to clear cache between tests**
-
-```python
-# Add to tests/pipeline/test_discovery.py at top
-import pytest
-
-@pytest.fixture(autouse=True)
-def clear_discovery_cache() -> None:
-    """Clear parent pipeline cache before each test."""
-    discovery.clear_parent_pipeline_cache()
-```
-
-**Step 6: Commit**
-
-```bash
-jj describe -m "feat(pipeline): add load_parent_pipeline with caching"
-```
-
----
-
-## Task 3: Add Producer Search in Parent Pipeline
-
-**Files:**
-- Modify: `src/pivot/pipeline/discovery.py`
-- Test: `tests/pipeline/test_discovery.py`
-
-**Step 1: Write the failing test**
-
-```python
-# Add to tests/pipeline/test_discovery.py
-from typing import Annotated
-from pathlib import Path
-
-from pivot import loaders
-from pivot.outputs import Out, Dep
-
-
-def test_find_producer_in_pipeline_finds_matching_stage(
-    tmp_path: pathlib.Path, mocker
-) -> None:
-    """Should find stage that produces the requested path."""
-    from pivot import project
-
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    # Create pipeline with a stage that produces output.txt
-    pipeline = Pipeline("test", root=tmp_path)
-
-    class Output(TypedDict):
-        data: Annotated[Path, Out("output.txt", loaders.PathOnly())]
-
-    def producer() -> Output:
-        return Output(data=Path("output.txt"))
-
-    pipeline.register(producer)
-
-    # Search for the producer of output.txt (absolute path)
-    abs_path = str(tmp_path / "output.txt")
-    result = discovery.find_producer_in_pipeline(pipeline, abs_path)
-
-    assert result == "producer"
-
-
-def test_find_producer_in_pipeline_returns_none_if_not_found(
-    tmp_path: pathlib.Path, mocker
-) -> None:
-    """Should return None if no stage produces the path."""
-    from pivot import project
-
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    pipeline = Pipeline("test", root=tmp_path)
-
-    result = discovery.find_producer_in_pipeline(pipeline, "/nonexistent/path.txt")
-
-    assert result is None
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `uv run pytest tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_finds_matching_stage -v`
+Run: `uv run pytest tests/test_discovery.py::test_find_parent_pipeline_paths_finds_pipeline_py -v`
 Expected: FAIL with "AttributeError"
 
 **Step 3: Write minimal implementation**
 
 ```python
-# Add to src/pivot/pipeline/discovery.py
-def find_producer_in_pipeline(pipeline: Pipeline, dep_path: str) -> str | None:
-    """Find stage in pipeline that produces the given path.
+# Add to src/pivot/discovery.py after existing imports
+from collections.abc import Iterator
+
+
+def find_parent_pipeline_paths(
+    start_dir: Path,
+    stop_at: Path,
+) -> Iterator[Path]:
+    """Find pipeline config files in parent directories.
+
+    Traverses up from start_dir (exclusive) to stop_at (inclusive),
+    yielding each pivot.yaml or pipeline.py found. Closest parents first.
+    Errors if any directory has both.
 
     Args:
-        pipeline: Pipeline to search.
-        dep_path: Absolute path to look for as an output.
+        start_dir: Directory to start from (its config is NOT included).
+        stop_at: Stop traversal at this directory (inclusive).
 
-    Returns:
-        Stage name if found, None otherwise.
+    Yields:
+        Paths to pivot.yaml or pipeline.py files.
+
+    Raises:
+        DiscoveryError: If a directory has both pivot.yaml and pipeline.py.
     """
-    for stage_name in pipeline.list_stages():
-        stage_info = pipeline.get(stage_name)
-        if dep_path in stage_info["outs_paths"]:
-            return stage_name
-    return None
+    import pathlib
+
+    current = pathlib.Path(start_dir).resolve().parent
+    stop_at_resolved = pathlib.Path(stop_at).resolve()
+
+    while True:
+        # Check for config files (same logic as discover_pipeline)
+        yaml_path = None
+        for yaml_name in PIVOT_YAML_NAMES:
+            candidate = current / yaml_name
+            if candidate.exists():
+                yaml_path = candidate
+                break
+
+        pipeline_path = current / PIPELINE_PY_NAME
+        pipeline_exists = pipeline_path.exists()
+
+        if yaml_path and pipeline_exists:
+            raise DiscoveryError(
+                f"Found both {yaml_path.name} and {PIPELINE_PY_NAME} in {current}. "
+                "Remove one to resolve ambiguity."
+            )
+
+        if yaml_path:
+            yield yaml_path
+        elif pipeline_exists:
+            yield pipeline_path
+
+        if current == stop_at_resolved or current.parent == current:
+            break
+        current = current.parent
 ```
 
 **Step 4: Run test to verify it passes**
 
-Run: `uv run pytest tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_finds_matching_stage tests/pipeline/test_discovery.py::test_find_producer_in_pipeline_returns_none_if_not_found -v`
+Run: `uv run pytest tests/test_discovery.py::test_find_parent_pipeline_paths_finds_pipeline_py tests/test_discovery.py::test_find_parent_pipeline_paths_finds_pivot_yaml tests/test_discovery.py::test_find_parent_pipeline_paths_errors_on_both tests/test_discovery.py::test_find_parent_pipeline_paths_skips_own_directory -v`
 Expected: PASS
 
 **Step 5: Commit**
 
 ```bash
-jj describe -m "feat(pipeline): add find_producer_in_pipeline"
+jj describe -m "feat(discovery): add find_parent_pipeline_paths"
 ```
 
 ---
 
-## Task 4: Add resolve_from_parents Method to Pipeline
+## Task 2: Make load_pipeline_from_module Public
+
+**Files:**
+- Modify: `src/pivot/discovery.py`
+- Test: `tests/test_discovery.py`
+
+**Step 1: Write the failing test**
+
+```python
+# Add to tests/test_discovery.py
+from pytest_mock import MockerFixture
+
+from pivot import project
+
+
+def test_load_pipeline_from_path_loads_pipeline_py(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should load Pipeline from pipeline.py file."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    pipeline_code = '''
+from pivot.pipeline import Pipeline
+pipeline = Pipeline("test")
+'''
+    (tmp_path / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.load_pipeline_from_path(tmp_path / "pipeline.py")
+
+    assert result is not None
+    assert result.name == "test"
+
+
+def test_load_pipeline_from_path_loads_pivot_yaml(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should load Pipeline from pivot.yaml file."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    yaml_content = '''
+stages:
+  - name: example
+    cmd: echo hello
+'''
+    (tmp_path / "pivot.yaml").write_text(yaml_content)
+
+    result = discovery.load_pipeline_from_path(tmp_path / "pivot.yaml")
+
+    assert result is not None
+
+
+def test_load_pipeline_from_path_returns_none_for_no_pipeline(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Should return None if file doesn't define a pipeline."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pipeline.py").write_text("x = 1\n")
+
+    result = discovery.load_pipeline_from_path(tmp_path / "pipeline.py")
+
+    assert result is None
+
+
+def test_load_pipeline_from_path_logs_errors(
+    tmp_path: pathlib.Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Should log errors when loading fails."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pipeline.py").write_text("raise RuntimeError('fail')")
+
+    import logging
+    with caplog.at_level(logging.DEBUG):
+        result = discovery.load_pipeline_from_path(tmp_path / "pipeline.py")
+
+    assert result is None
+    assert "Failed to load" in caplog.text
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_discovery.py::test_load_pipeline_from_path_loads_pipeline_py -v`
+Expected: FAIL with "AttributeError"
+
+**Step 3: Write implementation**
+
+```python
+# Add to src/pivot/discovery.py
+
+def load_pipeline_from_path(path: Path) -> Pipeline | None:
+    """Load a Pipeline from a pivot.yaml or pipeline.py file.
+
+    Args:
+        path: Path to pivot.yaml or pipeline.py file.
+
+    Returns:
+        Pipeline instance, or None if file doesn't define one.
+        Returns None (with debug log) on load errors.
+    """
+    import pathlib
+
+    path = pathlib.Path(path)
+
+    # Determine file type and load accordingly
+    if path.name in PIVOT_YAML_NAMES:
+        try:
+            return pipeline_config.load_pipeline_from_yaml(path)
+        except Exception as e:
+            logger.debug(f"Failed to load pipeline from {path}: {e}")
+            return None
+    elif path.name == PIPELINE_PY_NAME:
+        try:
+            return _load_pipeline_from_module(path)
+        except DiscoveryError:
+            # DiscoveryError means file exists but no valid pipeline
+            return None
+        except Exception as e:
+            logger.debug(f"Failed to load pipeline from {path}: {e}")
+            return None
+    else:
+        logger.debug(f"Unknown pipeline file type: {path}")
+        return None
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_discovery.py::test_load_pipeline_from_path_loads_pipeline_py tests/test_discovery.py::test_load_pipeline_from_path_loads_pivot_yaml tests/test_discovery.py::test_load_pipeline_from_path_returns_none_for_no_pipeline tests/test_discovery.py::test_load_pipeline_from_path_logs_errors -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj describe -m "feat(discovery): add load_pipeline_from_path for lazy resolution"
+```
+
+---
+
+## Task 3: Add resolve_from_parents Method to Pipeline
 
 **Files:**
 - Modify: `src/pivot/pipeline/pipeline.py`
 - Test: `tests/pipeline/test_pipeline.py`
 
-**Step 1: Write the failing test**
+**Step 1: Write the failing test for basic resolution**
 
 ```python
 # Add to tests/pipeline/test_pipeline.py
@@ -437,23 +308,11 @@ from pivot.outputs import Out, Dep
 def test_pipeline_resolve_from_parents_includes_producer(
     tmp_path: pathlib.Path, mocker: MockerFixture
 ) -> None:
-    """Should include producer stage from parent pipeline when dependency unresolved."""
+    """Should include producer stage from parent pipeline."""
     mocker.patch.object(project, "_project_root_cache", tmp_path)
     (tmp_path / ".git").mkdir()
 
     # Parent pipeline at project root
-    parent = Pipeline("parent", root=tmp_path)
-
-    class ProducerOutput(TypedDict):
-        data: Annotated[Path, Out("shared/data.txt", loaders.PathOnly())]
-
-    def producer() -> ProducerOutput:
-        Path("shared/data.txt").write_text("data")
-        return ProducerOutput(data=Path("shared/data.txt"))
-
-    parent.register(producer)
-
-    # Save parent pipeline to file
     parent_code = '''
 from typing import Annotated, TypedDict
 from pathlib import Path
@@ -467,6 +326,7 @@ class ProducerOutput(TypedDict):
     data: Annotated[Path, Out("shared/data.txt", loaders.PathOnly())]
 
 def producer() -> ProducerOutput:
+    Path("shared").mkdir(exist_ok=True)
     Path("shared/data.txt").write_text("data")
     return ProducerOutput(data=Path("shared/data.txt"))
 
@@ -547,151 +407,47 @@ pipeline.register(stage_b)
 
     child.resolve_from_parents()
 
-    # Should include both stage_a and stage_b
     assert "stage_a" in child.list_stages()
     assert "stage_b" in child.list_stages()
     assert "consumer" in child.list_stages()
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer -v`
-Expected: FAIL with "AttributeError: 'Pipeline' object has no attribute 'resolve_from_parents'"
-
-**Step 3: Write minimal implementation**
-
-```python
-# Add to src/pivot/pipeline/pipeline.py
-
-# Add import at top
-from pivot.pipeline import discovery as pipeline_discovery
-
-# Add method to Pipeline class
-def resolve_from_parents(self) -> None:
-    """Resolve unresolved dependencies by searching parent pipelines.
-
-    For each dependency that has no local producer:
-    1. Traverse up directory tree looking for pipeline.py files
-    2. Load each parent pipeline and search for a stage producing the dependency
-    3. Include that stage (and recursively resolve its dependencies)
-
-    Dependencies that exist on disk or have no producer anywhere are left as-is
-    (treated as external inputs).
-
-    Raises:
-        PipelineConfigError: If multiple parent pipelines produce the same artifact.
-    """
-    project_root = project.get_project_root()
-
-    # Build local outputs map
-    local_outputs = set[str]()
-    for stage_name in self.list_stages():
-        stage_info = self.get(stage_name)
-        local_outputs.update(stage_info["outs_paths"])
-
-    # Find unresolved dependencies
-    unresolved = set[str]()
-    for stage_name in self.list_stages():
-        stage_info = self.get(stage_name)
-        for dep_path in stage_info["deps_paths"]:
-            if dep_path not in local_outputs:
-                unresolved.add(dep_path)
-
-    # Resolve from parents
-    self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
 
 
-def _resolve_deps_from_parents(
-    self,
-    unresolved: set[str],
-    local_outputs: set[str],
-    project_root: pathlib.Path,
-) -> None:
-    """Recursively resolve dependencies from parent pipelines."""
-    if not unresolved:
-        return
-
-    # Find parent pipeline files
-    parent_files = list(pipeline_discovery.find_parent_pipeline_files(self.root, project_root))
-    if not parent_files:
-        return  # No parents to search
-
-    newly_included = list[str]()
-
-    for dep_path in list(unresolved):
-        # Skip if file exists on disk (external input)
-        if pathlib.Path(dep_path).exists():
-            unresolved.discard(dep_path)
-            continue
-
-        # Search parent pipelines for producer
-        for parent_file in parent_files:
-            parent = pipeline_discovery.load_parent_pipeline(parent_file)
-            if parent is None:
-                continue
-
-            producer_name = pipeline_discovery.find_producer_in_pipeline(parent, dep_path)
-            if producer_name is None:
-                continue
-
-            # Check for duplicate producer (error condition)
-            if producer_name in self._registry.list_stages():
-                # Already included, dependency resolved
-                unresolved.discard(dep_path)
-                break
-
-            # Include the producer stage
-            import copy
-            stage_info = copy.deepcopy(parent.get(producer_name))
-            self._registry.add_existing(stage_info)
-            newly_included.append(producer_name)
-            local_outputs.update(stage_info["outs_paths"])
-            unresolved.discard(dep_path)
-
-            # Add producer's dependencies to unresolved
-            for producer_dep in stage_info["deps_paths"]:
-                if producer_dep not in local_outputs:
-                    unresolved.add(producer_dep)
-
-            logger.debug(f"Included stage '{producer_name}' from parent pipeline '{parent.name}'")
-            break
-
-    # Recurse if we added stages with new dependencies
-    if newly_included and unresolved:
-        self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
-```
-
-**Step 4: Run test to verify it passes**
-
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_transitive_deps -v`
-Expected: PASS
-
-**Step 5: Commit**
-
-```bash
-jj describe -m "feat(pipeline): add resolve_from_parents for lazy dependency resolution"
-```
-
----
-
-## Task 5: Integrate resolve_from_parents into build_dag
-
-**Files:**
-- Modify: `src/pivot/pipeline/pipeline.py`
-- Test: `tests/pipeline/test_pipeline.py`
-
-**Step 1: Write the failing test**
-
-```python
-# Add to tests/pipeline/test_pipeline.py
-def test_pipeline_build_dag_auto_resolves_from_parents(
+def test_pipeline_resolve_from_parents_skips_existing_files(
     tmp_path: pathlib.Path, mocker: MockerFixture
 ) -> None:
-    """build_dag should automatically resolve dependencies from parents."""
+    """Should treat existing files as external inputs."""
     mocker.patch.object(project, "_project_root_cache", tmp_path)
     (tmp_path / ".git").mkdir()
 
-    # Parent pipeline
+    # Create external input file
+    (tmp_path / "external.txt").write_text("external data")
+
+    # No parent pipeline
+    child = Pipeline("child", root=tmp_path)
+
+    class ConsumerOutput(TypedDict):
+        result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
+
+    def consumer(
+        data: Annotated[Path, Dep("external.txt", loaders.PathOnly())]
+    ) -> ConsumerOutput:
+        return ConsumerOutput(result=Path("result.txt"))
+
+    child.register(consumer)
+
+    # Should not raise, external.txt exists
+    child.resolve_from_parents()
+
+    assert child.list_stages() == ["consumer"]
+
+
+def test_pipeline_resolve_from_parents_is_idempotent(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Calling resolve_from_parents multiple times should be safe."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir()
+
     parent_code = '''
 from typing import Annotated, TypedDict
 from pathlib import Path
@@ -701,17 +457,16 @@ from pivot.outputs import Out
 
 pipeline = Pipeline("parent")
 
-class ProducerOutput(TypedDict):
+class Output(TypedDict):
     data: Annotated[Path, Out("data.txt", loaders.PathOnly())]
 
-def producer() -> ProducerOutput:
-    return ProducerOutput(data=Path("data.txt"))
+def producer() -> Output:
+    return Output(data=Path("data.txt"))
 
 pipeline.register(producer)
 '''
     (tmp_path / "pipeline.py").write_text(parent_code)
 
-    # Child pipeline
     child_dir = tmp_path / "child"
     child_dir.mkdir()
     child = Pipeline("child", root=child_dir)
@@ -726,230 +481,133 @@ pipeline.register(producer)
 
     child.register(consumer)
 
-    # build_dag should auto-resolve
-    dag = child.build_dag(validate=True)
+    child.resolve_from_parents()
+    count_after_first = len(child.list_stages())
 
-    assert "producer" in dag.nodes
-    assert "consumer" in dag.nodes
-    assert dag.has_edge("consumer", "producer")
+    child.resolve_from_parents()
+    count_after_second = len(child.list_stages())
+
+    assert count_after_first == count_after_second == 2
 ```
 
 **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_build_dag_auto_resolves_from_parents -v`
-Expected: FAIL with "DependencyNotFoundError" (producer not included)
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer -v`
+Expected: FAIL with "AttributeError: 'Pipeline' object has no attribute 'resolve_from_parents'"
 
-**Step 3: Modify build_dag to call resolve_from_parents**
+**Step 3: Write implementation**
 
 ```python
-# Modify build_dag in src/pivot/pipeline/pipeline.py
-def build_dag(self, validate: bool = True) -> DiGraph[str]:
-    """Build DAG from registered stages.
+# Add to src/pivot/pipeline/pipeline.py
 
-    Automatically resolves unresolved dependencies by searching parent
-    pipelines (lazy dependency resolution).
+# Add import at top (after existing imports)
+from pivot import discovery
 
-    Args:
-        validate: If True, validate that all dependencies exist
+# Add method to Pipeline class
+def resolve_from_parents(self) -> None:
+    """Resolve unresolved dependencies by searching parent pipelines.
 
-    Returns:
-        NetworkX DiGraph with stages as nodes and dependencies as edges
+    For each dependency that has no local producer:
+    1. Traverse up directory tree looking for pivot.yaml or pipeline.py
+    2. Load each parent pipeline and search for a stage producing the artifact
+    3. Include that stage and add its dependencies to the work queue
 
-    Raises:
-        CyclicGraphError: If graph contains cycles
-        DependencyNotFoundError: If dependency doesn't exist (when validate=True)
+    Dependencies that exist on disk are treated as external inputs.
+    Uses per-call caching (parents loaded once per resolve, discarded after).
     """
-    # Auto-resolve from parents before building DAG
-    self.resolve_from_parents()
-    return self._registry.build_dag(validate=validate)
-```
+    project_root = project.get_project_root()
 
-**Step 4: Run test to verify it passes**
+    # Build set of locally produced outputs
+    local_outputs = set[str]()
+    for stage_name in self.list_stages():
+        local_outputs.update(self.get(stage_name)["outs_paths"])
 
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_build_dag_auto_resolves_from_parents -v`
-Expected: PASS
+    # Build work queue of unresolved dependencies
+    work = set[str]()
+    for stage_name in self.list_stages():
+        for dep_path in self.get(stage_name)["deps_paths"]:
+            if dep_path not in local_outputs:
+                work.add(dep_path)
 
-**Step 5: Commit**
-
-```bash
-jj describe -m "feat(pipeline): auto-resolve from parents in build_dag"
-```
-
----
-
-## Task 6: Add Error for Multiple Producers
-
-**Files:**
-- Modify: `src/pivot/pipeline/pipeline.py`
-- Modify: `src/pivot/pipeline/yaml.py` (add new exception)
-- Test: `tests/pipeline/test_pipeline.py`
-
-**Step 1: Write the failing test**
-
-```python
-# Add to tests/pipeline/test_pipeline.py
-def test_pipeline_resolve_from_parents_errors_on_multiple_producers(
-    tmp_path: pathlib.Path, mocker: MockerFixture
-) -> None:
-    """Should error if multiple parent pipelines produce the same artifact."""
-    mocker.patch.object(project, "_project_root_cache", tmp_path)
-    (tmp_path / ".git").mkdir()
-
-    # First parent at project root
-    parent1_code = '''
-from typing import Annotated, TypedDict
-from pathlib import Path
-from pivot.pipeline import Pipeline
-from pivot import loaders
-from pivot.outputs import Out
-
-pipeline = Pipeline("parent1")
-
-class Output(TypedDict):
-    data: Annotated[Path, Out("shared.txt", loaders.PathOnly())]
-
-def producer1() -> Output:
-    return Output(data=Path("shared.txt"))
-
-pipeline.register(producer1)
-'''
-    (tmp_path / "pipeline.py").write_text(parent1_code)
-
-    # Second parent at mid level
-    mid_dir = tmp_path / "mid"
-    mid_dir.mkdir()
-    parent2_code = '''
-from typing import Annotated, TypedDict
-from pathlib import Path
-from pivot.pipeline import Pipeline
-from pivot import loaders
-from pivot.outputs import Out
-
-pipeline = Pipeline("parent2")
-
-class Output(TypedDict):
-    data: Annotated[Path, Out("shared.txt", loaders.PathOnly())]
-
-def producer2() -> Output:
-    return Output(data=Path("shared.txt"))
-
-pipeline.register(producer2)
-'''
-    (mid_dir / "pipeline.py").write_text(parent2_code)
-
-    # Child pipeline
-    child_dir = mid_dir / "child"
-    child_dir.mkdir()
-    child = Pipeline("child", root=child_dir)
-
-    class ConsumerOutput(TypedDict):
-        result: Annotated[Path, Out("result.txt", loaders.PathOnly())]
-
-    def consumer(
-        data: Annotated[Path, Dep("shared.txt", loaders.PathOnly())]
-    ) -> ConsumerOutput:
-        return ConsumerOutput(result=Path("result.txt"))
-
-    child.register(consumer)
-
-    from pivot.pipeline.yaml import PipelineConfigError
-
-    with pytest.raises(PipelineConfigError, match="Multiple parent pipelines produce"):
-        child.resolve_from_parents()
-```
-
-**Step 2: Run test to verify it fails**
-
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_errors_on_multiple_producers -v`
-Expected: FAIL (no error raised, or wrong error)
-
-**Step 3: Update implementation to detect multiple producers**
-
-```python
-# Update _resolve_deps_from_parents in src/pivot/pipeline/pipeline.py
-def _resolve_deps_from_parents(
-    self,
-    unresolved: set[str],
-    local_outputs: set[str],
-    project_root: pathlib.Path,
-) -> None:
-    """Recursively resolve dependencies from parent pipelines."""
-    if not unresolved:
+    if not work:
         return
 
-    parent_files = list(pipeline_discovery.find_parent_pipeline_files(self.root, project_root))
+    # Find parent pipeline files once
+    parent_files = list(discovery.find_parent_pipeline_paths(self.root, project_root))
     if not parent_files:
         return
 
-    newly_included = list[str]()
+    # Per-call cache: avoid reloading same parent for each unresolved dep
+    loaded_parents: dict[pathlib.Path, Pipeline | None] = {}
 
-    for dep_path in list(unresolved):
-        if pathlib.Path(dep_path).exists():
-            unresolved.discard(dep_path)
+    # Process work queue iteratively
+    while work:
+        dep_path = work.pop()
+
+        # Skip if already resolved (by a stage we just added)
+        if dep_path in local_outputs:
             continue
 
-        # Find all producers across all parents
-        producers_found: list[tuple[str, Pipeline]] = []
+        # Skip if file exists on disk (external input)
+        if pathlib.Path(dep_path).exists():
+            continue
+
+        # Search parent pipelines for producer
         for parent_file in parent_files:
-            parent = pipeline_discovery.load_parent_pipeline(parent_file)
+            # Load parent (cached within this call)
+            if parent_file not in loaded_parents:
+                loaded_parents[parent_file] = discovery.load_pipeline_from_path(parent_file)
+            parent = loaded_parents[parent_file]
             if parent is None:
                 continue
 
-            producer_name = pipeline_discovery.find_producer_in_pipeline(parent, dep_path)
-            if producer_name is not None:
-                producers_found.append((producer_name, parent))
+            # Find stage that produces this artifact
+            producer_name = None
+            for stage_name in parent.list_stages():
+                if dep_path in parent.get(stage_name)["outs_paths"]:
+                    producer_name = stage_name
+                    break
 
-        # Error if multiple producers
-        if len(producers_found) > 1:
-            producer_names = [f"'{name}' in '{p.name}'" for name, p in producers_found]
-            raise PipelineConfigError(
-                f"Multiple parent pipelines produce '{dep_path}': {', '.join(producer_names)}. "
-                f"This indicates a malformed project DAG."
+            if producer_name is None:
+                continue
+
+            # Skip if already included (idempotency)
+            if producer_name in self._registry.list_stages():
+                break
+
+            # Include the producer stage
+            stage_info = copy.deepcopy(parent.get(producer_name))
+            self._registry.add_existing(stage_info)
+            local_outputs.update(stage_info["outs_paths"])
+
+            # Add producer's dependencies to work queue
+            for producer_dep in stage_info["deps_paths"]:
+                if producer_dep not in local_outputs:
+                    work.add(producer_dep)
+
+            logger.debug(
+                f"Included stage '{producer_name}' from parent pipeline '{parent.name}'"
             )
-
-        if not producers_found:
-            continue  # No producer found, leave as external input
-
-        producer_name, parent = producers_found[0]
-
-        if producer_name in self._registry.list_stages():
-            unresolved.discard(dep_path)
-            continue
-
-        import copy
-        stage_info = copy.deepcopy(parent.get(producer_name))
-        self._registry.add_existing(stage_info)
-        newly_included.append(producer_name)
-        local_outputs.update(stage_info["outs_paths"])
-        unresolved.discard(dep_path)
-
-        for producer_dep in stage_info["deps_paths"]:
-            if producer_dep not in local_outputs:
-                unresolved.add(producer_dep)
-
-        logger.debug(f"Included stage '{producer_name}' from parent pipeline '{parent.name}'")
-
-    if newly_included and unresolved:
-        self._resolve_deps_from_parents(unresolved, local_outputs, project_root)
+            break
 ```
 
-**Step 4: Run test to verify it passes**
+**Step 4: Run tests to verify they pass**
 
-Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_errors_on_multiple_producers -v`
+Run: `uv run pytest tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_producer tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_includes_transitive_deps tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_skips_existing_files tests/pipeline/test_pipeline.py::test_pipeline_resolve_from_parents_is_idempotent -v`
 Expected: PASS
 
 **Step 5: Commit**
 
 ```bash
-jj describe -m "feat(pipeline): error on multiple producers in lazy resolution"
+jj describe -m "feat(pipeline): add resolve_from_parents for lazy dependency resolution"
 ```
 
 ---
 
-## Task 7: Add Integration Test with Real Execution
+## Task 4: Add Integration Test
 
 **Files:**
-- Test: `tests/integration/test_lazy_resolution.py`
+- Create: `tests/integration/test_lazy_resolution.py`
 
 **Step 1: Write integration test**
 
@@ -960,15 +618,16 @@ from __future__ import annotations
 import pathlib
 
 import pytest
+from pytest_mock import MockerFixture
 
-from pivot.cli import cli
-from click.testing import CliRunner
+from pivot import project
+from pivot.pipeline.pipeline import Pipeline
 
 
 @pytest.fixture
-def lazy_resolution_project(tmp_path: pathlib.Path) -> pathlib.Path:
-    """Create a project with parent/child pipeline structure."""
-    # Initialize git repo
+def lazy_project(tmp_path: pathlib.Path, mocker: MockerFixture) -> pathlib.Path:
+    """Create project with parent/child pipeline structure."""
+    mocker.patch.object(project, "_project_root_cache", tmp_path)
     (tmp_path / ".git").mkdir()
 
     # Parent pipeline at root
@@ -986,14 +645,14 @@ class ProducerOutput(TypedDict):
 
 def producer() -> ProducerOutput:
     Path("data").mkdir(exist_ok=True)
-    Path("data/output.txt").write_text("produced data")
+    Path("data/output.txt").write_text("produced")
     return ProducerOutput(data=Path("data/output.txt"))
 
 pipeline.register(producer)
 '''
     (tmp_path / "pipeline.py").write_text(parent_code)
 
-    # Child pipeline in subdirectory
+    # Child pipeline
     child_dir = tmp_path / "child"
     child_dir.mkdir()
     child_code = '''
@@ -1022,30 +681,38 @@ pipeline.register(consumer)
     return tmp_path
 
 
-def test_lazy_resolution_repro_from_child(
-    lazy_resolution_project: pathlib.Path,
-) -> None:
-    """Running repro from child directory should auto-include parent stages."""
-    runner = CliRunner()
-    child_dir = lazy_resolution_project / "child"
+def test_lazy_resolution_builds_complete_dag(lazy_project: pathlib.Path) -> None:
+    """Child pipeline should build complete DAG including parent stages."""
+    from pivot import discovery
 
-    with runner.isolated_filesystem(temp_dir=lazy_resolution_project):
-        # Change to child directory
-        import os
-        os.chdir(child_dir)
+    child_dir = lazy_project / "child"
+    child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+    assert child is not None
 
-        result = runner.invoke(cli, ["repro"], catch_exceptions=False)
+    child.resolve_from_parents()
+    dag = child.build_dag(validate=True)
 
-    assert result.exit_code == 0
-    assert "producer" in result.output or "consumer" in result.output
+    assert "producer" in dag.nodes
+    assert "consumer" in dag.nodes
+    assert dag.has_edge("consumer", "producer")
 
-    # Verify outputs exist
-    assert (lazy_resolution_project / "data" / "output.txt").exists()
-    assert (child_dir / "result.txt").exists()
-    assert (child_dir / "result.txt").read_text() == "consumed: produced data"
+
+def test_lazy_resolution_preserves_parent_state_dir(lazy_project: pathlib.Path) -> None:
+    """Included parent stages should retain their original state_dir."""
+    from pivot import discovery
+
+    child_dir = lazy_project / "child"
+    child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+    assert child is not None
+
+    child.resolve_from_parents()
+
+    producer_info = child.get("producer")
+    # Producer's state_dir should be parent's .pivot, not child's
+    assert producer_info["state_dir"] == lazy_project / ".pivot"
 ```
 
-**Step 2: Run integration test**
+**Step 2: Run integration tests**
 
 Run: `uv run pytest tests/integration/test_lazy_resolution.py -v`
 Expected: PASS
@@ -1053,12 +720,12 @@ Expected: PASS
 **Step 3: Commit**
 
 ```bash
-jj describe -m "test: add integration test for lazy pipeline resolution"
+jj describe -m "test: add integration tests for lazy pipeline resolution"
 ```
 
 ---
 
-## Task 8: Run Quality Checks and Final Verification
+## Task 5: Run Quality Checks
 
 **Step 1: Run all tests**
 
@@ -1070,43 +737,41 @@ Expected: All tests pass
 Run: `uv run basedpyright`
 Expected: No errors
 
-**Step 3: Run linter**
+**Step 3: Run linter and formatter**
 
-Run: `uv run ruff check .`
+Run: `uv run ruff check . && uv run ruff format .`
 Expected: No errors
 
-**Step 4: Run formatter**
-
-Run: `uv run ruff format .`
-Expected: Files formatted
-
-**Step 5: Final commit**
+**Step 4: Final commit**
 
 ```bash
 jj describe -m "feat(pipeline): lazy dependency resolution from parent pipelines
 
-When building a pipeline's DAG, unresolved dependencies are automatically
-resolved by traversing up the directory tree, loading parent pipeline.py
-files, and including stages that produce the needed artifacts.
+When a child pipeline has unresolved dependencies, resolve_from_parents()
+traverses up the directory tree to find parent pivot.yaml or pipeline.py
+files, loads them, and includes stages that produce the needed artifacts.
 
 Key behaviors:
-- Closest parent pipeline is searched first
-- Transitive dependencies are recursively resolved
-- Multiple producers for the same artifact is an error
-- Files that exist on disk are treated as external inputs
-- Parent stages retain their original state_dir"
+- Searches for both pivot.yaml and pipeline.py (errors if both exist)
+- Closest parent is searched first
+- Transitive dependencies are resolved iteratively
+- Files on disk are treated as external inputs
+- No caching - each resolve sees fresh parent state (watch mode safe)
+- Parent stages retain their original state_dir
+- build_dag() is unchanged (non-mutating) - call resolve_from_parents() explicitly"
 ```
 
 ---
 
 ## Summary
 
-This implementation adds lazy pipeline dependency resolution through:
+This simplified implementation:
 
-1. **`find_parent_pipeline_files()`** - Traverses up directory tree to find parent pipeline.py files
-2. **`load_parent_pipeline()`** - Loads and caches parent Pipeline instances
-3. **`find_producer_in_pipeline()`** - Searches a pipeline for a stage producing a path
-4. **`Pipeline.resolve_from_parents()`** - Main entry point that resolves unresolved deps
-5. **Integration with `build_dag()`** - Auto-resolution happens before DAG construction
+1. **~100 lines of new code** (vs ~400 in original plan)
+2. **No new modules** - extends existing `discovery.py` and `pipeline.py`
+3. **Per-call caching** - parents cached within single `resolve_from_parents()` call, discarded after (safe, no staleness issues, no test isolation concerns)
+4. **Non-mutating `build_dag()`** - explicit `resolve_from_parents()` call
+5. **Supports both pivot.yaml and pipeline.py** in parent directories
+6. **Iterative algorithm** - simple work queue, no recursion
 
-The design preserves existing behavior while enabling child pipelines to depend on parent pipeline outputs without explicit `include()` calls.
+**Future optimization:** If watch mode performance becomes an issue (150ms per event vs ~0.5ms with mtime cache), can add mtime-based caching with proper mitigations (deep copy, bounded size, error handling).

--- a/src/pivot/discovery.py
+++ b/src/pivot/discovery.py
@@ -8,6 +8,7 @@ from pivot import fingerprint, metrics, project
 from pivot.pipeline import yaml as pipeline_config
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from pivot.pipeline.pipeline import Pipeline
@@ -20,6 +21,35 @@ PIPELINE_PY_NAME = "pipeline.py"
 
 class DiscoveryError(Exception):
     """Error during pipeline discovery."""
+
+
+def _find_config_path_in_dir(directory: Path) -> Path | None:
+    """Find the pipeline config file in a directory.
+
+    Returns the path to pivot.yaml/yml or pipeline.py if found.
+    Raises DiscoveryError if both exist in the same directory.
+    Returns None if neither exists.
+    """
+    yaml_path = None
+    for yaml_name in PIVOT_YAML_NAMES:
+        candidate = directory / yaml_name
+        if candidate.is_file():
+            yaml_path = candidate
+            break
+
+    pipeline_path = directory / PIPELINE_PY_NAME
+    pipeline_exists = pipeline_path.is_file()
+
+    if yaml_path and pipeline_exists:
+        msg = f"Found both {yaml_path.name} and {PIPELINE_PY_NAME} in {directory}. "
+        msg += "Remove one to resolve ambiguity."
+        raise DiscoveryError(msg)
+
+    if yaml_path:
+        return yaml_path
+    if pipeline_exists:
+        return pipeline_path
+    return None
 
 
 def discover_pipeline(project_root: Path | None = None) -> Pipeline | None:
@@ -40,48 +70,31 @@ def discover_pipeline(project_root: Path | None = None) -> Pipeline | None:
     """
     with metrics.timed("discovery.total"):
         root = project_root or project.get_project_root()
+        config_path = _find_config_path_in_dir(root)
 
-        # Check which files exist upfront
-        yaml_path = None
-        for yaml_name in PIVOT_YAML_NAMES:
-            candidate = root / yaml_name
-            if candidate.exists():
-                yaml_path = candidate
-                break
+        if config_path is None:
+            return None
 
-        pipeline_path = root / PIPELINE_PY_NAME
-        pipeline_exists = pipeline_path.exists()
+        logger.info(f"Discovered {config_path}")
 
-        # Error if both exist
-        if yaml_path and pipeline_exists:
-            raise DiscoveryError(
-                f"Found both {yaml_path.name} and {PIPELINE_PY_NAME} in {root}. Remove one to resolve ambiguity."
-            )
-
-        # Load from yaml if found
-        if yaml_path:
-            logger.info(f"Discovered {yaml_path}")
+        if config_path.name in PIVOT_YAML_NAMES:
             try:
-                return pipeline_config.load_pipeline_from_yaml(yaml_path)
+                return pipeline_config.load_pipeline_from_yaml(config_path)
             except pipeline_config.PipelineConfigError as e:
-                raise DiscoveryError(f"Failed to load {yaml_path}: {e}") from e
+                raise DiscoveryError(f"Failed to load {config_path}: {e}") from e
 
-        # Try pipeline.py
-        if pipeline_exists:
-            logger.info(f"Discovered {pipeline_path}")
-            try:
-                return _load_pipeline_from_module(pipeline_path)
-            except SystemExit as e:
-                raise DiscoveryError(f"Pipeline {pipeline_path} called sys.exit({e.code})") from e
-            except DiscoveryError:
-                # Re-raise DiscoveryError without wrapping
-                raise
-            except Exception as e:
-                raise DiscoveryError(f"Failed to load {pipeline_path}: {e}") from e
-            finally:
-                fingerprint.flush_ast_hash_cache()
-
-        return None
+        # pipeline.py
+        try:
+            return _load_pipeline_from_module(config_path)
+        except SystemExit as e:
+            raise DiscoveryError(f"Pipeline {config_path} called sys.exit({e.code})") from e
+        except DiscoveryError:
+            # Re-raise DiscoveryError without wrapping
+            raise
+        except Exception as e:
+            raise DiscoveryError(f"Failed to load {config_path}: {e}") from e
+        finally:
+            fingerprint.flush_ast_hash_cache()
 
 
 def _load_pipeline_from_module(path: Path) -> Pipeline | None:
@@ -115,3 +128,78 @@ def _load_pipeline_from_module(path: Path) -> Pipeline | None:
 
     # No Pipeline found anywhere
     return None
+
+
+def find_parent_pipeline_paths(
+    start_dir: Path,
+    stop_at: Path,
+) -> Iterator[Path]:
+    """Find pipeline config files in parent directories.
+
+    Traverses up from start_dir (exclusive) to stop_at (inclusive),
+    yielding each pivot.yaml or pipeline.py found. Closest parents first.
+    Errors if any directory has both.
+
+    Args:
+        start_dir: Directory to start from (its config is NOT included).
+        stop_at: Stop traversal at this directory (inclusive).
+
+    Yields:
+        Paths to pivot.yaml or pipeline.py files.
+
+    Raises:
+        DiscoveryError: If a directory has both pivot.yaml and pipeline.py.
+    """
+    current = start_dir.resolve().parent
+    stop_at_resolved = stop_at.resolve()
+
+    while True:
+        # Stop if we've gone above stop_at (stop_at must be ancestor of start_dir)
+        try:
+            current.relative_to(stop_at_resolved)
+        except ValueError:
+            # current is not under stop_at - we've gone too far
+            break
+
+        config_path = _find_config_path_in_dir(current)
+        if config_path:
+            yield config_path
+
+        if current == stop_at_resolved or current.parent == current:
+            break
+        current = current.parent
+
+
+def load_pipeline_from_path(path: Path) -> Pipeline | None:
+    """Load a Pipeline from a pivot.yaml or pipeline.py file.
+
+    Args:
+        path: Path to pivot.yaml or pipeline.py file.
+
+    Returns:
+        Pipeline instance, or None if file doesn't define one.
+        Returns None (with debug log) on load errors.
+    """
+
+    # Determine file type and load accordingly
+    if path.name in PIVOT_YAML_NAMES:
+        try:
+            return pipeline_config.load_pipeline_from_yaml(path)
+        except Exception as e:
+            logger.debug(f"Failed to load pipeline from {path}: {e}")
+            return None
+    elif path.name == PIPELINE_PY_NAME:
+        try:
+            return _load_pipeline_from_module(path)
+        except DiscoveryError as e:
+            # Log at warning level - user likely made a typo (e.g., wrong variable name)
+            logger.warning(f"Pipeline discovery issue in {path}: {e}")
+            return None
+        except Exception as e:
+            logger.debug(f"Failed to load pipeline from {path}: {e}")
+            return None
+        finally:
+            fingerprint.flush_ast_hash_cache()
+    else:
+        logger.debug(f"Unknown pipeline file type: {path}")
+        return None

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -61,7 +61,7 @@ class RegistryStageInfo(TypedDict):
         func: The stage function to execute.
         name: Unique stage identifier (function name or custom name).
         deps: Named input file dependencies (name -> path(s), absolute paths).
-        deps_paths: Flattened list of all dependency paths (for DAG/worker).
+        deps_paths: Flattened list of all dependency paths (absolute paths, for DAG/worker).
         outs: Output specifications (expanded for DAG/caching - one Out per file).
         outs_paths: Output file paths (absolute paths).
         params: Pydantic model instance with parameter values.

--- a/tests/cli/test_cli_export.py
+++ b/tests/cli/test_cli_export.py
@@ -112,7 +112,6 @@ def test_export_default_output_creates_dvc_yaml(
 ) -> None:
     """Export without args creates dvc.yaml in current directory."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_with_data_dep, name="preprocess")
 
@@ -131,7 +130,6 @@ def test_export_custom_output_path(
 ) -> None:
     """Export with --output writes to specified path."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_no_deps, name="preprocess")
 
@@ -149,7 +147,6 @@ def test_export_specific_stages_only(
 ) -> None:
     """Export with stage names exports only those stages."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_a_txt, name="preprocess")
     register_test_stage(_helper_evaluate_b_txt, name="evaluate")
@@ -174,7 +171,6 @@ def test_export_generates_params_yaml(
 ) -> None:
     """Export generates params.yaml with Pydantic model defaults."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(
         _helper_train_with_params,
@@ -202,7 +198,6 @@ def test_export_unknown_stage_error(
 ) -> None:
     """Export with unknown stage name shows error."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_a_txt, name="preprocess")
 
@@ -236,7 +231,6 @@ def test_export_dvc_yaml_structure(
 ) -> None:
     """Exported dvc.yaml has correct structure with cmd, deps, outs."""
     _ = mock_discovery
-    (set_project_root / ".git").mkdir()
 
     register_test_stage(_helper_preprocess_with_input_dep, name="preprocess")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,8 +134,12 @@ def reset_pivot_state(mocker: MockerFixture) -> Generator[None]:
 
 @pytest.fixture
 def set_project_root(tmp_path: pathlib.Path, mocker: MockerFixture) -> Generator[pathlib.Path]:
-    """Set project root to tmp_path for tests that register stages with temp paths."""
+    """Set project root to tmp_path for tests that register stages with temp paths.
+
+    Also creates .git directory so fingerprinting and other git-dependent operations work.
+    """
     mocker.patch.object(project, "_project_root_cache", tmp_path)
+    (tmp_path / ".git").mkdir(exist_ok=True)
     yield tmp_path
 
 

--- a/tests/core/test_discovery.py
+++ b/tests/core/test_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import pytest
@@ -19,13 +20,35 @@ if TYPE_CHECKING:
 
 
 def test_discover_pipeline_returns_none_when_no_files(set_project_root: Path) -> None:
-    """discover_pipeline returns None when no pivot.yaml or pipeline.py."""
+    """discover_pipeline returns None when no pivot.yaml or pipeline.py exist.
+
+    Prevents regression where discovery fails instead of returning None.
+    """
     result = discovery.discover_pipeline(set_project_root)
     assert result is None
 
 
+def test_discover_pipeline_ignores_directories_with_config_names(set_project_root: Path) -> None:
+    """discover_pipeline ignores directories named pivot.yaml or pipeline.py.
+
+    Tests that _find_config_path_in_dir uses is_file() not exists(), preventing
+    confusion when a directory happens to be named like a config file.
+    """
+    # Create directories with config file names
+    (set_project_root / "pivot.yaml").mkdir()
+    (set_project_root / "pipeline.py").mkdir()
+
+    result = discovery.discover_pipeline(set_project_root)
+
+    # Should return None, not try to parse directories as files
+    assert result is None
+
+
 def test_discover_pipeline_from_pipeline_py(set_project_root: Path) -> None:
-    """discover_pipeline should find Pipeline instance in pipeline.py."""
+    """discover_pipeline finds and loads Pipeline instance from pipeline.py.
+
+    Tests the pipeline.py discovery path including stage registration.
+    """
     from pivot.pipeline.pipeline import Pipeline
 
     # Create pipeline.py that defines a Pipeline
@@ -49,8 +72,32 @@ pipeline.register(_stage, name="my_stage")
     assert "my_stage" in result.list_stages()
 
 
+def test_discover_pipeline_py_no_pipeline_variable(set_project_root: Path) -> None:
+    """discover_pipeline returns None when pipeline.py has no Pipeline at all.
+
+    Tests the case where pipeline.py exists but doesn't define a Pipeline instance
+    under any variable name. This is different from the "wrong name" case which
+    raises an error.
+    """
+    # Create pipeline.py with no Pipeline instances
+    pipeline_code = """\
+# Just some module with no Pipeline
+x = 1
+y = "hello"
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.discover_pipeline(set_project_root)
+
+    assert result is None
+
+
 def test_discover_pipeline_missing_pipeline_variable(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError when pipeline.py has Pipeline but wrong name."""
+    """discover_pipeline raises DiscoveryError when Pipeline exists with wrong variable name.
+
+    This catches the common mistake of creating a Pipeline but naming it something other
+    than 'pipeline'. The error message should guide the user to rename it.
+    """
     # Create pipeline.py with Pipeline assigned to wrong variable name
     pipeline_code = """\
 from pivot.pipeline.pipeline import Pipeline
@@ -68,7 +115,10 @@ my_pipe = Pipeline("oops")
 
 
 def test_discover_pipeline_wrong_type(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError when 'pipeline' is not a Pipeline instance."""
+    """discover_pipeline raises DiscoveryError when 'pipeline' variable is not a Pipeline.
+
+    Prevents confusion when someone assigns a non-Pipeline value to 'pipeline'.
+    """
     # Create pipeline.py with wrong type for 'pipeline'
     pipeline_code = """\
 pipeline = "not a Pipeline"
@@ -82,10 +132,23 @@ pipeline = "not a Pipeline"
         discovery.discover_pipeline(set_project_root)
 
 
-def test_discover_pipeline_both_files_raises_error(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError when both pivot.yaml and pipeline.py exist."""
-    # Create pivot.yaml
-    (set_project_root / "pivot.yaml").write_text("stages: {}")
+@pytest.mark.parametrize(
+    "yaml_name",
+    [
+        pytest.param("pivot.yaml", id="yaml"),
+        pytest.param("pivot.yml", id="yml"),
+    ],
+)
+def test_discover_pipeline_both_yaml_and_pipeline_py_raises_error(
+    set_project_root: Path, yaml_name: str
+) -> None:
+    """discover_pipeline raises DiscoveryError when both YAML config and pipeline.py exist.
+
+    Tests both pivot.yaml and pivot.yml extensions to ensure consistent behavior.
+    Prevents ambiguity about which config to use.
+    """
+    # Create YAML config
+    (set_project_root / yaml_name).write_text("stages: {}")
 
     # Create pipeline.py
     pipeline_code = """\
@@ -96,13 +159,66 @@ pipeline = Pipeline("test")
 
     with pytest.raises(
         discovery.DiscoveryError,
-        match="Found both pivot.yaml and pipeline.py",
+        match=f"Found both {yaml_name} and pipeline.py",
     ):
         discovery.discover_pipeline(set_project_root)
 
 
+def test_discover_pipeline_prefers_yaml_over_yml(set_project_root: Path) -> None:
+    """discover_pipeline prefers pivot.yaml when both pivot.yaml and pivot.yml exist.
+
+    Tests the PIVOT_YAML_NAMES tuple ordering to ensure .yaml takes precedence.
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    # Create minimal stage module
+    stages_py = set_project_root / "stages.py"
+    stages_py.write_text(
+        """\
+import pathlib
+from typing import Annotated, TypedDict
+from pivot import loaders, outputs
+
+class ProcessOutputs(TypedDict):
+    out: Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]
+
+def process() -> ProcessOutputs:
+    return {"out": pathlib.Path("output.txt")}
+"""
+    )
+
+    # Create both files with different names
+    (set_project_root / "pivot.yaml").write_text(
+        """\
+pipeline: yaml_wins
+stages:
+  process:
+    python: stages.process
+"""
+    )
+    (set_project_root / "pivot.yml").write_text(
+        """\
+pipeline: yml_loses
+stages:
+  process:
+    python: stages.process
+"""
+    )
+
+    with stage_module_isolation(set_project_root):
+        result = discovery.discover_pipeline(set_project_root)
+
+    assert result is not None
+    assert isinstance(result, Pipeline)
+    # Should load from pivot.yaml, not pivot.yml
+    assert result.name == "yaml_wins"
+
+
 def test_discover_pipeline_sys_exit_raises(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError when pipeline.py calls sys.exit()."""
+    """discover_pipeline raises DiscoveryError when pipeline.py calls sys.exit().
+
+    Prevents silent failures when pipeline.py has top-level sys.exit() calls.
+    """
     # Create pipeline.py that calls sys.exit
     pipeline_code = """\
 import sys
@@ -115,7 +231,10 @@ sys.exit(42)
 
 
 def test_discover_pipeline_runtime_error_raises(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError when pipeline.py has runtime error."""
+    """discover_pipeline wraps non-DiscoveryError exceptions in DiscoveryError.
+
+    Tests generic exception handling during pipeline.py loading.
+    """
     # Create pipeline.py with an error
     pipeline_code = """\
 raise RuntimeError("intentional error")
@@ -126,8 +245,40 @@ raise RuntimeError("intentional error")
         discovery.discover_pipeline(set_project_root)
 
 
-def test_discover_pipeline_from_yaml(set_project_root: Path) -> None:
-    """discover_pipeline returns Pipeline when only pivot.yaml exists."""
+def test_discover_pipeline_reraises_discovery_error(set_project_root: Path) -> None:
+    """discover_pipeline re-raises DiscoveryError from _load_pipeline_from_module without wrapping.
+
+    Tests that internal DiscoveryErrors (like wrong variable name) are not double-wrapped.
+    """
+    # Create pipeline.py that will trigger DiscoveryError
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+wrong_name = Pipeline("test")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    # Should get the original DiscoveryError, not "Failed to load" wrapper
+    with pytest.raises(
+        discovery.DiscoveryError,
+        match="does not define a 'pipeline' variable.*Found Pipeline instance named 'wrong_name'",
+    ):
+        discovery.discover_pipeline(set_project_root)
+
+
+@pytest.mark.parametrize(
+    "yaml_name,pipeline_name",
+    [
+        pytest.param("pivot.yaml", "yaml_pipeline", id="yaml"),
+        pytest.param("pivot.yml", "yml_pipeline", id="yml"),
+    ],
+)
+def test_discover_pipeline_from_yaml_files(
+    set_project_root: Path, yaml_name: str, pipeline_name: str
+) -> None:
+    """discover_pipeline loads Pipeline from both pivot.yaml and pivot.yml files.
+
+    Parametrized test to ensure both YAML extensions work correctly.
+    """
     from pivot.pipeline.pipeline import Pipeline
 
     # Create a simple stage module
@@ -146,10 +297,10 @@ def process() -> ProcessOutputs:
 """
     )
 
-    # Create only pivot.yaml (no pipeline.py)
-    (set_project_root / "pivot.yaml").write_text(
-        """\
-pipeline: yaml_pipeline
+    # Create YAML config
+    (set_project_root / yaml_name).write_text(
+        f"""\
+pipeline: {pipeline_name}
 stages:
   process:
     python: stages.process
@@ -161,51 +312,15 @@ stages:
 
     assert result is not None
     assert isinstance(result, Pipeline)
-    assert result.name == "yaml_pipeline"
+    assert result.name == pipeline_name
     assert "process" in result.list_stages()
 
 
-def test_discover_pipeline_from_yml(set_project_root: Path) -> None:
-    """discover_pipeline returns Pipeline when only pivot.yml exists."""
-    from pivot.pipeline.pipeline import Pipeline
-
-    # Create a simple stage module
-    stages_py = set_project_root / "stages.py"
-    stages_py.write_text(
-        """\
-import pathlib
-from typing import Annotated, TypedDict
-from pivot import loaders, outputs
-
-class AnalyzeOutputs(TypedDict):
-    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
-
-def analyze() -> AnalyzeOutputs:
-    return {"result": pathlib.Path("result.txt")}
-"""
-    )
-
-    # Create only pivot.yml (note: .yml not .yaml)
-    (set_project_root / "pivot.yml").write_text(
-        """\
-pipeline: yml_pipeline
-stages:
-  analyze:
-    python: stages.analyze
-"""
-    )
-
-    with stage_module_isolation(set_project_root):
-        result = discovery.discover_pipeline(set_project_root)
-
-    assert result is not None
-    assert isinstance(result, Pipeline)
-    assert result.name == "yml_pipeline"
-    assert "analyze" in result.list_stages()
-
-
 def test_discover_pipeline_invalid_yaml_raises(set_project_root: Path) -> None:
-    """discover_pipeline raises DiscoveryError for invalid pivot.yaml."""
+    """discover_pipeline raises DiscoveryError for invalid pivot.yaml content.
+
+    Tests error handling when YAML config references non-existent modules.
+    """
     pivot_yaml = set_project_root / "pivot.yaml"
     pivot_yaml.write_text(
         """\
@@ -218,3 +333,280 @@ stages:
 
     with pytest.raises(discovery.DiscoveryError, match="Failed to load"):
         discovery.discover_pipeline(set_project_root)
+
+
+# =============================================================================
+# Parent Pipeline Discovery Tests (find_parent_pipeline_paths)
+# =============================================================================
+
+
+def test_find_parent_pipeline_paths_finds_pipeline_py(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths finds pipeline.py files in parent directories.
+
+    Tests traversal order: closest parents first, stopping at specified directory.
+    """
+    (set_project_root / "pipeline.py").touch()
+    mid = set_project_root / "mid"
+    mid.mkdir()
+    (mid / "pipeline.py").touch()
+    child = mid / "child"
+    child.mkdir()
+
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=set_project_root))
+
+    # Should find mid's pipeline.py first (closest parent), then root's
+    assert len(result) == 2
+    assert result[0] == mid / "pipeline.py"
+    assert result[1] == set_project_root / "pipeline.py"
+
+
+def test_find_parent_pipeline_paths_finds_pivot_yaml(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths finds pivot.yaml in parent directories."""
+    (set_project_root / "pivot.yaml").touch()
+    child = set_project_root / "child"
+    child.mkdir()
+
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=set_project_root))
+
+    assert result == [set_project_root / "pivot.yaml"]
+
+
+def test_find_parent_pipeline_paths_finds_pivot_yml(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths finds pivot.yml in parent directories."""
+    (set_project_root / "pivot.yml").touch()
+    child = set_project_root / "child"
+    child.mkdir()
+
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=set_project_root))
+
+    assert result == [set_project_root / "pivot.yml"]
+
+
+def test_find_parent_pipeline_paths_errors_on_both(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths raises DiscoveryError when directory has both configs.
+
+    Prevents ambiguity during parent traversal, same as discover_pipeline.
+    """
+    (set_project_root / "pipeline.py").touch()
+    (set_project_root / "pivot.yaml").touch()
+    child = set_project_root / "child"
+    child.mkdir()
+
+    with pytest.raises(discovery.DiscoveryError, match="Found both"):
+        list(discovery.find_parent_pipeline_paths(child, stop_at=set_project_root))
+
+
+def test_find_parent_pipeline_paths_skips_own_directory(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths does not include start_dir's own config files.
+
+    Tests that traversal starts from start_dir.parent, not start_dir itself.
+    """
+    (set_project_root / "pipeline.py").touch()
+
+    result = list(
+        discovery.find_parent_pipeline_paths(set_project_root, stop_at=set_project_root.parent)
+    )
+
+    assert result == []
+
+
+def test_find_parent_pipeline_paths_stops_at_root(tmp_path: Path) -> None:
+    """find_parent_pipeline_paths stops at filesystem root without infinite loop.
+
+    Tests the current.parent == current safety check that prevents infinite loops
+    when stop_at is above the actual filesystem root.
+    """
+    # Create a deep directory structure
+    deep_dir = tmp_path / "a" / "b" / "c"
+    deep_dir.mkdir(parents=True)
+
+    # No stop_at specified would normally go to filesystem root
+    # Should stop when it reaches filesystem root (parent == self)
+    import pathlib
+
+    result = list(
+        discovery.find_parent_pipeline_paths(deep_dir, stop_at=pathlib.Path(tmp_path.root))
+    )
+
+    # Should not raise, should complete (likely finding nothing unless files exist in path)
+    assert isinstance(result, list)
+
+
+def test_find_parent_pipeline_paths_start_equals_stop(set_project_root: Path) -> None:
+    """find_parent_pipeline_paths returns empty when start_dir equals stop_at.
+
+    When start_dir equals stop_at, the range is empty (start_dir is exclusive),
+    so no configs should be found. This also tests that the function doesn't
+    traverse above stop_at.
+    """
+    # Create config at project root (which equals both start_dir and stop_at)
+    (set_project_root / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_paths(set_project_root, stop_at=set_project_root))
+
+    # Should return empty - start_dir is exclusive, and parent is above stop_at
+    assert result == []
+
+
+def test_find_parent_pipeline_paths_does_not_traverse_above_stop_at(tmp_path: Path) -> None:
+    """find_parent_pipeline_paths stops traversal at stop_at boundary.
+
+    Tests that the function doesn't find configs in directories above stop_at,
+    even if they exist.
+    """
+    # Structure: /root/above/project/child
+    # stop_at = /root/above/project, start_dir = /root/above/project/child
+    # Config exists at /root/above (should NOT be found)
+    above = tmp_path / "above"
+    project = above / "project"
+    child = project / "child"
+    child.mkdir(parents=True)
+
+    # Put config ABOVE stop_at - should not be found
+    (above / "pipeline.py").touch()
+
+    result = list(discovery.find_parent_pipeline_paths(child, stop_at=project))
+
+    # Should return empty - the only config is above stop_at
+    assert result == []
+
+
+# =============================================================================
+# Load Pipeline From Path Tests (load_pipeline_from_path)
+# =============================================================================
+
+
+def test_load_pipeline_from_path_loads_pipeline_py(set_project_root: Path) -> None:
+    """load_pipeline_from_path loads Pipeline from pipeline.py file."""
+    pipeline_code = """
+from pivot.pipeline import Pipeline
+pipeline = Pipeline("test")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.load_pipeline_from_path(set_project_root / "pipeline.py")
+
+    assert result is not None
+    assert result.name == "test"
+
+
+def test_load_pipeline_from_path_loads_pivot_yaml(set_project_root: Path) -> None:
+    """load_pipeline_from_path loads Pipeline from pivot.yaml file."""
+    stages_py = set_project_root / "stages.py"
+    stages_py.write_text(
+        """\
+import pathlib
+from typing import Annotated, TypedDict
+from pivot import loaders, outputs
+
+class ExampleOutputs(TypedDict):
+    out: Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]
+
+def example() -> ExampleOutputs:
+    return {"out": pathlib.Path("output.txt")}
+"""
+    )
+    yaml_content = """\
+pipeline: yaml_test
+stages:
+  example:
+    python: stages.example
+"""
+    (set_project_root / "pivot.yaml").write_text(yaml_content)
+
+    with stage_module_isolation(set_project_root):
+        result = discovery.load_pipeline_from_path(set_project_root / "pivot.yaml")
+
+    assert result is not None
+    assert result.name == "yaml_test"
+
+
+def test_load_pipeline_from_path_loads_pivot_yml(set_project_root: Path) -> None:
+    """load_pipeline_from_path loads Pipeline from pivot.yml file."""
+    stages_py = set_project_root / "stages.py"
+    stages_py.write_text(
+        """\
+import pathlib
+from typing import Annotated, TypedDict
+from pivot import loaders, outputs
+
+class ExampleOutputs(TypedDict):
+    out: Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]
+
+def example() -> ExampleOutputs:
+    return {"out": pathlib.Path("output.txt")}
+"""
+    )
+    yaml_content = """\
+pipeline: yml_test
+stages:
+  example:
+    python: stages.example
+"""
+    (set_project_root / "pivot.yml").write_text(yaml_content)
+
+    with stage_module_isolation(set_project_root):
+        result = discovery.load_pipeline_from_path(set_project_root / "pivot.yml")
+
+    assert result is not None
+    assert result.name == "yml_test"
+
+
+def test_load_pipeline_from_path_returns_none_for_no_pipeline(set_project_root: Path) -> None:
+    """load_pipeline_from_path returns None when pipeline.py has no Pipeline."""
+    (set_project_root / "pipeline.py").write_text("x = 1\n")
+
+    result = discovery.load_pipeline_from_path(set_project_root / "pipeline.py")
+
+    assert result is None
+
+
+def test_load_pipeline_from_path_returns_none_for_discovery_error(set_project_root: Path) -> None:
+    """load_pipeline_from_path returns None when pipeline.py raises DiscoveryError.
+
+    Tests that DiscoveryErrors (like wrong variable name) are swallowed and return None,
+    since this function is designed for optional loading during parent traversal.
+    """
+    # Create pipeline.py with wrong variable name (triggers DiscoveryError)
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+wrong_name = Pipeline("test")
+"""
+    (set_project_root / "pipeline.py").write_text(pipeline_code)
+
+    result = discovery.load_pipeline_from_path(set_project_root / "pipeline.py")
+
+    assert result is None
+
+
+def test_load_pipeline_from_path_logs_errors(
+    set_project_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """load_pipeline_from_path logs errors at DEBUG level and returns None.
+
+    Tests error handling for generic exceptions during loading.
+    """
+    (set_project_root / "pipeline.py").write_text("raise RuntimeError('fail')")
+
+    with caplog.at_level(logging.DEBUG):
+        result = discovery.load_pipeline_from_path(set_project_root / "pipeline.py")
+
+    assert result is None
+    assert "Failed to load" in caplog.text
+
+
+def test_load_pipeline_from_path_unknown_file_type(
+    set_project_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """load_pipeline_from_path returns None and logs for unknown file types.
+
+    Tests the fallback path when file is neither pivot.yaml, pivot.yml, nor pipeline.py.
+    """
+    unknown_file = set_project_root / "config.toml"
+    unknown_file.write_text("[tool.something]")
+
+    with caplog.at_level(logging.DEBUG):
+        result = discovery.load_pipeline_from_path(unknown_file)
+
+    assert result is None
+    assert "Unknown pipeline file type" in caplog.text

--- a/tests/integration/test_lazy_resolution.py
+++ b/tests/integration/test_lazy_resolution.py
@@ -1,0 +1,279 @@
+# tests/integration/test_lazy_resolution.py
+"""Integration tests for lazy pipeline dependency resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from conftest import stage_module_isolation
+from pivot import discovery
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+# =============================================================================
+# Helper functions for generating pipeline code
+# =============================================================================
+
+
+def _make_producer_pipeline_code(
+    name: str,
+    stage_name: str,
+    output_path: str,
+) -> str:
+    """Generate pipeline code for a producer stage."""
+    return f'''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("{name}")
+
+class _Output(TypedDict):
+    data: Annotated[Path, Out("{output_path}", loaders.PathOnly())]
+
+def {stage_name}() -> _Output:
+    Path("{output_path}").parent.mkdir(parents=True, exist_ok=True)
+    Path("{output_path}").write_text("produced")
+    return _Output(data=Path("{output_path}"))
+
+pipeline.register({stage_name})
+'''
+
+
+def _make_consumer_pipeline_code(
+    name: str,
+    stage_name: str,
+    dep_path: str,
+    output_path: str,
+) -> str:
+    """Generate pipeline code for a consumer stage."""
+    return f'''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+pipeline = Pipeline("{name}")
+
+class _Output(TypedDict):
+    result: Annotated[Path, Out("{output_path}", loaders.PathOnly())]
+
+def {stage_name}(
+    data: Annotated[Path, Dep("{dep_path}", loaders.PathOnly())]
+) -> _Output:
+    return _Output(result=Path("{output_path}"))
+
+pipeline.register({stage_name})
+'''
+
+
+def _make_transform_pipeline_code(
+    name: str,
+    stage_name: str,
+    dep_path: str,
+    output_path: str,
+) -> str:
+    """Generate pipeline code for a transform stage (consumes and produces)."""
+    return f'''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out, Dep
+
+pipeline = Pipeline("{name}")
+
+class _Output(TypedDict):
+    data: Annotated[Path, Out("{output_path}", loaders.PathOnly())]
+
+def {stage_name}(
+    input_data: Annotated[Path, Dep("{dep_path}", loaders.PathOnly())]
+) -> _Output:
+    Path("{output_path}").write_text("transformed")
+    return _Output(data=Path("{output_path}"))
+
+pipeline.register({stage_name})
+'''
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+def test_lazy_resolution_builds_complete_dag(set_project_root: pathlib.Path) -> None:
+    """Child pipeline should build complete DAG including parent stages.
+
+    End-to-end test verifying that resolve_from_parents() enables build_dag()
+    to succeed by including necessary producers from parent pipeline.
+    """
+    # Parent pipeline at root
+    (set_project_root / "pipeline.py").write_text(
+        _make_producer_pipeline_code("parent", "producer", "data/output.txt")
+    )
+
+    # Child pipeline
+    child_dir = set_project_root / "child"
+    child_dir.mkdir()
+    (child_dir / "pipeline.py").write_text(
+        _make_consumer_pipeline_code("child", "consumer", "../data/output.txt", "result.txt")
+    )
+
+    # Load child pipeline and resolve
+    child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+    assert child is not None, "Failed to load child pipeline"
+
+    child.resolve_from_parents()
+    dag = child.build_dag(validate=True)
+
+    assert "producer" in dag.nodes, "Expected producer from parent in DAG"
+    assert "consumer" in dag.nodes, "Expected consumer from child in DAG"
+    assert dag.has_edge("consumer", "producer"), "Expected edge from consumer to producer"
+
+
+def test_lazy_resolution_preserves_parent_state_dir(set_project_root: pathlib.Path) -> None:
+    """Included parent stages should retain their original state_dir.
+
+    Critical for correctness: lock files and state.db must remain in parent's
+    .pivot directory, not child's, to avoid conflicts and enable proper
+    incremental builds.
+    """
+    # Parent pipeline at root
+    (set_project_root / "pipeline.py").write_text(
+        _make_producer_pipeline_code("parent", "producer", "data/output.txt")
+    )
+
+    # Child pipeline
+    child_dir = set_project_root / "child"
+    child_dir.mkdir()
+    (child_dir / "pipeline.py").write_text(
+        _make_consumer_pipeline_code("child", "consumer", "../data/output.txt", "result.txt")
+    )
+
+    # Load child pipeline and resolve
+    child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+    assert child is not None, "Failed to load child pipeline"
+
+    child.resolve_from_parents()
+
+    # Producer's state_dir should be parent's .pivot, not child's
+    producer_info = child.get("producer")
+    assert producer_info["state_dir"] == set_project_root / ".pivot", (
+        f"Expected producer state_dir to be {set_project_root / '.pivot'}, "
+        f"got {producer_info['state_dir']}"
+    )
+
+    consumer_info = child.get("consumer")
+    assert consumer_info["state_dir"] == child_dir / ".pivot", (
+        f"Expected consumer state_dir to be {child_dir / '.pivot'}, "
+        f"got {consumer_info['state_dir']}"
+    )
+
+
+def test_lazy_resolution_multilevel_hierarchy(set_project_root: pathlib.Path) -> None:
+    """Should resolve dependencies through multiple levels of parent pipelines.
+
+    Tests grandparent -> parent -> child dependency chain to ensure
+    transitive resolution works across multiple directory levels.
+    """
+    # Grandparent produces raw.txt
+    (set_project_root / "pipeline.py").write_text(
+        _make_producer_pipeline_code("grandparent", "extract", "raw.txt")
+    )
+
+    # Parent depends on raw.txt, produces processed.txt
+    parent_dir = set_project_root / "parent"
+    parent_dir.mkdir()
+    (parent_dir / "pipeline.py").write_text(
+        _make_transform_pipeline_code("parent", "process", "../raw.txt", "processed.txt")
+    )
+
+    # Child depends on processed.txt, produces final.txt
+    child_dir = parent_dir / "child"
+    child_dir.mkdir()
+    (child_dir / "pipeline.py").write_text(
+        _make_consumer_pipeline_code("child", "finalize", "../processed.txt", "final.txt")
+    )
+
+    # Load child and resolve
+    child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+    assert child is not None, "Failed to load child pipeline"
+
+    child.resolve_from_parents()
+
+    # Should have all three stages
+    stages = set(child.list_stages())
+    assert stages == {"extract", "process", "finalize"}, (
+        f"Expected all three stages to be included, got {stages}"
+    )
+
+    # Build DAG should succeed
+    dag = child.build_dag(validate=True)
+
+    # Verify dependency chain
+    assert dag.has_edge("finalize", "process"), "Expected finalize -> process edge"
+    assert dag.has_edge("process", "extract"), "Expected process -> extract edge"
+
+    # Verify state_dirs are preserved
+    assert child.get("extract")["state_dir"] == set_project_root / ".pivot"
+    assert child.get("process")["state_dir"] == parent_dir / ".pivot"
+    assert child.get("finalize")["state_dir"] == child_dir / ".pivot"
+
+
+def test_lazy_resolution_with_pivot_yaml_parent(set_project_root: pathlib.Path) -> None:
+    """Should resolve dependencies from parent defined in pivot.yaml.
+
+    Tests that lazy resolution works with YAML-configured parent pipelines,
+    not just pipeline.py.
+    """
+    # Create parent stages.py module
+    parent_stages = set_project_root / "stages.py"
+    parent_stages.write_text("""
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot import loaders
+from pivot.outputs import Out
+
+class ProducerOutput(TypedDict):
+    data: Annotated[Path, Out("data.txt", loaders.PathOnly())]
+
+def producer() -> ProducerOutput:
+    Path("data.txt").write_text("from yaml parent")
+    return ProducerOutput(data=Path("data.txt"))
+""")
+
+    # Parent pipeline via pivot.yaml
+    pivot_yaml = set_project_root / "pivot.yaml"
+    pivot_yaml.write_text("""
+pipeline: yaml_parent
+stages:
+  producer:
+    python: stages.producer
+""")
+
+    # Child pipeline.py depends on data.txt
+    child_dir = set_project_root / "child"
+    child_dir.mkdir()
+    (child_dir / "pipeline.py").write_text(
+        _make_consumer_pipeline_code("child", "consumer", "../data.txt", "result.txt")
+    )
+
+    with stage_module_isolation(set_project_root):
+        # Load child and resolve
+        child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
+        assert child is not None, "Failed to load child pipeline"
+
+        child.resolve_from_parents()
+
+    # Should include producer from YAML parent
+    assert "producer" in child.list_stages(), "Expected to include producer from pivot.yaml parent"
+    assert "consumer" in child.list_stages()
+
+    # Build DAG should succeed
+    dag = child.build_dag(validate=True)
+    assert dag.has_edge("consumer", "producer")


### PR DESCRIPTION
## Summary

Enables pipelines to automatically discover and include stages from parent pipelines when dependencies are unresolved locally.

- Add `find_parent_pipeline_paths()` to traverse up directory tree finding parent pipeline configs
- Add `load_pipeline_from_path()` to load a Pipeline from a pivot.yaml or pipeline.py file
- Add `Pipeline.resolve_from_parents()` method that resolves unresolved dependencies by searching parent pipelines

## Key behaviors

- Searches for both pivot.yaml and pipeline.py (errors if both exist in same directory)
- Closest parent is searched first
- Transitive dependencies are resolved iteratively
- Files on disk are treated as external inputs
- Per-call caching (no persistence between calls - safe for watch mode)
- Parent stages retain their original state_dir

## Test plan

- [x] Unit tests for `find_parent_pipeline_paths` (4 tests)
- [x] Unit tests for `load_pipeline_from_path` (4 tests)
- [x] Unit tests for `resolve_from_parents` (12 tests)
- [x] Integration tests for lazy resolution (4 tests)
- [x] All 3080 tests passing
- [x] basedpyright: 0 errors
- [x] ruff: all checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)