### PR TITLE
fix(loaders): support list index_col for CSV MultiIndex columns

### DIFF
--- a/src/pivot/loaders.py
+++ b/src/pivot/loaders.py
@@ -77,7 +77,7 @@ class CSV[T](Loader[T, T]):
     Always returns pandas.DataFrame at runtime.
     """
 
-    index_col: int | str | None = None
+    index_col: int | str | list[int | str] | None = None
     sep: str = ","
     dtype: dict[str, str] | None = None
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -92,6 +92,18 @@ def test_csv_loader_with_index_col(tmp_path: pathlib.Path) -> None:
     assert list(df.index) == ["a", "b"]
 
 
+def test_csv_loader_with_multi_index_col(tmp_path: pathlib.Path) -> None:
+    """CSV loader supports list index_col for MultiIndex."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("idx1,idx2,val\na,x,1\nb,y,2\n")
+
+    loader = loaders.CSV(index_col=[0, 1])
+    df = loader.load(csv_file)
+
+    assert df.index.names == ["idx1", "idx2"]
+    assert list(df.index) == [("a", "x"), ("b", "y")]
+
+
 def test_csv_loader_with_sep(tmp_path: pathlib.Path) -> None:
     """CSV loader respects sep option."""
     csv_file = tmp_path / "data.tsv"


### PR DESCRIPTION
## Summary
- Updated CSV loader `index_col` type annotation to include `list[int | str]`
- Pandas `read_csv` supports list for creating MultiIndex, but the type was `int | str | None`
- Added test for MultiIndex column support

## Test plan
- [x] New test `test_csv_loader_with_multi_index_col` passes
- [x] All existing CSV tests pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)