### PR TITLE
perf(remote): optimize push/pull with connection pooling and LIST-based existence checks

### DIFF
--- a/src/pivot/discovery.py
+++ b/src/pivot/discovery.py
@@ -72,7 +72,8 @@ def discover_pipeline(project_root: pathlib.Path | None = None) -> Pipeline | No
     Raises:
         DiscoveryError: If discovery fails, or if both config types exist
     """
-    with metrics.timed("discovery.total"):
+    _t = metrics.start()
+    try:
         root = project_root or project.get_project_root()
         try:
             cwd = pathlib.Path.cwd().resolve()
@@ -112,6 +113,8 @@ def discover_pipeline(project_root: pathlib.Path | None = None) -> Pipeline | No
             raise DiscoveryError(f"Failed to load {config_path}: {e}") from e
         finally:
             fingerprint.flush_ast_hash_cache()
+    finally:
+        metrics.end("discovery.total", _t)
 
 
 def _load_pipeline_from_module(path: pathlib.Path) -> Pipeline | None:

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -288,7 +288,8 @@ class StageRegistry:
             InvalidPathError: If paths resolve outside project root.
             ParamsError: If params specified but function lacks params argument.
         """
-        with metrics.timed("registry.register"):
+        _t = metrics.start()
+        try:
             # Invalidate DAG cache on any registration
             self._cached_dag = None
 
@@ -491,6 +492,8 @@ class StageRegistry:
                 params_arg_name=params_arg_name,
                 state_dir=state_dir,
             )
+        finally:
+            metrics.end("registry.register", _t)
 
     def add_existing(self, stage_info: RegistryStageInfo) -> None:
         """Add a pre-validated stage info (for pipeline composition).

--- a/src/pivot/status.py
+++ b/src/pivot/status.py
@@ -169,7 +169,8 @@ def get_pipeline_explanations(
         graph: Optional bipartite graph from Engine. If provided, extracts stage DAG
             via get_stage_dag() instead of building a new one.
     """
-    with metrics.timed("status.get_pipeline_explanations"):
+    _t = metrics.start()
+    try:
         tracked_files, tracked_trie = _discover_tracked_files(allow_missing)
         if graph is None:
             graph = engine_graph.build_graph(all_stages)
@@ -199,6 +200,8 @@ def get_pipeline_explanations(
         explanations = [explanations_by_name[name] for name in execution_order]
 
         return _compute_explanations_with_upstream(explanations, stage_graph)
+    finally:
+        metrics.end("status.get_pipeline_explanations", _t)
 
 
 def _compute_explanations_with_upstream(
@@ -260,7 +263,8 @@ def get_pipeline_status(
         graph: Optional bipartite graph. If provided, extracts stage DAG
             via get_stage_dag() instead of building a new one.
     """
-    with metrics.timed("status.get_pipeline_status"):
+    _t = metrics.start()
+    try:
         tracked_files, tracked_trie = _discover_tracked_files(allow_missing)
         if graph is None:
             graph = engine_graph.build_graph(all_stages)
@@ -291,6 +295,8 @@ def get_pipeline_status(
         # Reuse the shared upstream computation logic
         enriched = _compute_explanations_with_upstream(explanations, stage_graph)
         return _explanations_to_status(enriched), stage_graph
+    finally:
+        metrics.end("status.get_pipeline_status", _t)
 
 
 def _explanations_to_status(explanations: list[StageExplanation]) -> list[PipelineStatusInfo]:


### PR DESCRIPTION
## Summary

Optimizes `pivot push` and `pivot pull` operations with several performance improvements:

### P0 - Critical: Singleton S3 Client per Batch
- **Before:** Each file in a batch created a new S3 client (N files = N sessions, ~100-400ms overhead each)
- **After:** Single S3 client reused for all files in batch, reusing connection pool

### P1 - High: LIST-based bulk_exists for Large Batches
- **Before:** N hashes = N HEAD requests
- **After:** Groups by 2-char prefix, uses S3 LIST (1 request returns up to 1000 keys)
- Threshold: < 50 hashes use HEAD, >= 50 use LIST

### P2 - Medium: Cached S3 Config
- Caches AioConfig at module level to avoid repeated config parsing

### P2 - Medium: os.scandir for Local Cache Scanning
- **Before:** `pathlib.iterdir()` + `is_file()`/`is_dir()` = 2 syscalls per entry
- **After:** `os.scandir()` with cached stat in DirEntry = 0 extra syscalls
- Eliminates ~20K syscalls for 10K files across 256 dirs

### Zero-overhead Metrics
- Replaces `metrics.timed()` context manager with `start()`/`end()` functions
- When `PIVOT_METRICS` not set, overhead is a single boolean check (~1ns)

## Test plan
- [x] All 3193 unit tests pass
- [x] All 118 remote tests pass
- [x] Added test for LIST-based bulk_exists optimization
- [x] ruff format/check pass
- [x] basedpyright passes