### PR TITLE
feat(tui): color logs by level instead of all stderr as red

### DIFF
--- a/docs/plans/2026-02-03-feat-tui-log-level-coloring-plan.md
+++ b/docs/plans/2026-02-03-feat-tui-log-level-coloring-plan.md
@@ -1,0 +1,319 @@
+---
+title: "TUI: Fix Log Coloring (Everything Shows as Red)"
+type: feat
+date: 2026-02-03
+issue: "#330"
+deepened: 2026-02-03
+reviewed: 2026-02-03
+---
+
+# TUI: Fix Log Coloring Based on Log Levels
+
+## Review Summary
+
+**Reviewed by:** DHH Rails Reviewer, Kieran Python Reviewer, Code Simplicity Reviewer
+
+### Key Changes After Review
+1. **Removed Enum** - Was over-engineering; just map strings directly to styles
+2. **Single data structure** - Merged 3 dicts into 1 (`_LEVEL_STYLES`)
+3. **Inlined detection** - No need for separate `_detect_log_level()` function
+4. **~40% LOC reduction** - From ~35 lines to ~20 lines
+
+### Reviewer Consensus
+> "The enum must die" - DHH
+> "Carrying 3 data structures when 1 suffices" - Simplicity Reviewer
+> "The enum would be justified if you needed to pass log levels around... For 'regex match -> pick a color string,' it's pure overhead" - Simplicity Reviewer
+
+---
+
+## Overview
+
+Currently all Python logging output appears red in the TUI because Python's `logging` module writes to stderr by default. This makes logs hard to read and removes meaningful visual distinction between INFO messages and actual errors.
+
+**Fix:** Detect log level prefixes and color appropriately instead of blindly coloring all stderr as red.
+
+## Problem Statement
+
+```
+[14:32:15] [red]INFO: Loading data from input.csv[/]     <- red (wrong)
+[14:32:16] [red]WARNING: Deprecated function used[/]     <- red (wrong)
+[14:32:17] [red]ERROR: ValueError: invalid value[/]      <- red (correct)
+```
+
+**Root Cause:** `_write_line()` in `src/pivot/tui/widgets/logs.py:72-75` treats all `is_stderr=True` as red. Since Python's logging handler writes everything to stderr, all log levels appear red.
+
+## Proposed Solution
+
+Parse log lines for level prefixes and apply semantic colors:
+
+| Level | Color | Rich Markup |
+|-------|-------|-------------|
+| DEBUG | dim | `[dim]` |
+| INFO | default | (none) |
+| WARNING/WARN | yellow | `[yellow]` |
+| ERROR | red | `[red]` |
+| CRITICAL/FATAL | red bold | `[red bold]` |
+| No level detected + stderr | red | `[red]` (fallback) |
+
+### Research Insights: Color Conventions
+
+The industry-standard convention (from coloredlogs, colorlog, structlog) follows a **cool-to-warm severity gradient**:
+- DEBUG = dim/grey (low importance, diagnostic)
+- INFO = default/neutral (normal operation)
+- WARNING = yellow (attention needed)
+- ERROR = red (problem occurred)
+- CRITICAL = bold red (immediate attention)
+
+This aligns with existing TUI patterns in `src/pivot/tui/widgets/status.py` and `src/pivot/tui/console.py`.
+
+## Technical Approach
+
+### Implementation Location
+
+All changes in `src/pivot/tui/widgets/logs.py` - keep it simple, no new files.
+
+### Log Level Detection
+
+Add a private function to detect log levels from common formats:
+
+**Patterns to recognize:**
+```python
+# Pivot's own format (from _QueueLoggingHandler)
+"INFO: message"
+"WARNING: message"
+
+# Common external formats
+"[INFO] message"
+"INFO - message"
+"2024-01-01 10:00:00 INFO message"  # timestamp prefix
+```
+
+### Research Insights: Pattern Matching
+
+**Compiled regex is the right choice** (from performance-oracle analysis):
+- Pre-compiled regex executes in **1-5 microseconds** per line
+- At 10,000 lines, that's 10-50ms total - negligible vs TUI rendering
+- String methods would be more complex and not significantly faster
+- The actual bottleneck is `self.write()` / TUI rendering, not detection
+
+**Order alternations by frequency** for micro-optimization:
+- Put INFO before DEBUG (INFO is most common)
+
+### Edge Cases
+
+**Multi-line logs:** Each line is detected independently. Continuation lines without a level prefix fall back to red if from stderr. This matches user expectations for tracebacks.
+
+**ANSI sequences:** Strip ANSI escape codes before detection. Pivot's own logging doesn't emit them, and external library colors would conflict with semantic coloring.
+
+**Partial matches:** Regex is anchored to line start and requires a delimiter, preventing false matches like "INFORMATION" or "WARNING_FILE.txt".
+
+**Long lines:** Limit search to first 100 characters - log levels always appear at the start.
+
+## Implementation
+
+### Add Constants and Update `_write_line()`
+
+**src/pivot/tui/widgets/logs.py**
+
+Simplified implementation based on reviewer feedback - no enum, single dict:
+
+```python
+import re
+
+# Matches: [optional ANSI][optional timestamp][LEVEL][delimiter]
+# Examples: "INFO: msg", "[DEBUG] msg", "2024-01-01 10:00:00 WARNING msg"
+_LOG_LEVEL_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?:\x1b\[[0-9;]*m)*"           # Skip leading ANSI escape sequences
+    r"(?:\[?[\d\-:.\s,TZ]+\]?\s*)?"   # Optional timestamp (various formats)
+    r"(?:\[?(INFO|WARNING|WARN|ERROR|DEBUG|CRITICAL|FATAL)\]?)"  # Level
+    r"[\s:\-\]]",                      # Delimiter after level
+    re.IGNORECASE,
+)
+
+# Single dict: level string -> Rich style (None = default color)
+_LEVEL_STYLES: dict[str, str | None] = {
+    "DEBUG": "dim",
+    "INFO": None,
+    "WARNING": "yellow",
+    "WARN": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "red bold",
+    "FATAL": "red bold",
+}
+
+
+def _write_line(self, line: str, is_stderr: bool, timestamp: float) -> None:
+    time_str = time.strftime("[%H:%M:%S]", time.localtime(timestamp))
+    escaped_line = rich.markup.escape(line)
+
+    # Detect level and get style in one step
+    style: str | None = None
+    if match := _LOG_LEVEL_PATTERN.match(line):
+        style = _LEVEL_STYLES.get(match.group(1).upper())
+    elif is_stderr:
+        style = "red"  # Fallback for unrecognized stderr
+
+    if style:
+        self.write(f"[dim]{time_str}[/] [{style}]{escaped_line}[/]")
+    else:
+        self.write(f"[dim]{time_str}[/] {escaped_line}")
+```
+
+**Why this is better than the original plan:**
+- No enum overhead - regex match gives us a string, we need a string (style)
+- Single data structure instead of 3
+- Detection inlined - no separate function for 3 lines of logic
+- ~40% less code
+- Equally testable via the dict and regex directly
+
+### Add Unit Tests
+
+**tests/tui/test_log_level_detection.py**
+
+Test the regex pattern and style mapping directly:
+
+```python
+import pytest
+from pivot.tui.widgets.logs import _LOG_LEVEL_PATTERN, _LEVEL_STYLES
+
+@pytest.mark.parametrize("line,expected_level", [
+    # Pivot format (colon)
+    ("INFO: Loading data", "INFO"),
+    ("WARNING: Deprecated", "WARNING"),
+    ("ERROR: Failed", "ERROR"),
+    ("DEBUG: Internal", "DEBUG"),
+    ("CRITICAL: Fatal", "CRITICAL"),
+
+    # Bracketed format
+    ("[INFO] Processing", "INFO"),
+    ("[WARNING] Check this", "WARNING"),
+
+    # Dash format
+    ("INFO - message", "INFO"),
+    ("ERROR - failed", "ERROR"),
+
+    # With timestamp
+    ("2024-01-01 10:00:00 INFO Loading", "INFO"),
+    ("[2024-01-01T10:00:00] ERROR Failed", "ERROR"),
+
+    # Case insensitive
+    ("info: lowercase", "INFO"),
+    ("Info: mixed", "INFO"),
+
+    # Aliases
+    ("WARN: short form", "WARN"),
+    ("FATAL: alias", "FATAL"),
+])
+def test_log_level_pattern_matches(line: str, expected_level: str) -> None:
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None
+    assert match.group(1).upper() == expected_level.upper()
+
+@pytest.mark.parametrize("line", [
+    "Just a regular line",
+    "This is INFORMATION",  # not at start
+    "WARNING_FILE.txt processed",  # no delimiter
+    "",
+    "   ",
+])
+def test_log_level_pattern_no_match(line: str) -> None:
+    assert _LOG_LEVEL_PATTERN.match(line) is None
+
+def test_log_level_pattern_with_ansi() -> None:
+    """ANSI sequences at start should not prevent matching."""
+    line = "\033[31mERROR: message\033[0m"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None
+    assert match.group(1).upper() == "ERROR"
+
+def test_level_styles_complete() -> None:
+    """All matched levels should have a style defined."""
+    levels = ["DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", "FATAL"]
+    for level in levels:
+        assert level in _LEVEL_STYLES, f"Missing style for {level}"
+
+def test_level_styles_values() -> None:
+    """Verify expected style values."""
+    assert _LEVEL_STYLES["DEBUG"] == "dim"
+    assert _LEVEL_STYLES["INFO"] is None
+    assert _LEVEL_STYLES["WARNING"] == "yellow"
+    assert _LEVEL_STYLES["ERROR"] == "red"
+    assert _LEVEL_STYLES["CRITICAL"] == "red bold"
+```
+
+## Acceptance Criteria
+
+- [ ] INFO-level logs appear in default color (not red)
+- [ ] DEBUG logs appear dim
+- [ ] WARNING/WARN logs appear yellow
+- [ ] ERROR logs appear red
+- [ ] CRITICAL/FATAL logs appear red bold
+- [ ] Non-logging stderr output still appears red (fallback)
+- [ ] Works with common formats: `LEVEL:`, `[LEVEL]`, `LEVEL -`, timestamped
+- [ ] Case-insensitive level matching
+- [ ] Unit tests for detection logic pass
+- [ ] `uv run ruff format . && uv run ruff check . && uv run basedpyright` passes
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/pivot/tui/widgets/logs.py` | Add `_LOG_LEVEL_PATTERN` regex, `_LEVEL_STYLES` dict, update `_write_line()` |
+| `tests/tui/test_log_level_detection.py` | New file with unit tests |
+
+## Testing
+
+```bash
+# Run unit tests
+uv run pytest tests/tui/test_log_level_detection.py -v
+
+# Run all quality checks
+uv run ruff format . && uv run ruff check . && uv run basedpyright
+
+# Manual verification
+uv run pivot repro  # Check TUI output colors
+```
+
+## Performance Considerations
+
+From performance-oracle analysis:
+
+| Operation | Relative Cost | Notes |
+|-----------|---------------|-------|
+| `_detect_log_level()` | Low | ~1-5μs per call |
+| `rich.markup.escape()` | Low-Medium | String scanning |
+| `time.strftime()` | Low | Called every line |
+| `self.write()` / TUI rendering | **High** | Actual bottleneck |
+
+**Conclusion:** The implementation is well-optimized. If performance becomes an issue, batch writes to the TUI would have far greater impact than optimizing detection.
+
+## Alternative Considered: Even Simpler Regex
+
+DHH suggested an even simpler approach using `re.search()`:
+
+```python
+_LOG_LEVEL_PATTERN = re.compile(r"(DEBUG|INFO|WARNING|WARN|ERROR|CRITICAL|FATAL)", re.IGNORECASE)
+# Used with: _LOG_LEVEL_PATTERN.search(line[:100])
+```
+
+**Trade-offs:**
+- Pro: Simpler regex, finds level anywhere in first 100 chars, more robust to format variations
+- Con: Higher false-positive risk (e.g., "This is INFORMATION about...")
+
+**Decision:** Keep the anchored regex with delimiter requirement since:
+1. Handles ANSI codes correctly
+2. Requires delimiters to prevent false matches
+3. Matches the issue's proposed solution
+4. False positives would be confusing (non-log lines getting colored)
+
+If false negatives become a problem (legitimate logs not detected), we can switch to the simpler approach.
+
+## References
+
+- GitHub Issue: #330
+- Current implementation: `src/pivot/tui/widgets/logs.py:69-75`
+- Logging handler format: `src/pivot/executor/worker.py:80` (`%(levelname)s: %(message)s`)
+- Python logging docs: https://docs.python.org/3/library/logging.html
+- Rich markup docs: https://rich.readthedocs.io/en/stable/markup.html
+- Textual RichLog: https://textual.textualize.io/widgets/rich_log/
+- coloredlogs conventions: https://coloredlogs.readthedocs.io/

--- a/tests/tui/widgets/test_log_level_detection.py
+++ b/tests/tui/widgets/test_log_level_detection.py
@@ -1,0 +1,250 @@
+"""Tests for log level detection regex and style mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from pivot.tui.widgets.logs import _LEVEL_STYLES, _LOG_LEVEL_PATTERN, _get_line_style
+
+# =============================================================================
+# Pattern Matching - Basic Formats
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line,expected_level",
+    [
+        # Pivot format (colon)
+        ("INFO: Loading data", "INFO"),
+        ("WARNING: Deprecated", "WARNING"),
+        ("ERROR: Failed", "ERROR"),
+        ("DEBUG: Internal", "DEBUG"),
+        ("CRITICAL: Fatal", "CRITICAL"),
+        # Bracketed format
+        ("[INFO] Processing", "INFO"),
+        ("[WARNING] Check this", "WARNING"),
+        # Dash format
+        ("INFO - message", "INFO"),
+        ("ERROR - failed", "ERROR"),
+        # With timestamp
+        ("2024-01-01 10:00:00 INFO Loading", "INFO"),
+        ("[2024-01-01T10:00:00] ERROR Failed", "ERROR"),
+        # Case insensitive
+        ("info: lowercase", "INFO"),
+        ("Info: mixed", "INFO"),
+        # Aliases
+        ("WARN: short form", "WARN"),
+        ("FATAL: alias", "FATAL"),
+    ],
+)
+def test_log_level_pattern_matches(line: str, expected_level: str) -> None:
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None
+    assert match.group(1).upper() == expected_level.upper()
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Just a regular line",
+        "This is INFORMATION",  # not at start
+        "WARNING_FILE.txt processed",  # no delimiter
+        "",
+        "   ",
+    ],
+)
+def test_log_level_pattern_no_match(line: str) -> None:
+    assert _LOG_LEVEL_PATTERN.match(line) is None
+
+
+# =============================================================================
+# Pattern Matching - ANSI Edge Cases
+# =============================================================================
+
+
+def test_log_level_pattern_with_ansi() -> None:
+    """ANSI sequences at start should not prevent matching."""
+    line = "\033[31mERROR: message\033[0m"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None
+    assert match.group(1).upper() == "ERROR"
+
+
+def test_log_level_pattern_with_multiple_ansi() -> None:
+    """Multiple ANSI sequences should not prevent matching."""
+    line = "\033[1m\033[31m\033[4mERROR: message\033[0m"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None, "Multiple ANSI codes should not block matching"
+    assert match.group(1).upper() == "ERROR"
+
+
+# =============================================================================
+# Pattern Matching - Timestamp Edge Cases
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line,expected_level",
+    [
+        # Unix timestamp
+        ("1704088800 INFO message", "INFO"),
+        # ISO format with timezone
+        ("2024-01-01T10:00:00Z ERROR failed", "ERROR"),
+        # Comma separators in timestamp
+        ("2024,01,01 10:00:00 WARNING check", "WARNING"),
+        # Timestamp with brackets
+        ("[2024-01-01 10:00:00] DEBUG trace", "DEBUG"),
+        # Multiple spaces after timestamp
+        ("2024-01-01 10:00:00   INFO  spaced", "INFO"),
+    ],
+)
+def test_log_level_pattern_timestamp_variants(line: str, expected_level: str) -> None:
+    """Verify various timestamp formats don't prevent level detection."""
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None, f"Failed to match timestamp format: {line}"
+    assert match.group(1).upper() == expected_level
+
+
+# =============================================================================
+# Pattern Matching - Delimiter Edge Cases
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "ERROR.txt processed",  # period after level
+        "INFO_LOG started",  # underscore after level
+        "WARNINGCODE",  # no delimiter at all
+        "DEBUGfile.log",  # no space before filename
+    ],
+)
+def test_log_level_pattern_invalid_delimiters(line: str) -> None:
+    """Verify delimiter requirements prevent false positives."""
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is None, f"Should not match line without valid delimiter: {line}"
+
+
+def test_log_level_pattern_bracketed_no_space() -> None:
+    """Bracketed format should work with closing bracket as delimiter."""
+    line = "[ERROR]Failed"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None, "Closing bracket should count as valid delimiter"
+    assert match.group(1).upper() == "ERROR"
+
+
+def test_log_level_pattern_colon_only() -> None:
+    """Level followed by colon only (no message) should match."""
+    line = "INFO:"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None, "Colon-only delimiter should be valid"
+    assert match.group(1).upper() == "INFO"
+
+
+# =============================================================================
+# Pattern Matching - Case Sensitivity
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "level_variant",
+    ["eRrOr", "WaRnInG", "dEbUg", "CrItIcAl", "iNfO"],
+)
+def test_log_level_pattern_mixed_case_variants(level_variant: str) -> None:
+    """Pattern should handle any case combination (re.IGNORECASE flag)."""
+    line = f"{level_variant}: message"
+    match = _LOG_LEVEL_PATTERN.match(line)
+    assert match is not None, f"Should match mixed-case variant: {level_variant}"
+    assert match.group(1).upper() in _LEVEL_STYLES
+
+
+# =============================================================================
+# Style Dictionary Completeness
+# =============================================================================
+
+
+def test_level_styles_complete() -> None:
+    """All matched levels should have a style defined."""
+    levels = ["DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", "FATAL"]
+    for level in levels:
+        assert level in _LEVEL_STYLES, f"Missing style for {level}"
+
+
+def test_level_styles_values() -> None:
+    """Verify expected style values."""
+    assert _LEVEL_STYLES["DEBUG"] == "dim"
+    assert _LEVEL_STYLES["INFO"] is None
+    assert _LEVEL_STYLES["WARNING"] == "yellow"
+    assert _LEVEL_STYLES["WARN"] == "yellow"
+    assert _LEVEL_STYLES["ERROR"] == "red"
+    assert _LEVEL_STYLES["CRITICAL"] == "red bold"
+    assert _LEVEL_STYLES["FATAL"] == "red bold"
+
+
+def test_level_styles_unknown_level() -> None:
+    """Unknown levels should return None from style dict."""
+    assert _LEVEL_STYLES.get("TRACE") is None
+    assert _LEVEL_STYLES.get("VERBOSE") is None
+    assert _LEVEL_STYLES.get("UNKNOWN") is None
+
+
+# =============================================================================
+# Style Selection Logic (Integration)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line,is_stderr,expected_style",
+    [
+        # Log levels override stderr coloring
+        ("INFO: message", True, None),
+        ("WARNING: message", True, "yellow"),
+        ("ERROR: message", True, "red"),
+        ("DEBUG: trace", False, "dim"),
+        ("CRITICAL: crash", True, "red bold"),
+        # Non-log stderr gets red fallback
+        ("Some random stderr output", True, "red"),
+        # Non-log stdout gets no style
+        ("Some random stdout output", False, None),
+        # Empty lines
+        ("", True, "red"),
+        ("", False, None),
+    ],
+)
+def test_style_selection_logic(line: str, is_stderr: bool, expected_style: str | None) -> None:
+    """Test the complete style selection logic that _write_line uses."""
+    assert _get_line_style(line, is_stderr) == expected_style
+
+
+def test_style_selection_with_ansi_stderr_fallback() -> None:
+    """ANSI-prefixed non-log stderr should still get red fallback."""
+    line = "\033[1mSome non-log output\033[0m"
+    style = _get_line_style(line, is_stderr=True)
+    assert style == "red", "Non-log stderr with ANSI should fallback to red"
+
+
+def test_style_selection_level_takes_precedence() -> None:
+    """Log level style should take precedence over stderr fallback."""
+    line = "INFO: normal message"
+    # Even on stderr, INFO gets no style (not red fallback)
+    style = _get_line_style(line, is_stderr=True)
+    assert style is None, "INFO style (None) should override stderr fallback"
+
+
+def test_style_selection_multiline_traceback() -> None:
+    """First line gets level style, continuation lines get stderr fallback.
+
+    Each line is processed independently. Traceback continuation lines don't
+    have a level prefix, so they fall back to stderr coloring (red).
+    """
+    # Simulates a Python traceback on stderr
+    lines_and_expected = [
+        ("ERROR: Failed to process data", "red"),
+        ("Traceback (most recent call last):", "red"),
+        ('  File "foo.py", line 10, in bar', "red"),
+        ("    raise ValueError('bad input')", "red"),
+        ("ValueError: bad input", "red"),
+    ]
+    for line, expected_style in lines_and_expected:
+        style = _get_line_style(line, is_stderr=True)
+        assert style == expected_style, f"Line '{line}' should have style '{expected_style}'"


### PR DESCRIPTION
## Summary

Fix TUI log coloring so logs are colored by level instead of blindly coloring all stderr as red.

- Add `_LOG_LEVEL_PATTERN` regex to detect log levels (INFO, WARNING, ERROR, DEBUG, CRITICAL, FATAL)
- Add `_LEVEL_STYLES` dict mapping levels to Rich styles (dim, yellow, red, red bold)
- Extract `_get_line_style()` function for testable style selection logic
- Update `_write_line()` to apply semantic colors based on detected level

| Level | Color |
|-------|-------|
| DEBUG | dim |
| INFO | default |
| WARNING/WARN | yellow |
| ERROR | red |
| CRITICAL/FATAL | red bold |
| Unknown stderr | red (fallback) |

## Test Plan

- [x] 52 unit tests covering pattern matching, edge cases, and style selection
- [x] All 3222 existing tests pass
- [x] `ruff format`, `ruff check`, `basedpyright` all pass

Closes #330