### PR TITLE
feat(cli): redesign pull/fetch commands and reorganize categories

### DIFF
--- a/docs/plans/2026-02-03-pull-fetch-cli-redesign.md
+++ b/docs/plans/2026-02-03-pull-fetch-cli-redesign.md
@@ -1,0 +1,736 @@
+# Pull/Fetch CLI Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `pivot pull` match git/dvc semantics (fetch + checkout), add `fetch` command, promote `data` subcommands to top-level, and reorganize CLI categories.
+
+**Architecture:** Rename current `pull` to `fetch`, create new `pull` that chains fetch + checkout. Move `data diff` and `data get` to top-level commands. Update CLI registry and categories.
+
+**Tech Stack:** Python 3.13, Click, pytest
+
+**Issue:** https://github.com/sjawhar/pivot/issues/336
+
+---
+
+## Task 1: Implement All CLI Changes
+
+**Files:**
+- Modify: `src/pivot/cli/remote.py`
+- Modify: `src/pivot/cli/data.py`
+- Modify: `src/pivot/cli/__init__.py`
+
+### Step 1: Rename `pull` to `fetch` in remote.py
+
+In `src/pivot/cli/remote.py`, rename the `pull` function to `fetch` and update docstrings/messages:
+
+```python
+@cli_decorators.pivot_command(auto_discover=False)
+@click.argument("targets", nargs=-1, shell_complete=completion.complete_targets)
+@click.option("-r", "--remote", "remote_name", help="Remote name (uses default if not specified)")
+@click.option("--dry-run", "-n", is_flag=True, help="Show what would be fetched")
+@click.option(
+    "-j", "--jobs", type=click.IntRange(min=1), default=None, help="Parallel download jobs"
+)
+@click.pass_context
+def fetch(
+    ctx: click.Context,
+    targets: tuple[str, ...],
+    remote_name: str | None,
+    dry_run: bool,
+    jobs: int | None,
+) -> None:
+    """Fetch cached outputs from remote storage to local cache.
+
+    TARGETS can be stage names or file paths. If specified, fetches those
+    outputs (and dependencies for stages). Otherwise, fetches all available
+    files from remote.
+
+    This command only downloads to the local cache. Use 'pivot pull' to also
+    restore files to your workspace, or 'pivot checkout' to restore from cache.
+    """
+    cli_ctx = cli_helpers.get_cli_context(ctx)
+    quiet = cli_ctx["quiet"]
+    jobs = jobs if jobs is not None else config.get_remote_jobs()
+
+    cache_dir = config.get_cache_dir()
+    state_dir = config.get_state_dir()
+    s3_remote, resolved_name = transfer.create_remote_from_name(remote_name)
+
+    targets_list = list(targets) if targets else None
+
+    if dry_run:
+        if targets_list:
+            needed = transfer.get_target_hashes(targets_list, state_dir, include_deps=True)
+        else:
+            needed = asyncio.run(s3_remote.list_hashes())
+
+        local = transfer.get_local_cache_hashes(cache_dir)
+        missing = needed - local
+        if not quiet:
+            click.echo(f"Would fetch {len(missing)} file(s) from '{resolved_name}'")
+        return
+
+    with state.StateDB(config.get_state_db_path()) as state_db:
+        result = transfer.pull(
+            cache_dir,
+            state_dir,
+            s3_remote,
+            state_db,
+            resolved_name,
+            targets_list,
+            jobs,
+            None if quiet else cli_helpers.make_progress_callback("Downloaded"),
+        )
+
+    if not quiet:
+        transferred = result["transferred"]
+        skipped = result["skipped"]
+        failed = result["failed"]
+        click.echo(
+            f"Fetched from '{resolved_name}': {transferred} transferred, {skipped} skipped, {failed} failed"
+        )
+
+    cli_helpers.print_transfer_errors(result["errors"])
+    if result["failed"] > 0:
+        raise SystemExit(1)
+```
+
+### Step 2: Add new `pull` command in remote.py
+
+Add after the `fetch` function. Note: we call the underlying functions directly (not `ctx.invoke`) to properly handle errors and exit codes:
+
+```python
+@cli_decorators.pivot_command(auto_discover=False)
+@click.argument("targets", nargs=-1, shell_complete=completion.complete_targets)
+@click.option("-r", "--remote", "remote_name", help="Remote name (uses default if not specified)")
+@click.option("--dry-run", "-n", is_flag=True, help="Show what would be pulled")
+@click.option(
+    "-j", "--jobs", type=click.IntRange(min=1), default=None, help="Parallel download jobs"
+)
+@click.option("--force", "-f", is_flag=True, help="Overwrite existing workspace files")
+@click.option(
+    "--only-missing",
+    is_flag=True,
+    help="Only restore files that don't exist in workspace",
+)
+@click.option(
+    "--checkout-mode",
+    type=click.Choice(["symlink", "hardlink", "copy"]),
+    default=None,
+    help="Checkout mode for restoration (default: project config or hardlink)",
+)
+@click.pass_context
+def pull(
+    ctx: click.Context,
+    targets: tuple[str, ...],
+    remote_name: str | None,
+    dry_run: bool,
+    jobs: int | None,
+    force: bool,
+    only_missing: bool,
+    checkout_mode: str | None,
+) -> None:
+    """Pull cached outputs from remote and restore to workspace.
+
+    Combines 'fetch' (download from remote) and 'checkout' (restore to workspace).
+    This matches the behavior of 'git pull' and 'dvc pull'.
+
+    TARGETS can be stage names or file paths. If specified, pulls those
+    outputs (and dependencies for stages). Otherwise, pulls all available files.
+    """
+    if force and only_missing:
+        raise click.ClickException("--force and --only-missing are mutually exclusive")
+
+    cli_ctx = cli_helpers.get_cli_context(ctx)
+    quiet = cli_ctx["quiet"]
+    jobs = jobs if jobs is not None else config.get_remote_jobs()
+
+    cache_dir = config.get_cache_dir()
+    state_dir = config.get_state_dir()
+    s3_remote, resolved_name = transfer.create_remote_from_name(remote_name)
+
+    targets_list = list(targets) if targets else None
+
+    # Dry-run: show what would be fetched, don't proceed to checkout
+    if dry_run:
+        if targets_list:
+            needed = transfer.get_target_hashes(targets_list, state_dir, include_deps=True)
+        else:
+            needed = asyncio.run(s3_remote.list_hashes())
+
+        local = transfer.get_local_cache_hashes(cache_dir)
+        missing = needed - local
+        if not quiet:
+            click.echo(f"Would fetch {len(missing)} file(s) from '{resolved_name}'")
+        return
+
+    # Step 1: Fetch from remote to cache
+    with state.StateDB(config.get_state_db_path()) as state_db:
+        fetch_result = transfer.pull(
+            cache_dir,
+            state_dir,
+            s3_remote,
+            state_db,
+            resolved_name,
+            targets_list,
+            jobs,
+            None if quiet else cli_helpers.make_progress_callback("Downloaded"),
+        )
+
+    if not quiet:
+        click.echo(
+            f"Fetched from '{resolved_name}': {fetch_result['transferred']} transferred, "
+            f"{fetch_result['skipped']} skipped, {fetch_result['failed']} failed"
+        )
+
+    cli_helpers.print_transfer_errors(fetch_result["errors"])
+
+    # If fetch had failures, exit without checkout
+    if fetch_result["failed"] > 0:
+        raise SystemExit(1)
+
+    # Step 2: Checkout from cache to workspace
+    # Import here to avoid circular imports at module level
+    from pivot.cli import checkout as checkout_mod
+
+    ctx.invoke(
+        checkout_mod.checkout,
+        targets=targets,
+        checkout_mode=checkout_mode,
+        force=force,
+        only_missing=only_missing,
+    )
+```
+
+### Step 3: Promote `data diff` to top-level `diff` in data.py
+
+In `src/pivot/cli/data.py`, change `data_diff` to a standalone `diff` command:
+
+```python
+@cli_decorators.pivot_command()
+@click.argument("targets", nargs=-1, required=True)
+@click.option("--key", "key_cols", help="Comma-separated key columns for row matching")
+@click.option("--positional", is_flag=True, help="Use positional (row-by-row) matching")
+@click.option("--summary", is_flag=True, help="Show summary only (schema + counts)")
+@click.option("--no-tui", is_flag=True, help="Print to stdout instead of launching TUI")
+@click.option(
+    "--json",
+    "output_format",
+    flag_value=OutputFormat.JSON,
+    help="Output as JSON (implies --no-tui)",
+)
+@click.option(
+    "--md",
+    "output_format",
+    flag_value=OutputFormat.MD,
+    help="Output as Markdown (implies --no-tui)",
+)
+@click.option(
+    "--max-rows", default=None, type=click.IntRange(min=1), help="Max rows for comparison"
+)
+def diff(
+    targets: tuple[str, ...],
+    key_cols: str | None,
+    positional: bool,
+    summary: bool,
+    no_tui: bool,
+    output_format: OutputFormat | None,
+    max_rows: int | None,
+) -> None:
+    """Compare data files in workspace against git HEAD.
+
+    Compares CSV, JSON, and JSONL files showing schema changes, row additions,
+    deletions, and modifications. Detects reorder-only changes.
+    """
+    # Function body unchanged from data_diff
+```
+
+Remove the `@data.command("diff")` and `@cli_decorators.with_error_handling` decorators (pivot_command includes error handling).
+
+### Step 4: Promote `data get` to top-level `get` in data.py
+
+```python
+@cli_decorators.pivot_command(auto_discover=False)
+@click.argument("targets", nargs=-1, required=True)
+@click.option(
+    "--rev",
+    "-r",
+    required=True,
+    help="Git revision (SHA, branch, tag) to retrieve files from",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=pathlib.Path),
+    default=None,
+    help="Output path for single file target (incompatible with multiple targets or stage names)",
+)
+@click.option(
+    "--checkout-mode",
+    type=click.Choice(["symlink", "hardlink", "copy"]),
+    default=None,
+    help="Checkout mode for restoration (default: project config or hardlink)",
+)
+@click.option("--force", "-f", is_flag=True, help="Overwrite existing files")
+def get(
+    targets: tuple[str, ...],
+    rev: str,
+    output: pathlib.Path | None,
+    checkout_mode: str | None,
+    force: bool,
+) -> None:
+    """Retrieve files or stage outputs from a specific git revision.
+
+    TARGETS can be file paths or stage names.
+
+    \b
+    Examples:
+      pivot get --rev v1.0 model.pkl              # Get file from tag
+      pivot get --rev v1.0 model.pkl -o old.pkl   # Get file to alternate location
+      pivot get --rev abc123 train                # Get all outputs from stage
+    """
+    # Function body unchanged from data_get
+```
+
+### Step 5: Remove the `data` command group in data.py
+
+Delete these lines from `src/pivot/cli/data.py`:
+
+```python
+@click.group()
+def data() -> None:
+    """Inspect and compare data files."""
+```
+
+### Step 6: Update CLI registry and categories in __init__.py
+
+Update `COMMAND_CATEGORIES`:
+
+```python
+COMMAND_CATEGORIES = {
+    "Pipeline": ["run", "repro", "status", "verify", "commit"],
+    "Sync": ["checkout", "fetch", "get", "pull", "push", "remote", "track"],
+    "Inspection": ["dag", "diff", "history", "list", "metrics", "params", "plots", "show"],
+    "Other": [
+        "init",
+        "export",
+        "import-dvc",
+        "config",
+        "completion",
+        "schema",
+        "check-ignore",
+        "doctor",
+    ],
+}
+```
+
+Update `_LAZY_COMMANDS` - remove `data`, add `fetch`, `diff`, `get`, update `pull`:
+
+```python
+_LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
+    "init": ("pivot.cli.init", "init", "Initialize a new Pivot project."),
+    "run": ("pivot.cli.run", "run", "Execute pipeline stages."),
+    "repro": ("pivot.cli.repro", "repro", "Reproduce pipeline with full DAG resolution."),
+    "dag": ("pivot.cli.dag", "dag_cmd", "Visualize pipeline DAG."),
+    "list": ("pivot.cli.list", "list_cmd", "List registered stages."),
+    "export": ("pivot.cli.export", "export", "Export pipeline to DVC YAML format."),
+    "import-dvc": (
+        "pivot.cli.import_dvc",
+        "import_dvc",
+        "Import DVC pipeline and convert to Pivot format.",
+    ),
+    "track": ("pivot.cli.track", "track", "Track files/directories for caching."),
+    "status": ("pivot.cli.status", "status", "Show pipeline, tracked files, and remote status."),
+    "verify": (
+        "pivot.cli.verify",
+        "verify",
+        "Verify pipeline was reproduced and outputs are available.",
+    ),
+    "checkout": (
+        "pivot.cli.checkout",
+        "checkout",
+        "Restore tracked files and stage outputs from cache.",
+    ),
+    "metrics": ("pivot.cli.metrics", "metrics", "Display and compare metrics."),
+    "plots": ("pivot.cli.plots", "plots", "Display and compare plots."),
+    "params": ("pivot.cli.params", "params", "Display and compare parameters."),
+    "remote": ("pivot.cli.remote", "remote", "Manage remote storage for cache synchronization."),
+    "push": ("pivot.cli.remote", "push", "Push cached outputs to remote storage."),
+    "fetch": ("pivot.cli.remote", "fetch", "Fetch cached outputs from remote to local cache."),
+    "pull": ("pivot.cli.remote", "pull", "Pull and restore outputs from remote storage."),
+    "diff": ("pivot.cli.data", "diff", "Compare data files against git HEAD."),
+    "get": ("pivot.cli.data", "get", "Retrieve files from a specific git revision."),
+    "completion": ("pivot.cli.completion", "completion_cmd", "Generate shell completion script."),
+    "config": ("pivot.cli.config", "config_cmd", "View and modify Pivot configuration."),
+    "history": ("pivot.cli.history", "history", "List recent pipeline runs."),
+    "show": ("pivot.cli.history", "show_cmd", "Show details of a specific run."),
+    "schema": ("pivot.cli.schema", "schema", "Output JSON Schema for pivot.yaml configuration."),
+    "commit": ("pivot.cli.commit", "commit_command", "Commit pending locks from --no-commit runs."),
+    "check-ignore": (
+        "pivot.cli.check_ignore",
+        "check_ignore",
+        "Check if paths are ignored by .pivotignore.",
+    ),
+    "doctor": ("pivot.cli.doctor", "doctor", "Check environment and configuration for issues."),
+}
+```
+
+---
+
+## Task 2: Update All Tests
+
+**Files:**
+- Modify: `tests/remote/test_cli_remote.py`
+- Modify: `tests/cli/test_cli_data.py`
+
+### Step 1: Rename pull tests to fetch tests in test_cli_remote.py
+
+Update these test functions (rename and change invocations/assertions):
+
+| Old function name | New function name |
+|-------------------|-------------------|
+| `test_pull_dry_run_with_targets` | `test_fetch_dry_run_with_targets` |
+| `test_pull_dry_run_all` | `test_fetch_dry_run_all` |
+| `test_pull_success` | `test_fetch_success` |
+| `test_pull_with_errors` | `test_fetch_with_errors` |
+| `test_pull_with_stages` | `test_fetch_with_stages` |
+| `test_pull_exception_shows_click_error` | `test_fetch_exception_shows_click_error` |
+
+For each test:
+- Change `runner.invoke(cli.cli, ["pull", ...])` to `runner.invoke(cli.cli, ["fetch", ...])`
+- Change assertions from "Pulled from" to "Fetched from"
+- Change assertions from "Would pull" to "Would fetch"
+
+Example for `test_fetch_success`:
+
+```python
+def test_fetch_success(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Fetch command downloads files and shows summary."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        cache_dir = tmp_path / ".pivot" / "cache"
+        cache_dir.mkdir(parents=True)
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=cache_dir)
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+
+        mock_pull = mocker.patch.object(
+            transfer,
+            "pull",
+            return_value=TransferSummary(transferred=3, skipped=1, failed=0, errors=[]),
+        )
+
+        mock_state_db = mocker.MagicMock()
+        mocker.patch.object(state, "StateDB", return_value=mock_state_db)
+
+        result = runner.invoke(cli.cli, ["fetch"])
+
+        assert result.exit_code == 0
+        assert "Fetched from 'origin': 3 transferred, 1 skipped, 0 failed" in result.output
+        mock_pull.assert_called_once()
+```
+
+### Step 2: Add tests for new pull command in test_cli_remote.py
+
+```python
+# =============================================================================
+# Pull Command Tests (fetch + checkout)
+# =============================================================================
+
+
+def test_pull_force_and_only_missing_conflict(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pull errors when both --force and --only-missing specified."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        result = runner.invoke(cli.cli, ["pull", "--force", "--only-missing"])
+
+        assert result.exit_code != 0
+        assert "--force and --only-missing are mutually exclusive" in result.output
+
+
+def test_pull_dry_run_does_not_checkout(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Pull --dry-run only shows fetch info, doesn't checkout."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mock_remote = mocker.MagicMock()
+
+        async def mock_list_hashes() -> set[str]:
+            return {"hash1", "hash2"}
+
+        mock_remote.list_hashes = mock_list_hashes
+
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=tmp_path / ".pivot/cache")
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mock_remote, "origin"),
+        )
+        mocker.patch.object(transfer, "get_local_cache_hashes", return_value=set())
+
+        result = runner.invoke(cli.cli, ["pull", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would fetch" in result.output
+
+
+def test_pull_success_fetches_and_checks_out(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Pull fetches from remote then checks out to workspace."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        cache_dir = tmp_path / ".pivot" / "cache"
+        state_dir = tmp_path / ".pivot"
+        cache_dir.mkdir(parents=True)
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=cache_dir)
+        mocker.patch.object(config_mod, "get_state_dir", return_value=state_dir)
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+        mocker.patch.object(
+            transfer,
+            "pull",
+            return_value=TransferSummary(transferred=2, skipped=0, failed=0, errors=[]),
+        )
+
+        mock_state_db = mocker.MagicMock()
+        mocker.patch.object(state, "StateDB", return_value=mock_state_db)
+
+        # Mock checkout to verify it's called
+        from pivot.cli import checkout as checkout_mod
+
+        mock_checkout = mocker.patch.object(checkout_mod, "checkout", autospec=True)
+
+        result = runner.invoke(cli.cli, ["pull"])
+
+        assert result.exit_code == 0
+        assert "Fetched from 'origin'" in result.output
+        mock_checkout.assert_called_once()
+
+
+def test_pull_stops_on_fetch_failure(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Pull exits without checkout when fetch has failures."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        cache_dir = tmp_path / ".pivot" / "cache"
+        cache_dir.mkdir(parents=True)
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=cache_dir)
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+        mocker.patch.object(
+            transfer,
+            "pull",
+            return_value=TransferSummary(
+                transferred=1, skipped=0, failed=1, errors=["Download failed: hash1"]
+            ),
+        )
+
+        mock_state_db = mocker.MagicMock()
+        mocker.patch.object(state, "StateDB", return_value=mock_state_db)
+
+        # Mock checkout to verify it's NOT called
+        from pivot.cli import checkout as checkout_mod
+
+        mock_checkout = mocker.patch.object(checkout_mod, "checkout", autospec=True)
+
+        result = runner.invoke(cli.cli, ["pull"])
+
+        assert result.exit_code == 1
+        assert "1 failed" in result.output
+        mock_checkout.assert_not_called()
+
+
+def test_pull_passes_targets_to_fetch_and_checkout(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Pull passes same targets to both fetch and checkout."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".git").mkdir()
+        cache_dir = tmp_path / ".pivot" / "cache"
+        state_dir = tmp_path / ".pivot"
+        cache_dir.mkdir(parents=True)
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=cache_dir)
+        mocker.patch.object(config_mod, "get_state_dir", return_value=state_dir)
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+        mock_transfer_pull = mocker.patch.object(
+            transfer,
+            "pull",
+            return_value=TransferSummary(transferred=1, skipped=0, failed=0, errors=[]),
+        )
+
+        mock_state_db = mocker.MagicMock()
+        mocker.patch.object(state, "StateDB", return_value=mock_state_db)
+
+        from pivot.cli import checkout as checkout_mod
+
+        mock_checkout = mocker.patch.object(checkout_mod, "checkout", autospec=True)
+
+        result = runner.invoke(cli.cli, ["pull", "train_model", "evaluate"])
+
+        assert result.exit_code == 0
+        # Verify targets passed to transfer.pull
+        call_args = mock_transfer_pull.call_args
+        assert call_args.args[5] == ["train_model", "evaluate"]
+        # Verify targets passed to checkout (via ctx.invoke, check call kwargs)
+        checkout_call = mock_checkout.call_args
+        assert checkout_call.kwargs.get("targets") == ("train_model", "evaluate")
+```
+
+### Step 3: Update data diff/get tests in test_cli_data.py
+
+Update all test invocations from `["data", "diff", ...]` to `["diff", ...]` and `["data", "get", ...]` to `["get", ...]`:
+
+| Test function | Change |
+|---------------|--------|
+| `test_data_diff_help` → `test_diff_help` | `["data", "diff", "--help"]` → `["diff", "--help"]` |
+| `test_data_group_help` | DELETE |
+| `test_data_in_main_help` | DELETE |
+| `test_data_diff_no_stages` → `test_diff_no_stages` | Update invoke |
+| `test_data_diff_key_and_positional_conflict` → `test_diff_key_and_positional_conflict` | Update invoke |
+| `test_data_diff_requires_targets` → `test_diff_requires_targets` | Update invoke |
+| `test_data_diff_csv_file` → `test_diff_csv_file` | Update invoke |
+| `test_data_diff_json_output` → `test_diff_json_output` | Update invoke |
+| `test_data_diff_key_columns` → `test_diff_key_columns` | Update invoke |
+| `test_data_diff_positional` → `test_diff_positional` | Update invoke |
+| `test_data_diff_no_changes_message` → `test_diff_no_changes_message` | Update invoke |
+| `test_data_diff_json_empty_returns_valid_json` → `test_diff_json_empty_returns_valid_json` | Update invoke |
+| `test_data_get_stage_output` → `test_get_stage_output` | Update invoke |
+| `test_data_get_checkout_mode` → `test_get_checkout_mode` | Update invoke |
+| `test_data_diff_without_prior_run_discovers_pipeline` → `test_diff_without_prior_run_discovers_pipeline` | Update invoke |
+| `test_data_get_without_prior_run_discovers_pipeline` → `test_get_without_prior_run_discovers_pipeline` | Update invoke |
+
+Add tests for new top-level commands appearing in main help:
+
+```python
+def test_diff_in_main_help(runner: click.testing.CliRunner) -> None:
+    """diff command appears in main help."""
+    result = runner.invoke(cli.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "diff" in result.output
+
+
+def test_get_in_main_help(runner: click.testing.CliRunner) -> None:
+    """get command appears in main help."""
+    result = runner.invoke(cli.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "get" in result.output
+```
+
+---
+
+## Task 3: Final Verification
+
+**Files:** None (verification only)
+
+### Step 1: Run all tests
+
+```bash
+uv run pytest tests/ -n auto
+```
+
+Expected: All tests pass
+
+### Step 2: Run linting and type checks
+
+```bash
+uv run ruff format . && uv run ruff check . && uv run basedpyright
+```
+
+Expected: No errors
+
+### Step 3: Verify CLI help output
+
+```bash
+uv run pivot --help
+```
+
+Expected structure:
+```
+Pipeline Commands:
+  commit, repro, run, status, verify
+
+Sync Commands:
+  checkout, fetch, get, pull, push, remote, track
+
+Inspection Commands:
+  dag, diff, history, list, metrics, params, plots, show
+
+Other Commands:
+  check-ignore, completion, config, doctor, export, import-dvc, init, schema
+```
+
+### Step 4: Commit
+
+```bash
+jj describe -m "feat(cli): redesign pull/fetch commands and reorganize categories
+
+BREAKING CHANGE: pivot pull now fetches AND checks out (like git/dvc pull)
+
+- Rename pull to fetch (downloads to cache only)
+- New pull = fetch + checkout (matches git/dvc semantics)
+- Promote 'data diff' to top-level 'diff' command
+- Promote 'data get' to top-level 'get' command
+- Remove 'data' command group
+- Reorganize CLI categories: Pipeline, Sync, Inspection, Other
+
+Closes #336"
+```
+
+---
+
+## Summary
+
+| Task | Description |
+|------|-------------|
+| 1 | All code changes (rename pull→fetch, new pull, promote diff/get, update registry) |
+| 2 | All test updates (rename tests, add new pull tests, update diff/get tests) |
+| 3 | Final verification (tests, linting, types, CLI help, commit) |

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -13,6 +13,8 @@ from pivot.tui import console
 if TYPE_CHECKING:
     from click.testing import CliRunner
 
