### PR TITLE
feat(completion): cache stage names for fast tab-completion

### DIFF
--- a/docs/plans/2026-02-05-stage-name-cache-design.md
+++ b/docs/plans/2026-02-05-stage-name-cache-design.md
@@ -1,0 +1,196 @@
+# Stage Name Cache for Fast Tab-Completion
+
+## Problem
+
+Tab-completion for `pivot repro <TAB>` takes ~2.5 seconds for `pipeline.py` pipelines because it triggers full discovery, which imports heavy dependencies (pandas, sklearn, etc.).
+
+**Metrics breakdown (108-stage pipeline):**
+- `discovery.load_module`: 2835ms total
+  - Module imports (pandas, sklearn, etc.): ~2170ms (76%)
+  - `registry.register` (includes fingerprinting): ~666ms (24%)
+
+The existing completion system has a fast path for `pivot.yaml` (~10ms) but `pipeline.py` users always hit the slow fallback.
+
+## Solution
+
+Cache stage names to `.pivot/cache/stages.cache` after discovery. Tab-completion reads the cache when fresh, avoiding Python imports entirely.
+
+**Target:** <50ms for cached tab-completion (actual: ~0.5ms for cache read + ~30-50ms Python startup).
+
+## Cache Format
+
+Location: `.pivot/cache/stages.cache`
+
+```
+v1
+pipeline.py:1707123456.789
+train
+preprocess
+evaluate
+deploy
+```
+
+- Line 1: Version tag (`v1`) for future format changes (unknown versions = cache miss)
+- Line 2: `<config_file>:<mtime>` — config path (relative) + mtime as float seconds
+- Lines 3+: Stage names, one per line
+
+**Why text format:**
+- File is tiny (<1KB for hundreds of stages)
+- Human-debuggable
+- No parsing library dependencies
+- Fast: ~0.5ms to read and parse
+
+## Implementation
+
+### Helper: detect config file
+
+```python
+def _detect_config_file(root: pathlib.Path) -> tuple[str, float] | None:
+    """Detect config file and capture its mtime.
+
+    Returns (relative_path, mtime) or None if no config found.
+    """
+    for name in ("pivot.yaml", "pivot.yml", "pipeline.py"):
+        path = root / name
+        if path.exists():
+            return (name, path.stat().st_mtime)
+    return None
+```
+
+### Reading the cache
+
+```python
+def _get_stages_from_cache(root: pathlib.Path) -> list[str] | None:
+    """Read stage names from cache if fresh."""
+    cache_path = root / ".pivot" / "cache" / "stages.cache"
+    try:
+        lines = cache_path.read_text().splitlines()
+    except FileNotFoundError:
+        return None
+
+    if len(lines) < 2 or lines[0] != "v1":
+        return None
+
+    header = lines[1]
+    sep_idx = header.rfind(":")
+    if sep_idx == -1:
+        return None
+
+    config_file, mtime_str = header[:sep_idx], header[sep_idx + 1:]
+
+    try:
+        current_mtime = (root / config_file).stat().st_mtime
+    except FileNotFoundError:
+        return None
+
+    if str(current_mtime) != mtime_str:
+        return None
+
+    return lines[2:]
+```
+
+### Writing the cache
+
+```python
+def _write_stages_cache(
+    root: pathlib.Path, config_file: str, mtime: float, stages: list[str]
+) -> None:
+    """Write stage names to cache (atomic)."""
+    cache_dir = root / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    cache_path = cache_dir / "stages.cache"
+    tmp_path = cache_path.with_suffix(".tmp")
+
+    content = f"v1\n{config_file}:{mtime}\n" + "\n".join(stages) + "\n"
+
+    tmp_path.write_text(content)
+    tmp_path.rename(cache_path)  # atomic on POSIX
+```
+
+### Integration with completion.py
+
+Update `_get_stages_fast()` to check cache first:
+
+```python
+def _get_stages_fast() -> list[str] | None:
+    root = _find_project_root_fast()
+    if root is None:
+        return None
+
+    # Try cache first (works for both YAML and pipeline.py)
+    if (stages := _get_stages_from_cache(root)) is not None:
+        return stages
+
+    # Existing YAML fast-path continues below...
+```
+
+Update `_get_stages_full()` to write cache after discovery.
+
+**Important:** Capture mtime *before* discovery to avoid race condition where config
+file changes during slow discovery (~2.5s). Only write cache if mtime unchanged.
+
+```python
+def _get_stages_full() -> list[str]:
+    from pivot import discovery, project
+
+    # Capture config file and mtime BEFORE discovery (race condition prevention)
+    root = _find_project_root_fast()
+    pre_discovery = _detect_config_file(root) if root else None
+
+    pipeline = discovery.discover_pipeline()
+    if pipeline is None:
+        return []
+
+    stages = pipeline.list_stages()
+
+    # Write cache only if config file unchanged during discovery
+    if root and pre_discovery:
+        config_file, pre_mtime = pre_discovery
+        try:
+            post_mtime = (root / config_file).stat().st_mtime
+            if pre_mtime == post_mtime:
+                _write_stages_cache(root, config_file, pre_mtime, stages)
+        except OSError:
+            pass  # Cache write failure is non-fatal
+
+    return stages
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No `.pivot/` directory | Cache miss → full discovery → creates cache |
+| Cache file corrupted/malformed | Cache miss → full discovery → overwrites cache |
+| `pipeline.py` deleted | Cache mtime check fails → cache miss |
+| `pipeline.py` edited | Mtime changes → cache miss → rediscover |
+| New clone (different mtimes) | Cache miss → full discovery |
+| Concurrent tab-completions | Atomic write prevents torn reads |
+
+## Known Limitations
+
+**Imported modules not tracked:** The cache only checks the entry point file's mtime (`pipeline.py`). If stages are defined in imported modules (e.g., `stages/train.py`), edits there won't invalidate the cache.
+
+This is acceptable because:
+- Tab-completion only needs stage *names*, not fingerprints
+- Stage names rarely change in imported modules
+- Full commands (`pivot repro`) still do proper discovery
+
+**Manual workaround:** If you rename stages in imported modules and need to refresh completions:
+```bash
+touch pipeline.py           # Invalidates cache via mtime change
+# or
+rm .pivot/cache/stages.cache  # Direct cache removal
+```
+
+## Files to Change
+
+1. `src/pivot/cli/completion.py` — Add cache read/write functions, integrate with existing completion
+
+## Not in Scope
+
+- Escape hatch CLI command (manual workaround sufficient)
+- Caching fingerprints or other stage metadata
+- Tracking imported module mtimes
+- Faster full discovery (that's a separate effort)

--- a/tests/cli/test_cli_completion.py
+++ b/tests/cli/test_cli_completion.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pathlib
+import time
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -7,7 +9,9 @@ import click
 import pytest
 
 from helpers import register_test_stage
+from pivot import discovery
 from pivot.cli import completion
+from pivot.pipeline import pipeline as pipeline_mod
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -207,7 +211,7 @@ def test_find_project_root_fast_returns_none_when_no_marker(
     mocker.patch("pathlib.Path.cwd", return_value=isolated)
 
     result = completion._find_project_root_fast()
-    assert result is None or hasattr(result, "exists")
+    assert result is None
 
 
 # =============================================================================
@@ -358,48 +362,9 @@ stages:
 # =============================================================================
 
 
-def test_complete_targets_includes_stage_names(
-    tmp_path: Path,
-    mock_ctx: mock.MagicMock,
-    mock_param: mock.MagicMock,
-    mocker: MockerFixture,
-) -> None:
-    """Target completion includes stage names."""
-    yaml_content = """
-stages:
-  train:
-    python: stages.train
-  test:
-    python: stages.test
-"""
-    (tmp_path / "pivot.yaml").write_text(yaml_content)
-    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
-
-    result = completion.complete_targets(mock_ctx, mock_param, "tr")
-    assert "train" in result
-
-
-def test_complete_targets_filters_by_prefix(
-    tmp_path: Path,
-    mock_ctx: mock.MagicMock,
-    mock_param: mock.MagicMock,
-    mocker: MockerFixture,
-) -> None:
-    """Filters targets by incomplete prefix."""
-    yaml_content = """
-stages:
-  train:
-    python: stages.train
-  test:
-    python: stages.test
-  deploy:
-    python: stages.deploy
-"""
-    (tmp_path / "pivot.yaml").write_text(yaml_content)
-    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
-
-    result = completion.complete_targets(mock_ctx, mock_param, "t")
-    assert set(result) == {"train", "test"}
+def test_complete_targets_is_alias_for_complete_stages() -> None:
+    """complete_targets is a direct alias for complete_stages."""
+    assert completion.complete_targets is completion.complete_stages
 
 
 # =============================================================================
@@ -408,8 +373,8 @@ stages:
 
 
 def test_complete_config_keys_returns_static_keys(
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
 ) -> None:
     """Returns static config keys with descriptions."""
     result = completion.complete_config_keys(mock_ctx, mock_param, "")
@@ -423,8 +388,8 @@ def test_complete_config_keys_returns_static_keys(
 
 
 def test_complete_config_keys_filters_by_prefix(
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
 ) -> None:
     """Filters keys by incomplete prefix."""
     result = completion.complete_config_keys(mock_ctx, mock_param, "cache")
@@ -436,8 +401,8 @@ def test_complete_config_keys_filters_by_prefix(
 
 def test_complete_config_keys_includes_local_remotes(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Includes existing remote names from local config."""
@@ -456,8 +421,8 @@ def test_complete_config_keys_includes_local_remotes(
 
 def test_complete_config_keys_includes_global_remotes(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Includes existing remote names from global config."""
@@ -476,8 +441,8 @@ def test_complete_config_keys_includes_global_remotes(
 
 def test_complete_config_keys_merges_both_configs(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Merges remotes from both global and local configs."""
@@ -499,8 +464,8 @@ def test_complete_config_keys_merges_both_configs(
 
 def test_complete_config_keys_filters_invalid_remote_names(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Filters out remote names with invalid characters."""
@@ -522,8 +487,8 @@ def test_complete_config_keys_filters_invalid_remote_names(
 
 
 def test_complete_config_keys_returns_empty_on_exception(
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Returns empty list if exception occurs."""
@@ -534,8 +499,8 @@ def test_complete_config_keys_returns_empty_on_exception(
 
 def test_complete_config_keys_handles_malformed_yaml(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Handles malformed YAML gracefully, returns static keys."""
@@ -555,8 +520,8 @@ def test_complete_config_keys_handles_malformed_yaml(
 
 def test_complete_config_keys_handles_remotes_not_dict(
     tmp_path: Path,
-    mock_ctx: click.Context,
-    mock_param: click.Parameter,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
     mocker: MockerFixture,
 ) -> None:
     """Handles remotes: null or remotes: 'string' gracefully."""
@@ -572,3 +537,462 @@ def test_complete_config_keys_handles_remotes_not_dict(
     # Should not crash, returns static keys
     values = [item.value for item in result]
     assert "cache.dir" in values
+
+
+# =============================================================================
+# _detect_config_file tests
+# =============================================================================
+
+
+def test_detect_config_file_finds_pivot_yaml(tmp_path: Path) -> None:
+    """Detects pivot.yaml and returns its mtime."""
+    config = tmp_path / "pivot.yaml"
+    config.write_text("stages: {}")
+
+    result = completion._detect_config_file(tmp_path)
+
+    assert result is not None
+    name, mtime = result
+    assert name == "pivot.yaml"
+    assert mtime == config.stat().st_mtime
+
+
+def test_detect_config_file_finds_pivot_yml(tmp_path: Path) -> None:
+    """Detects pivot.yml when pivot.yaml doesn't exist."""
+    config = tmp_path / "pivot.yml"
+    config.write_text("stages: {}")
+
+    result = completion._detect_config_file(tmp_path)
+
+    assert result is not None
+    name, mtime = result
+    assert name == "pivot.yml"
+    assert mtime == config.stat().st_mtime
+
+
+def test_detect_config_file_finds_pipeline_py(tmp_path: Path) -> None:
+    """Detects pipeline.py when no YAML exists."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    result = completion._detect_config_file(tmp_path)
+
+    assert result is not None
+    name, mtime = result
+    assert name == "pipeline.py"
+    assert mtime == config.stat().st_mtime
+
+
+def test_detect_config_file_prefers_yaml_over_pipeline(tmp_path: Path) -> None:
+    """pivot.yaml takes precedence over pipeline.py."""
+    (tmp_path / "pivot.yaml").write_text("stages: {}")
+    (tmp_path / "pipeline.py").write_text("# pipeline")
+
+    result = completion._detect_config_file(tmp_path)
+
+    assert result is not None
+    name, _ = result
+    assert name == "pivot.yaml"
+
+
+def test_detect_config_file_returns_none_when_nothing_found(tmp_path: Path) -> None:
+    """Returns None when no config file exists."""
+    result = completion._detect_config_file(tmp_path)
+    assert result is None
+
+
+# =============================================================================
+# _get_stages_from_cache tests
+# =============================================================================
+
+
+def test_get_stages_from_cache_reads_valid_cache(tmp_path: Path) -> None:
+    """Reads stage names from a valid cache file."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+    mtime = config.stat().st_mtime
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text(f"v1\npipeline.py:{mtime}\ntrain\ntest\nevaluate\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+
+    assert result == ["train", "test", "evaluate"]
+
+
+def test_get_stages_from_cache_returns_none_when_no_cache(tmp_path: Path) -> None:
+    """Returns None when cache file doesn't exist."""
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_returns_none_on_version_mismatch(tmp_path: Path) -> None:
+    """Returns None when cache version doesn't match."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+    mtime = config.stat().st_mtime
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text(f"v2\npipeline.py:{mtime}\ntrain\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_returns_none_on_mtime_mismatch(tmp_path: Path) -> None:
+    """Returns None when config file mtime doesn't match."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    # Use wrong mtime
+    (cache_dir / "stages.cache").write_text("v1\npipeline.py:0.0\ntrain\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_returns_none_when_config_deleted(tmp_path: Path) -> None:
+    """Returns None when config file no longer exists."""
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text("v1\npipeline.py:1234567890.0\ntrain\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_returns_none_on_malformed_header(tmp_path: Path) -> None:
+    """Returns None when header line is malformed (no colon)."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text("v1\nmalformed_no_colon\ntrain\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_returns_none_on_too_few_lines(tmp_path: Path) -> None:
+    """Returns None when cache has fewer than 2 lines."""
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text("v1\n")
+
+    result = completion._get_stages_from_cache(tmp_path)
+    assert result is None
+
+
+def test_get_stages_from_cache_handles_empty_stages(tmp_path: Path) -> None:
+    """Handles cache with no stages (empty pipeline) written by _write_stages_cache."""
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+    mtime = config.stat().st_mtime
+
+    # Use the actual writer to create the cache (tests roundtrip correctness)
+    completion._write_stages_cache(tmp_path, "pipeline.py", mtime, [])
+
+    result = completion._get_stages_from_cache(tmp_path)
+
+    # Empty list of stages - writer produces trailing blank line, reader filters it
+    assert result == []
+
+
+# =============================================================================
+# _write_stages_cache tests
+# =============================================================================
+
+
+def test_write_stages_cache_creates_cache_file(tmp_path: Path) -> None:
+    """Creates cache file with correct format."""
+    (tmp_path / ".pivot").mkdir()
+
+    completion._write_stages_cache(tmp_path, "pipeline.py", 1234567890.5, ["train", "test"])
+
+    cache_path = tmp_path / ".pivot" / "cache" / "stages.cache"
+    assert cache_path.exists()
+    content = cache_path.read_text()
+    lines = content.splitlines()
+    assert lines[0] == "v1"
+    assert lines[1] == "pipeline.py:1234567890.5"
+    assert lines[2] == "train"
+    assert lines[3] == "test"
+
+
+def test_write_stages_cache_creates_cache_dir(tmp_path: Path) -> None:
+    """Creates .pivot/cache directory if it doesn't exist."""
+    # Neither .pivot nor .pivot/cache exist
+    completion._write_stages_cache(tmp_path, "pipeline.py", 1234567890.0, ["stage1"])
+
+    assert (tmp_path / ".pivot" / "cache" / "stages.cache").exists()
+
+
+def test_write_stages_cache_overwrites_existing(tmp_path: Path) -> None:
+    """Overwrites existing cache file."""
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    cache_path = cache_dir / "stages.cache"
+    cache_path.write_text("old content")
+
+    completion._write_stages_cache(tmp_path, "pipeline.py", 999.0, ["new_stage"])
+
+    content = cache_path.read_text()
+    assert "new_stage" in content
+    assert "old content" not in content
+
+
+def test_write_stages_cache_handles_empty_stages(tmp_path: Path) -> None:
+    """Handles empty stages list."""
+    (tmp_path / ".pivot").mkdir()
+
+    completion._write_stages_cache(tmp_path, "pipeline.py", 1234567890.0, [])
+
+    cache_path = tmp_path / ".pivot" / "cache" / "stages.cache"
+    content = cache_path.read_text()
+    # Format: "v1\npipeline.py:mtime\n\n" - the join of empty list is ""
+    # So content ends with "\n\n" which gives 3 lines when split
+    assert content == "v1\npipeline.py:1234567890.0\n\n"
+
+
+# =============================================================================
+# Stage cache integration tests
+# =============================================================================
+
+
+def test_get_stages_fast_returns_cached_stages(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Fast path returns cached stages when cache is valid."""
+    # Create pipeline.py and its cache
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+    mtime = config.stat().st_mtime
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text(f"v1\npipeline.py:{mtime}\ncached_stage\n")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+
+    result = completion._get_stages_fast()
+
+    assert result == ["cached_stage"]
+
+
+def test_get_stages_fast_ignores_stale_cache(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Fast path ignores cache when mtime doesn't match."""
+    # Create pipeline.py
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    # Create cache with wrong mtime
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text("v1\npipeline.py:0.0\nstale_stage\n")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+
+    # Fast path should return None (no yaml, cache invalid)
+    result = completion._get_stages_fast()
+
+    assert result is None  # Falls through to None (no YAML file)
+
+
+def test_get_stages_full_writes_cache(
+    mock_discovery: Pipeline, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Full discovery writes cache after successful discovery."""
+    _ = mock_discovery
+
+    # Create pipeline.py config file
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    # Register stages
+    register_test_stage(_noop, name="discovered_stage")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+
+    result = completion._get_stages_full()
+
+    # Stage should be discovered
+    assert "discovered_stage" in result
+
+    # Cache should be written
+    cache_path = tmp_path / ".pivot" / "cache" / "stages.cache"
+    assert cache_path.exists()
+    content = cache_path.read_text()
+    assert "discovered_stage" in content
+
+
+def test_get_stages_full_skips_cache_on_mtime_change(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Full discovery skips cache write if config file changed during discovery."""
+
+    # Create pipeline.py
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+
+    # Create a mock pipeline that modifies the file during discovery
+    mock_pipeline = mocker.MagicMock(spec=pipeline_mod.Pipeline)
+    mock_pipeline.list_stages.return_value = ["stage1"]
+
+    def discover_and_modify() -> pipeline_mod.Pipeline:
+        # Simulate file change during discovery
+        time.sleep(0.01)  # Ensure mtime changes
+        config.write_text("# modified pipeline")
+        return mock_pipeline
+
+    mocker.patch.object(discovery, "discover_pipeline", side_effect=discover_and_modify)
+
+    completion._get_stages_full()
+
+    # Cache should NOT be written due to mtime change
+    cache_path = tmp_path / ".pivot" / "cache" / "stages.cache"
+    assert not cache_path.exists()
+
+
+def test_complete_stages_uses_cache(
+    tmp_path: Path,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
+    mocker: MockerFixture,
+) -> None:
+    """Complete stages uses cache when available."""
+    # Create pipeline.py with cache
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+    mtime = config.stat().st_mtime
+
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "stages.cache").write_text(f"v1\npipeline.py:{mtime}\ncached_train\ncached_test\n")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+
+    result = completion.complete_stages(mock_ctx, mock_param, "cached_t")
+
+    assert set(result) == {"cached_train", "cached_test"}
+
+
+# =============================================================================
+# _get_stages_full additional tests
+# =============================================================================
+
+
+def test_get_stages_full_returns_empty_when_no_pipeline(mocker: MockerFixture) -> None:
+    """Returns empty list when discover_pipeline() finds no pipeline."""
+    mocker.patch.object(discovery, "discover_pipeline", return_value=None)
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=None)
+
+    result = completion._get_stages_full()
+
+    assert result == []
+
+
+def test_get_stages_full_handles_cache_write_oserror(
+    mock_discovery: Pipeline, tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Cache write failure is silently ignored, stages still returned."""
+    _ = mock_discovery
+
+    # Create a config file so _detect_config_file succeeds
+    config = tmp_path / "pipeline.py"
+    config.write_text("# pipeline")
+
+    register_test_stage(_noop, name="resilient_stage")
+
+    mocker.patch.object(completion, "_find_project_root_fast", return_value=tmp_path)
+    # Make the cache write fail (e.g. read-only filesystem)
+    mocker.patch.object(
+        completion, "_write_stages_cache", side_effect=OSError("read-only filesystem")
+    )
+
+    result = completion._get_stages_full()
+
+    # Stages should still be returned despite cache write failure
+    assert "resilient_stage" in result
+
+
+# =============================================================================
+# _write_stages_cache error handling tests
+# =============================================================================
+
+
+def test_write_stages_cache_cleans_up_temp_on_rename_failure(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Cleans up temp file when rename fails, then re-raises."""
+    cache_dir = tmp_path / ".pivot" / "cache"
+    cache_dir.mkdir(parents=True)
+
+    # Make rename fail to trigger the OSError cleanup path
+    original_rename = pathlib.Path.rename
+    rename_called = False
+
+    def failing_rename(self: pathlib.Path, target: pathlib.Path) -> pathlib.Path:
+        nonlocal rename_called
+        # Only fail for .tmp files (the temp file created by mkstemp)
+        if self.suffix == ".tmp":
+            rename_called = True
+            raise OSError("simulated rename failure")
+        return original_rename(self, target)
+
+    mocker.patch.object(pathlib.Path, "rename", failing_rename)
+
+    with pytest.raises(OSError, match="simulated rename failure"):
+        completion._write_stages_cache(tmp_path, "pipeline.py", 1234567890.0, ["stage1"])
+
+    assert rename_called, "rename should have been called"
+    # Verify no .tmp files left behind in cache dir
+    tmp_files = list(cache_dir.glob("*.tmp"))
+    assert tmp_files == [], f"Temp files should be cleaned up, found: {tmp_files}"
+
+
+# =============================================================================
+# _get_config_keys edge case tests
+# =============================================================================
+
+
+def test_get_config_keys_skips_empty_yaml_file(
+    tmp_path: Path,
+    mock_ctx: mock.MagicMock,
+    mock_param: mock.MagicMock,
+    mocker: MockerFixture,
+) -> None:
+    """Skips config files with empty/non-dict YAML content (e.g. just a comment)."""
+    config_path = tmp_path / "config.yaml"
+    # yaml.safe_load("# just a comment") returns None, not a dict
+    config_path.write_text("# just a comment\n")
+    mocker.patch.object(
+        completion,
+        "_get_config_paths",
+        return_value=[config_path],
+    )
+
+    result = completion.complete_config_keys(mock_ctx, mock_param, "cache")
+    values = [item.value for item in result]
+    # Should still return static keys without crashing
+    assert "cache.dir" in values
+
+
+# =============================================================================
+# Cache write-then-read roundtrip tests
+# =============================================================================
+
+
+def test_cache_roundtrip_preserves_stages(tmp_path: Path) -> None:
+    """Writing then reading cache preserves the exact stage list."""
+    config = tmp_path / "pivot.yaml"
+    config.write_text("stages: {}")
+    mtime = config.stat().st_mtime
+
+    stages = ["train", "test@bert_swe", "preprocess", "evaluate@gpt_human"]
+    completion._write_stages_cache(tmp_path, "pivot.yaml", mtime, stages)
+    result = completion._get_stages_from_cache(tmp_path)
+
+    assert result == stages, "Roundtrip should preserve exact stage list and order"


### PR DESCRIPTION
## Summary

- Add stage name cache (`.pivot/cache/stages.cache`) for fast tab-completion of `pivot repro/run <TAB>`
- Cache stores stage names with config file mtime for freshness validation
- First tab-completion triggers full discovery (~2.5s), subsequent completions read from cache (<50ms)
- Add `discovery.load_module` metrics timing to measure import vs fingerprinting costs

## Details

Tab-completion for `pipeline.py` pipelines was slow (~2.5s) because it triggered full discovery, importing heavy dependencies (pandas, sklearn, etc.). The existing fast path only worked for `pivot.yaml` pipelines.

New cache functions in `completion.py`:
- `_detect_config_file()` — finds config file and captures mtime
- `_get_stages_from_cache()` — reads cache, validates version + mtime freshness
- `_write_stages_cache()` — atomic write via tempfile + rename
- Race condition prevention: captures mtime before discovery, verifies unchanged after

## Test plan

- [x] 56 completion tests pass (including 28 new cache tests)
- [x] basedpyright: 0 errors, 0 warnings
- [x] ruff format + check: clean
- [ ] Manual: run `PIVOT_METRICS=1 pivot repro --dry-run` to verify metrics
- [ ] Manual: test tab-completion with `pivot repro <TAB>` (first slow, second fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)