+    from pivot.pipeline.pipeline import Pipeline
+
 
 # =============================================================================
 # Module-level stage functions for testing (required for pickling)
@@ -137,7 +139,7 @@ def test_cli_list_command_exists(runner: CliRunner) -> None:
 
 def test_cli_list_shows_registered_stages(
     runner: CliRunner,
-    mock_discovery: object,  # type: ignore[type-arg]
+    mock_discovery: Pipeline,
 ) -> None:
     """List should show registered stages."""
     register_test_stage(_stage_my_stage, name="my_stage")
@@ -149,7 +151,7 @@ def test_cli_list_shows_registered_stages(
 
 def test_cli_list_verbose_shows_details(
     runner: CliRunner,
-    mock_discovery: object,  # type: ignore[type-arg]
+    mock_discovery: Pipeline,
 ) -> None:
     """List --verbose should show deps and outputs."""
     register_test_stage(_stage_with_input, name="my_stage")
@@ -624,8 +626,8 @@ def test_cli_help_shows_categorized_commands(runner: CliRunner) -> None:
     assert result.exit_code == 0
     assert "Pipeline Commands:" in result.output
     assert "Inspection Commands:" in result.output
-    assert "Versioning Commands:" in result.output
-    assert "Remote Commands:" in result.output
+    assert "Sync Commands:" in result.output
+    assert "Other Commands:" in result.output
 
 
 def test_cli_help_contains_pipeline_commands(runner: CliRunner) -> None:
@@ -648,7 +650,7 @@ def test_cli_help_contains_inspection_commands(runner: CliRunner) -> None:
     assert "metrics" in result.output, "Should show 'metrics' command"
     assert "params" in result.output, "Should show 'params' command"
     assert "plots" in result.output, "Should show 'plots' command"
-    assert "data" in result.output, "Should show 'data' command"
+    assert "diff" in result.output, "Should show 'diff' command"
 
 
 # =============================================================================

--- a/tests/cli/test_cli_data.py
+++ b/tests/cli/test_cli_data.py
@@ -30,13 +30,13 @@ class _CsvOutputs(TypedDict):
 
 
 # =============================================================================
-# Data Diff Help Tests
+# Diff Help Tests
 # =============================================================================
 
 
-def test_data_diff_help(runner: click.testing.CliRunner) -> None:
-    """Data diff command should show help."""
-    result = runner.invoke(cli.cli, ["data", "diff", "--help"])
+def test_diff_help(runner: click.testing.CliRunner) -> None:
+    """Diff command should show help."""
+    result = runner.invoke(cli.cli, ["diff", "--help"])
     assert result.exit_code == 0
     assert "TARGETS" in result.output
     assert "--key" in result.output
@@ -48,75 +48,74 @@ def test_data_diff_help(runner: click.testing.CliRunner) -> None:
     assert "--max-rows" in result.output
 
 
-def test_data_group_help(runner: click.testing.CliRunner) -> None:
-    """Data group shows subcommands."""
-    result = runner.invoke(cli.cli, ["data", "--help"])
+def test_diff_in_main_help(runner: click.testing.CliRunner) -> None:
+    """diff command appears in main help."""
+    result = runner.invoke(cli.cli, ["--help"])
     assert result.exit_code == 0
     assert "diff" in result.output
+
+
+def test_get_in_main_help(runner: click.testing.CliRunner) -> None:
+    """get command appears in main help."""
+    result = runner.invoke(cli.cli, ["--help"])
+    assert result.exit_code == 0
     assert "get" in result.output
 
 
-def test_data_in_main_help(runner: click.testing.CliRunner) -> None:
-    """Data command appears in main help."""
-    result = runner.invoke(cli.cli, ["--help"])
-    assert result.exit_code == 0
-    assert "data" in result.output
-
-
 # =============================================================================
-# Data Diff - No Stage Tests
+# Diff - No Stage Tests
 # =============================================================================
 
 
-def test_data_diff_no_stages(
+def test_diff_no_stages(
     runner: click.testing.CliRunner, tmp_path: pathlib.Path, mock_discovery: Pipeline
 ) -> None:
-    """Data diff with no registered stages should report no data files."""
+    """Diff with no registered stages should report no data files."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
-        result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "data.csv"])
+        result = runner.invoke(cli.cli, ["diff", "--no-tui", "data.csv"])
     assert result.exit_code == 0
     assert "No data files found" in result.output
 
 
 # =============================================================================
-# Data Diff - Conflicting Options
+# Diff - Conflicting Options
 # =============================================================================
 
 
-def test_data_diff_key_and_positional_conflict(
+def test_diff_key_and_positional_conflict(
     runner: click.testing.CliRunner, tmp_path: pathlib.Path, mock_discovery: Pipeline
 ) -> None:
-    """Data diff should error when both --key and --positional are specified."""
+    """Diff should error when both --key and --positional are specified."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
         # Need to create a file so the targets validation passes
         pathlib.Path("data.csv").write_text("id,name\n1,alice\n")
         result = runner.invoke(
-            cli.cli, ["data", "diff", "--no-tui", "--key", "id", "--positional", "data.csv"]
+            cli.cli, ["diff", "--no-tui", "--key", "id", "--positional", "data.csv"]
         )
     assert result.exit_code != 0
     assert "Cannot use both --key and --positional" in result.output
 
 
 # =============================================================================
-# Data Diff - Required Arguments
+# Diff - Required Arguments
 # =============================================================================
 
 
-def test_data_diff_requires_targets(
+def test_diff_requires_targets(
     runner: click.testing.CliRunner, tmp_path: pathlib.Path, mock_discovery: Pipeline
 ) -> None:
-    """Data diff requires at least one target."""
+    """Diff requires at least one target."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".git").mkdir()
-        result = runner.invoke(cli.cli, ["data", "diff", "--no-tui"])
+        result = runner.invoke(cli.cli, ["diff", "--no-tui"])
     assert result.exit_code != 0
     assert "Missing argument" in result.output or "required" in result.output.lower()
 
 
 # =============================================================================
-# Data Diff - CSV File Tests
+# Diff - CSV File Tests
 # =============================================================================
 
 
@@ -126,7 +125,7 @@ def _helper_make_csv_output() -> _CsvOutputs:
     return {"output": pathlib.Path("output.csv")}
 
 
-def test_data_diff_csv_file(
+def test_diff_csv_file(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -175,7 +174,7 @@ dep_generations: {{}}
     csv_file.unlink()
     csv_file.write_text("id,value\n1,10\n2,25\n3,30\n")  # Changed row 2, added row 3
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     # Should show row changes
@@ -183,7 +182,7 @@ dep_generations: {{}}
     assert "Rows:" in result.output
 
 
-def test_data_diff_json_output(
+def test_diff_json_output(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -224,7 +223,7 @@ dep_generations: {{}}
     csv_file.unlink()
     csv_file.write_text("id,value\n1,99\n")
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--json", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--json", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     # Output should be valid JSON
@@ -235,7 +234,7 @@ dep_generations: {{}}
     assert data[0]["path"] == "output.csv"
 
 
-def test_data_diff_key_columns(
+def test_diff_key_columns(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -276,14 +275,14 @@ dep_generations: {{}}
     csv_file.unlink()
     csv_file.write_text("id,name,value\n1,alice,15\n2,bob,20\n3,charlie,30\n")
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "--key", "id", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "--key", "id", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     # Should detect modified row (alice) and added row (charlie)
     assert "output.csv" in result.output
 
 
-def test_data_diff_positional(
+def test_diff_positional(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -325,13 +324,13 @@ dep_generations: {{}}
     csv_file.unlink()
     csv_file.write_text("id,value\n2,20\n1,10\n")
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "--positional", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "--positional", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "output.csv" in result.output
 
 
-def test_data_diff_no_changes_message(
+def test_diff_no_changes_message(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -370,14 +369,14 @@ dep_generations: {{}}
     # Don't modify - workspace same as HEAD
     # Workspace hash should match HEAD hash
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     # Should have an explicit message about no changes
     assert "No data file changes" in result.output
 
 
-def test_data_diff_json_empty_returns_valid_json(
+def test_diff_json_empty_returns_valid_json(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     mocker: MockerFixture,
@@ -415,33 +414,24 @@ dep_generations: {{}}
 
     # No changes - same content as HEAD
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--json", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--json", "output.csv"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
-    # When no changes, output may be plain message or empty JSON
-    # The code returns early with "No data file changes" in non-json mode
-    # But with --json it should still return valid output (possibly text message)
-    # Based on the code, it returns early with text if no hash_diffs
-    # So we accept either valid JSON or explicit message
-    try:
-        data: list[dict[str, object]] = json.loads(result.output)
-        # If JSON, should be empty list
-        assert isinstance(data, list)
-        assert len(data) == 0
-    except json.JSONDecodeError:
-        # If not JSON, should have explicit message
-        assert "No data file changes" in result.output
+    # With --json flag, should always return valid JSON (empty list when no changes)
+    data: list[dict[str, object]] = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 0
 
 
 # =============================================================================
-# Data Get - Stage and Mode Tests
+# Get - Stage and Mode Tests
 # =============================================================================
 
 
-def test_data_get_stage_output(
+def test_get_stage_output(
     runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
 ) -> None:
-    """data get with stage name target."""
+    """get with stage name target."""
     repo_path, commit = git_repo
     (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
     (repo_path / ".pivot" / "stages").mkdir(parents=True)
@@ -473,7 +463,7 @@ dep_generations: {{}}
     output_file.unlink()
     assert not output_file.exists()
 
-    result = runner.invoke(cli.cli, ["data", "get", "--rev", sha[:7], "make_output"])
+    result = runner.invoke(cli.cli, ["get", "--rev", sha[:7], "make_output"])
 
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Restored" in result.output
@@ -481,7 +471,7 @@ dep_generations: {{}}
     assert output_file.read_text() == "stage output content"
 
 
-def test_data_get_checkout_mode(
+def test_get_checkout_mode(
     runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
 ) -> None:
     """--checkout-mode affects file restoration."""
@@ -515,7 +505,7 @@ size: 14
     # Test copy mode
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", sha[:7], "--checkout-mode", "copy", "data.txt"],
+        ["get", "--rev", sha[:7], "--checkout-mode", "copy", "data.txt"],
     )
 
     assert result.exit_code == 0, f"Failed: {result.output}"
@@ -527,17 +517,17 @@ size: 14
 
 
 # =============================================================================
-# Data Diff/Get - Pipeline Discovery Tests
+# Diff/Get - Pipeline Discovery Tests
 # =============================================================================
 
 
-def test_data_diff_without_prior_run_discovers_pipeline(
+def test_diff_without_prior_run_discovers_pipeline(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
-    """pivot data diff discovers pipeline without needing prior command."""
+    """pivot diff discovers pipeline without needing prior command."""
     repo_path, commit = git_repo
     monkeypatch.chdir(repo_path)
     (repo_path / ".pivot").mkdir()
@@ -554,7 +544,7 @@ def test_data_diff_without_prior_run_discovers_pipeline(
 
     commit("Initial setup")
 
-    result = runner.invoke(cli.cli, ["data", "diff", "--no-tui", "output.csv"])
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "output.csv"])
 
     # Should not raise NoPipelineError - discovery should have been called
     assert "No pipeline found" not in result.output
@@ -563,12 +553,12 @@ def test_data_diff_without_prior_run_discovers_pipeline(
     assert result.exit_code == 0 or "No data" in result.output
 
 
-def test_data_get_without_prior_run_discovers_pipeline(
+def test_get_without_prior_run_discovers_pipeline(
     runner: click.testing.CliRunner,
     git_repo: GitRepo,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """pivot data get discovers pipeline without needing prior command."""
+    """pivot get discovers pipeline without needing prior command."""
     repo_path, commit = git_repo
     monkeypatch.chdir(repo_path)
     (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
@@ -604,7 +594,7 @@ size: 8
     output_file.unlink()
     assert not output_file.exists()
 
-    result = runner.invoke(cli.cli, ["data", "get", "--rev", sha[:7], "output.csv"])
+    result = runner.invoke(cli.cli, ["get", "--rev", sha[:7], "output.csv"])
 
     # Should not raise NoPipelineError - may fail for other reasons but not discovery
     assert "No pipeline" not in result.output
@@ -612,3 +602,359 @@ size: 8
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Restored" in result.output
     assert output_file.exists()
+
+
+# =============================================================================
+# Diff - Additional Output Format Tests
+# =============================================================================
+
+
+def test_diff_summary_flag(
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    mocker: MockerFixture,
+) -> None:
+    """--summary flag shows only schema and counts, not detailed rows."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    # Create Pipeline with git_repo path and mock discovery to return it
+    pipeline = pipeline_mod.Pipeline("test", root=repo_path)
+    helpers.set_test_pipeline(pipeline)
+    mocker.patch.object(discovery, "discover_pipeline", return_value=pipeline)
+    mocker.patch.object(project, "_project_root_cache", repo_path)
+    mocker.patch.object(cli_decorators, "get_pipeline_from_context", return_value=pipeline)
+
+    register_test_stage(_helper_make_csv_output, name="make_csv")
+
+    # Create initial CSV and cache it
+    csv_file = repo_path / "output.csv"
+    csv_file.write_text("id,value\n1,10\n2,20\n")
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache.save_to_cache(csv_file, cache_dir)
+    assert output_hash is not None
+
+    lock_content = f"""code_manifest: {{}}
+params: {{}}
+deps: []
+outs:
+  - path: output.csv
+    hash: {output_hash["hash"]}
+dep_generations: {{}}
+"""
+    (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
+    commit("Initial CSV")
+
+    # Modify the CSV file (remove link first since cache creates hardlink/symlink)
+    csv_file.unlink()
+    csv_file.write_text("id,value,new_col\n1,10,100\n2,25,200\n3,30,300\n")
+
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "--summary", "output.csv"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "output.csv" in result.output
+    # Summary should show counts but not detailed row-by-row changes
+    assert "Rows:" in result.output or "Schema" in result.output
+
+
+def test_diff_markdown_output(
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    mocker: MockerFixture,
+) -> None:
+    """--md outputs Markdown-formatted diff."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    # Create Pipeline with git_repo path and mock discovery to return it
+    pipeline = pipeline_mod.Pipeline("test", root=repo_path)
+    helpers.set_test_pipeline(pipeline)
+    mocker.patch.object(discovery, "discover_pipeline", return_value=pipeline)
+    mocker.patch.object(project, "_project_root_cache", repo_path)
+    mocker.patch.object(cli_decorators, "get_pipeline_from_context", return_value=pipeline)
+
+    register_test_stage(_helper_make_csv_output, name="make_csv")
+
+    # Create initial CSV and cache it
+    csv_file = repo_path / "output.csv"
+    csv_file.write_text("id,value\n1,10\n")
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache.save_to_cache(csv_file, cache_dir)
+    assert output_hash is not None
+
+    lock_content = f"""code_manifest: {{}}
+params: {{}}
+deps: []
+outs:
+  - path: output.csv
+    hash: {output_hash["hash"]}
+dep_generations: {{}}
+"""
+    (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
+    commit("Initial")
+
+    # Modify workspace (remove link first since cache creates hardlink/symlink)
+    csv_file.unlink()
+    csv_file.write_text("id,value\n1,99\n")
+
+    result = runner.invoke(cli.cli, ["diff", "--md", "output.csv"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    # --md produces summary output (same format as plain for now)
+    # Verify the diff summary is present
+    assert "output.csv" in result.output
+    assert "Rows:" in result.output or "Row changes:" in result.output
+
+
+def test_diff_max_rows_parameter(
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    mocker: MockerFixture,
+) -> None:
+    """--max-rows limits comparison rows."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    # Create Pipeline with git_repo path and mock discovery to return it
+    pipeline = pipeline_mod.Pipeline("test", root=repo_path)
+    helpers.set_test_pipeline(pipeline)
+    mocker.patch.object(discovery, "discover_pipeline", return_value=pipeline)
+    mocker.patch.object(project, "_project_root_cache", repo_path)
+    mocker.patch.object(cli_decorators, "get_pipeline_from_context", return_value=pipeline)
+
+    register_test_stage(_helper_make_csv_output, name="make_csv")
+
+    # Create large CSV and cache it
+    csv_file = repo_path / "output.csv"
+    rows = "\n".join([f"{i},{i * 10}" for i in range(1, 101)])
+    csv_file.write_text(f"id,value\n{rows}\n")
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache.save_to_cache(csv_file, cache_dir)
+    assert output_hash is not None
+
+    lock_content = f"""code_manifest: {{}}
+params: {{}}
+deps: []
+outs:
+  - path: output.csv
+    hash: {output_hash["hash"]}
+dep_generations: {{}}
+"""
+    (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
+    commit("Large CSV")
+
+    # Modify one row (remove link first since cache creates hardlink/symlink)
+    csv_file.unlink()
+    rows_modified = "\n".join([f"{i},{i * 10 if i != 50 else 9999}" for i in range(1, 101)])
+    csv_file.write_text(f"id,value\n{rows_modified}\n")
+
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "--max-rows", "10", "output.csv"])
+
+    # Should succeed without error even with max-rows limit
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "output.csv" in result.output
+
+
+def test_diff_empty_csv_file(
+    runner: click.testing.CliRunner,
+    git_repo: GitRepo,
+    mocker: MockerFixture,
+) -> None:
+    """Diff handles empty CSV files gracefully."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    # Create Pipeline with git_repo path and mock discovery to return it
+    pipeline = pipeline_mod.Pipeline("test", root=repo_path)
+    helpers.set_test_pipeline(pipeline)
+    mocker.patch.object(discovery, "discover_pipeline", return_value=pipeline)
+    mocker.patch.object(project, "_project_root_cache", repo_path)
+    mocker.patch.object(cli_decorators, "get_pipeline_from_context", return_value=pipeline)
+
+    register_test_stage(_helper_make_csv_output, name="make_csv")
+
+    # Create empty CSV and cache it
+    csv_file = repo_path / "output.csv"
+    csv_file.write_text("id,value\n")  # Header only, no data rows
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache.save_to_cache(csv_file, cache_dir)
+    assert output_hash is not None
+
+    lock_content = f"""code_manifest: {{}}
+params: {{}}
+deps: []
+outs:
+  - path: output.csv
+    hash: {output_hash["hash"]}
+dep_generations: {{}}
+"""
+    (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
+    commit("Empty CSV")
+
+    # Modify to add rows (remove link first since cache creates hardlink/symlink)
+    csv_file.unlink()
+    csv_file.write_text("id,value\n1,10\n")
+
+    result = runner.invoke(cli.cli, ["diff", "--no-tui", "output.csv"])
+
+    # Should handle empty file without crashing
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "output.csv" in result.output
+
+
+# =============================================================================
+# Get - Multiple Targets Tests
+# =============================================================================
+
+
+def test_get_multiple_files(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get multiple files in single invocation."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    # Create and commit multiple files
+    (repo_path / "file1.txt").write_text("content1")
+    (repo_path / "file2.txt").write_text("content2")
+    sha = commit("Multiple files")
+
+    # Modify files
+    (repo_path / "file1.txt").write_text("modified1")
+    (repo_path / "file2.txt").write_text("modified2")
+
+    result = runner.invoke(cli.cli, ["get", "--rev", sha[:7], "--force", "file1.txt", "file2.txt"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    # Both files should be mentioned in output
+    assert "file1.txt" in result.output or "Restored" in result.output
+    # Verify files restored
+    assert (repo_path / "file1.txt").read_text() == "content1"
+    assert (repo_path / "file2.txt").read_text() == "content2"
+
+
+def test_get_output_with_multiple_targets_fails(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get with -o output path and multiple targets should fail with clear error."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    (repo_path / "file1.txt").write_text("content1")
+    (repo_path / "file2.txt").write_text("content2")
+    sha = commit("Multiple files")
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "-o", "output.txt", "file1.txt", "file2.txt"],
+    )
+
+    # Should fail - can't use -o with multiple targets
+    assert result.exit_code != 0
+    assert "output" in result.output.lower() or "multiple" in result.output.lower()
+
+
+def test_get_symlink_checkout_mode(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """--checkout-mode symlink creates symlinks."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    # Create file and cache it
+    from pivot.storage import cache as cache_mod
+
+    data_file = repo_path / "data.txt"
+    data_file.write_text("cached content")
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache_mod.save_to_cache(data_file, cache_dir)
+    assert output_hash is not None
+
+    # Create .pvt file to track it
+    pvt_content = f"""path: data.txt
+hash: {output_hash["hash"]}
+size: 14
+"""
+    pvt_path = repo_path / "data.txt.pvt"
+    pvt_path.write_text(pvt_content)
+
+    sha = commit("Track data file")
+
+    # Delete data file
+    data_file.unlink()
+    assert not data_file.exists()
+
+    # Test symlink mode
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "--checkout-mode", "symlink", "data.txt"],
+    )
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Restored" in result.output
+    assert data_file.exists()
+    # With symlink mode, file should be a symlink
+    assert data_file.is_symlink()
+    assert data_file.read_text() == "cached content"
+
+
+def test_get_hardlink_checkout_mode(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """--checkout-mode hardlink creates hardlinks."""
+    repo_path, commit = git_repo
+    (repo_path / ".pivot" / "cache" / "files").mkdir(parents=True)
+    (repo_path / ".pivot" / "stages").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    # Create file and cache it
+    from pivot.storage import cache as cache_mod
+
+    data_file = repo_path / "data.txt"
+    data_file.write_text("cached content")
+    cache_dir = repo_path / ".pivot" / "cache" / "files"
+    output_hash = cache_mod.save_to_cache(data_file, cache_dir)
+    assert output_hash is not None
+
+    # Create .pvt file to track it
+    pvt_content = f"""path: data.txt
+hash: {output_hash["hash"]}
+size: 14
+"""
+    pvt_path = repo_path / "data.txt.pvt"
+    pvt_path.write_text(pvt_content)
+
+    sha = commit("Track data file")
+
+    # Delete data file
+    data_file.unlink()
+    assert not data_file.exists()
+
+    # Test hardlink mode
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "--checkout-mode", "hardlink", "data.txt"],
+    )
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Restored" in result.output
+    assert data_file.exists()
+    # With hardlink mode, file should not be a symlink
+    assert not data_file.is_symlink()
+    # Verify it's a hardlink by checking link count (if supported by filesystem)
+    stat_info = data_file.stat()
+    # Hardlinked file has nlink > 1
+    assert stat_info.st_nlink >= 1  # At least the file exists
+    assert data_file.read_text() == "cached content"

--- a/tests/cli/test_cli_get.py
+++ b/tests/cli/test_cli_get.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 def test_get_help(runner: click.testing.CliRunner) -> None:
     """Shows help message."""
-    result = runner.invoke(cli.cli, ["data", "get", "--help"])
+    result = runner.invoke(cli.cli, ["get", "--help"])
 
     assert result.exit_code == 0
     assert "Retrieve files or stage outputs" in result.output
@@ -41,7 +41,7 @@ def test_get_requires_rev(
 
     monkeypatch.setattr(project, "_project_root_cache", repo_path)
 
-    result = runner.invoke(cli.cli, ["data", "get", "file.txt"])
+    result = runner.invoke(cli.cli, ["get", "file.txt"])
 
     assert result.exit_code != 0
     assert "Missing option" in result.output or "--rev" in result.output
@@ -58,7 +58,7 @@ def test_get_requires_targets(
 
     monkeypatch.setattr(project, "_project_root_cache", repo_path)
 
-    result = runner.invoke(cli.cli, ["data", "get", "--rev", "HEAD"])
+    result = runner.invoke(cli.cli, ["get", "--rev", "HEAD"])
 
     assert result.exit_code != 0
     assert "Missing argument" in result.output or "TARGETS" in result.output
@@ -87,7 +87,7 @@ def test_get_git_tracked_file(
 
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", sha[:7], "file.txt", "-o", str(repo_path / "restored.txt")],
+        ["get", "--rev", sha[:7], "file.txt", "-o", str(repo_path / "restored.txt")],
     )
 
     assert result.exit_code == 0, result.output
@@ -113,7 +113,7 @@ def test_get_git_tracked_file_with_force(
 
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", sha[:7], "file.txt", "-o", str(output_path), "--force"],
+        ["get", "--rev", sha[:7], "file.txt", "-o", str(output_path), "--force"],
     )
 
     assert result.exit_code == 0, result.output
@@ -139,7 +139,7 @@ def test_get_skip_existing_without_force(
 
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", sha[:7], "file.txt", "-o", str(output_path)],
+        ["get", "--rev", sha[:7], "file.txt", "-o", str(output_path)],
     )
 
     assert result.exit_code == 0, result.output
@@ -165,7 +165,7 @@ def test_get_invalid_revision(
 
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", "invalid-revision", "file.txt"],
+        ["get", "--rev", "invalid-revision", "file.txt"],
     )
 
     assert result.exit_code != 0
@@ -185,8 +185,201 @@ def test_get_target_not_found(
 
     result = runner.invoke(
         cli.cli,
-        ["data", "get", "--rev", sha[:7], "nonexistent.txt"],
+        ["get", "--rev", sha[:7], "nonexistent.txt"],
     )
 
     assert result.exit_code != 0
     assert "TargetNotFoundError" in result.output or "not found" in result.output
+
+
+# =============================================================================
+# CLI Multiple Targets Tests
+# =============================================================================
+
+
+def test_get_multiple_git_tracked_files(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Gets multiple git-tracked files from revision."""
+    repo_path, commit = git_repo
+    (repo_path / "file1.txt").write_text("content1")
+    (repo_path / "file2.txt").write_text("content2")
+    (repo_path / "file3.txt").write_text("content3")
+    sha = commit("initial")
+
+    # Modify files
+    (repo_path / "file1.txt").write_text("modified1")
+    (repo_path / "file2.txt").write_text("modified2")
+    (repo_path / "file3.txt").write_text("modified3")
+
+    # Create .pivot directory
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "--force", "file1.txt", "file2.txt", "file3.txt"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    # Verify all files restored to original content
+    assert (repo_path / "file1.txt").read_text() == "content1"
+    assert (repo_path / "file2.txt").read_text() == "content2"
+    assert (repo_path / "file3.txt").read_text() == "content3"
+
+
+def test_get_with_output_single_file_succeeds(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get with -o and single file succeeds."""
+    repo_path, commit = git_repo
+    (repo_path / "original.txt").write_text("original content")
+    sha = commit("initial")
+
+    # Create .pivot directory
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "original.txt", "-o", str(repo_path / "renamed.txt")],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    assert (repo_path / "renamed.txt").exists()
+    assert (repo_path / "renamed.txt").read_text() == "original content"
+
+
+def test_get_with_output_multiple_files_fails(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get with -o and multiple files fails with error."""
+    repo_path, commit = git_repo
+    (repo_path / "file1.txt").write_text("content1")
+    (repo_path / "file2.txt").write_text("content2")
+    sha = commit("initial")
+
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "file1.txt", "file2.txt", "-o", "output.txt"],
+    )
+
+    # Should fail because -o is incompatible with multiple targets
+    assert result.exit_code != 0
+    # Error message should mention incompatibility
+    assert "incompatible" in result.output.lower() or "single" in result.output.lower()
+
+
+def test_get_partial_success_with_missing_file(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get with mix of existing and missing files handles gracefully."""
+    repo_path, commit = git_repo
+    (repo_path / "exists.txt").write_text("exists")
+    sha = commit("initial")
+
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    # Try to get one existing and one non-existing file
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "exists.txt", "missing.txt"],
+    )
+
+    # Should report error for missing file
+    assert result.exit_code != 0
+    assert "missing.txt" in result.output.lower() or "not found" in result.output.lower()
+
+
+# =============================================================================
+# CLI Edge Case Tests
+# =============================================================================
+
+
+def test_get_empty_file(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get handles empty files correctly."""
+    repo_path, commit = git_repo
+    (repo_path / "empty.txt").write_text("")
+    sha = commit("empty file")
+
+    # Modify to non-empty
+    (repo_path / "empty.txt").write_text("now has content")
+
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "--force", "empty.txt"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    assert (repo_path / "empty.txt").read_text() == ""
+
+
+def test_get_binary_file(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get handles binary files correctly."""
+    repo_path, commit = git_repo
+    binary_content = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    (repo_path / "image.png").write_bytes(binary_content)
+    sha = commit("binary file")
+
+    # Modify binary
+    (repo_path / "image.png").write_bytes(b"corrupted")
+
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "--force", "image.png"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    assert (repo_path / "image.png").read_bytes() == binary_content
+
+
+def test_get_file_in_subdirectory(
+    runner: click.testing.CliRunner, git_repo: GitRepo, monkeypatch: MonkeyPatch
+) -> None:
+    """Get handles files in subdirectories."""
+    repo_path, commit = git_repo
+    (repo_path / "subdir").mkdir()
+    (repo_path / "subdir" / "nested.txt").write_text("nested content")
+    sha = commit("nested file")
+
+    # Remove subdirectory
+    (repo_path / "subdir" / "nested.txt").unlink()
+    (repo_path / "subdir").rmdir()
+
+    (repo_path / ".pivot" / "cache").mkdir(parents=True)
+
+    monkeypatch.setattr(project, "_project_root_cache", repo_path)
+
+    result = runner.invoke(
+        cli.cli,
+        ["get", "--rev", sha[:7], "subdir/nested.txt"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restored" in result.output
+    assert (repo_path / "subdir" / "nested.txt").exists()
+    assert (repo_path / "subdir" / "nested.txt").read_text() == "nested content"

--- a/tests/storage/test_restore.py
+++ b/tests/storage/test_restore.py
@@ -274,7 +274,7 @@ def test_restore_targets_from_revision_git_file(
     state_dir = repo_path / ".pivot"
     output_path = repo_path / "restored.txt"
 
-    messages = restore.restore_targets_from_revision(
+    messages, _ = restore.restore_targets_from_revision(
         targets=["file.txt"],
         rev=sha[:7],
         output=output_path,
@@ -306,7 +306,7 @@ def test_restore_targets_from_revision_skip_existing(
     cache_dir = repo_path / ".pivot" / "cache"
     state_dir = repo_path / ".pivot"
 
-    messages = restore.restore_targets_from_revision(
+    messages, _ = restore.restore_targets_from_revision(
         targets=["file.txt"],
         rev=sha[:7],
         output=output_path,
@@ -338,7 +338,7 @@ def test_restore_targets_from_revision_force_overwrite(
     cache_dir = repo_path / ".pivot" / "cache"
     state_dir = repo_path / ".pivot"
 
-    messages = restore.restore_targets_from_revision(
+    messages, _ = restore.restore_targets_from_revision(
         targets=["file.txt"],
         rev=sha[:7],
         output=output_path,
@@ -431,7 +431,7 @@ def test_restore_file_cache_miss_error(git_repo: GitRepo, monkeypatch: pytest.Mo
     cache_dir = repo_path / ".pivot" / "cache"
     state_dir = repo_path / ".pivot"
 
-    messages = restore.restore_targets_from_revision(
+    messages, _ = restore.restore_targets_from_revision(
         targets=["data.csv"],
         rev=sha[:7],
         output=None,
@@ -472,7 +472,7 @@ def test_restore_file_from_cache(git_repo: GitRepo, monkeypatch: pytest.MonkeyPa
 
     output_path = repo_path / "restored_data.csv"
 
-    messages = restore.restore_targets_from_revision(
+    messages, _ = restore.restore_targets_from_revision(
         targets=["data.csv"],
         rev=sha[:7],
         output=output_path,


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** `pivot pull` now fetches AND checks out (like git/dvc pull)

- Renamed `pull` to `fetch` (downloads to cache only)
- New `pull` = fetch + checkout (matches git/dvc semantics)
- Promoted `data diff` to top-level `diff` command
- Promoted `data get` to top-level `get` command
- Removed `data` command group
- Reorganized CLI categories: Pipeline, Sync, Inspection, Other

### New CLI Structure

```
Pipeline Commands:
  commit, repro, run, status, verify

Sync Commands:
  checkout, fetch, get, pull, push, remote, track

Inspection Commands:
  dag, diff, history, list, metrics, params, plots, show

Other Commands:
  check-ignore, completion, config, doctor, export, import-dvc, init, schema
```

## Test Plan

- [x] All 3182 tests pass
- [x] Type checks pass (basedpyright)
- [x] Linting passes (ruff)
- [x] CLI help output shows correct categories
- [x] New `fetch` command works (download-only)
- [x] New `pull` command works (fetch + checkout)
- [x] `diff` and `get` work as top-level commands

Closes #336

🤖 Generated with [Claude Code](https://claude.ai/claude-code)