### PR TITLE
perf(registry): lazy fingerprinting — decouple graph-building from fingerprinting

### DIFF
--- a/docs/plans/2026-02-05-lazy-fingerprinting-design.md
+++ b/docs/plans/2026-02-05-lazy-fingerprinting-design.md
@@ -1,0 +1,146 @@
+# Lazy Fingerprinting: Decouple Graph-Building from Fingerprinting
+
+## Problem
+
+Pipeline startup is slow because fingerprinting happens eagerly during stage registration, before the graph is built or any stage can execute. For a 108-stage pipeline, `registry.register()` spends ~666ms on fingerprinting — blocking graph availability and delaying execution.
+
+Fingerprinting and graph topology are independent concerns:
+- **Graph topology** ("what depends on what") only changes when stage definitions change (new deps/outputs/stages)
+- **Fingerprints** ("has the code changed") change whenever any code in a stage's dependency tree changes
+
+Watch mode demonstrates this clearly: after editing a helper function, fingerprints change but the graph stays the same.
+
+## Solution
+
+Make fingerprint computation lazy. Remove fingerprinting from `registry.register()` and compute fingerprints on first access via an accessor on `StageRegistry`. The graph becomes available immediately after registration, and fingerprints are computed just-in-time when the engine is about to dispatch each stage.
+
+**Target:** Eliminate ~666ms of fingerprinting from the registration path. Fingerprinting cost shifts to execution time, where it's pipelined with stage execution (later waves fingerprint while earlier waves run).
+
+## Design
+
+### RegistryStageInfo
+
+Change `fingerprint` from required to nullable:
+
+```python
+# Before
+fingerprint: dict[str, str]
+
+# After
+fingerprint: dict[str, str] | None
+```
+
+`register()` sets `fingerprint=None` instead of computing it.
+
+### Accessor: `StageRegistry.ensure_fingerprint()`
+
+Add `ensure_fingerprint()` to `StageRegistry`:
+
+```python
+def ensure_fingerprint(self, stage_name: str) -> dict[str, str]:
+    info = self._stages[stage_name]
+    if info["fingerprint"] is None:
+        info["fingerprint"] = _compute_fingerprint(stage_name, info)
+    return info["fingerprint"]
+```
+
+### Fingerprint computation
+
+`_compute_fingerprint` replaces the inline logic currently at `register()` lines 470–473. It uses `dep_specs` and `out_specs` from the stored `RegistryStageInfo` directly, which lets us inline the loader fingerprinting rather than calling the three-argument `_get_annotation_loader_fingerprints(dep_specs, return_out_specs, single_out_spec)` helper (since `out_specs` already merges both return and single output specs):
+
+```python
+def _compute_fingerprint(stage_name: str, info: RegistryStageInfo) -> dict[str, str]:
+    try:
+        fp = fingerprint.get_stage_fingerprint(info["func"])
+        for spec in info["dep_specs"].values():
+            fp.update(fingerprint.get_loader_fingerprint(spec.loader))
+        for out in info["out_specs"].values():
+            fp.update(fingerprint.get_loader_fingerprint(out.loader))
+        return fp
+    except Exception as exc:
+        raise exceptions.PivotError(
+            f"Stage '{stage_name}': fingerprinting failed: {exc}"
+        ) from exc
+```
+
+This may allow removing `_get_annotation_loader_fingerprints` if no other callers remain.
+
+### Error handling
+
+Fingerprint errors shift from registration time to first access (execution, status, watch reload). This is acceptable for the goal of fast graph building. Commands that only need graph topology (`pivot list`, `pivot dag`, tab-completion) no longer surface fingerprint problems — they work without computing fingerprints at all.
+
+`ensure_fingerprint()` wraps failures in `PivotError` with the stage name so the user sees which stage failed and why.
+
+### Concurrency
+
+`pivot.fingerprint` caches are not thread-safe. To maintain that invariant, fingerprints must be computed on the main thread before any parallel work:
+
+- **`status.get_pipeline_explanations`**: precompute fingerprints for all stages in `execution_order` on the main thread before submitting to the `ThreadPoolExecutor`.
+- **Engine execution**: compute the fingerprint in `_start_ready_stages` (on the event loop thread, before submitting the worker to the process pool). This is safe because `_start_ready_stages` is `async` but runs on a single-threaded event loop — no concurrent `ensure_fingerprint()` calls.
+- **Watch reload**: runs on the event loop thread, same single-threaded guarantee.
+
+No lock is needed. The computation is synchronous and idempotent, and all call sites are single-threaded.
+
+### Watch mode reload
+
+`_emit_reload_event` compares old and new fingerprints to detect modified stages. With lazy fingerprinting, both old and new `RegistryStageInfo` may have `fingerprint=None` at comparison time.
+
+The fix: call `ensure_fingerprint()` on both old and new stage infos for the intersection of stage names. If fingerprinting fails during reload, log a warning and conservatively treat the stage as modified (keeps the UI informative, prevents engine crashes):
+
+```python
+for stage_name in sorted(old_stage_names & new_stages_set):
+    try:
+        old_fp = old_registry.ensure_fingerprint(stage_name)
+    except exceptions.PivotError:
+        old_fp = None
+    try:
+        new_fp = self._registry.ensure_fingerprint(stage_name)
+    except exceptions.PivotError:
+        new_fp = None
+    if old_fp != new_fp:
+        modified.append(stage_name)
+```
+
+Note: `snapshot()` returns a shallow copy — it shares references to the same `RegistryStageInfo` dicts. If `ensure_fingerprint()` was called on the live registry before snapshotting, the snapshot gets the materialized fingerprint for free. If not, calling `ensure_fingerprint()` on the old registry during reload still works because it mutates the shared dict in place. Either way, comparison is correct.
+
+Selective re-fingerprinting (only fingerprint stages affected by changed files) is a future optimization tracked in #358.
+
+### `add_existing()`
+
+Stages added via `add_existing()` may arrive with `fingerprint=None` (from another lazy registry) or pre-computed. `ensure_fingerprint()` handles both — it checks for `None` and computes if needed.
+
+### Consumers
+
+All sites that access `stage_info["fingerprint"]` switch to `registry.ensure_fingerprint(stage_name)`:
+
+| File | Context | Notes |
+|------|---------|-------|
+| `engine/engine.py` | Watch mode comparison | Call on both old and new registries |
+| `engine/engine.py` | `_start_ready_stages` | Compute before worker dispatch |
+| `executor/core.py` | Building `WorkerStageInfo` | Receives pre-computed fingerprint from engine |
+| `tui/run.py` | Building `WorkerStageInfo` | Call before building WorkerStageInfo |
+| `tui/diff_panels.py` | Building `WorkerStageInfo` | Call before building WorkerStageInfo |
+| `status.py` | `get_pipeline_explanations` | Precompute all before entering thread pool |
+| `engine/agent_rpc.py` | Agent RPC | Call before building WorkerStageInfo |
+
+**No changes needed:**
+- `executor/worker.py` — receives the computed fingerprint via `WorkerStageInfo`
+- `fingerprint.py` — computation logic unchanged, just called from a different place
+- `engine/graph.py` — graph building doesn't touch fingerprints
+
+### Tests and metrics
+
+Existing tests cover all consumer paths — they exercise the full pipeline through execution. The `registry.register` metric will naturally get faster (that's the point). The existing `fingerprint.get_stage_fingerprint` metric inside `fingerprint.py` still fires when `ensure_fingerprint()` triggers computation, so fingerprinting cost remains independently measurable.
+
+Add a test for the lazy computation behavior: register a stage, verify `fingerprint` is `None`, call `ensure_fingerprint()`, verify it returns a non-empty dict and caches it.
+
+## What This Does NOT Change
+
+- **Fingerprint computation logic** — `fingerprint.py` stays the same
+- **Graph construction** — already fingerprint-free, no changes
+- **Worker skip detection** — workers receive fingerprints via `WorkerStageInfo`, unchanged
+- **Fingerprint caching** — in-memory and persistent StateDB caches still work
+
+## Known Limitations
+
+- Watch mode fingerprints all stages on re-discovery, not just affected ones (#358).

--- a/src/pivot/cli/helpers.py
+++ b/src/pivot/cli/helpers.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     from pivot.cli import CliContext
     from pivot.pipeline.pipeline import Pipeline
-    from pivot.registry import RegistryStageInfo
+    from pivot.registry import RegistryStageInfo, StageRegistry
 
 from pivot import exceptions
 from pivot.cli import decorators as cli_decorators
@@ -41,6 +41,11 @@ def _get_pipeline() -> Pipeline:
     if pipeline is None:
         raise NoPipelineError()
     return pipeline
+
+
+def get_registry() -> StageRegistry:
+    """Get StageRegistry from Pipeline in context."""
+    return _get_pipeline()._registry  # pyright: ignore[reportPrivateUsage]
 
 
 def list_stages() -> list[str]:

--- a/src/pivot/cli/repro.py
+++ b/src/pivot/cli/repro.py
@@ -128,6 +128,7 @@ def _output_explain(
         stages_list,
         single_stage=False,
         all_stages=all_stages,
+        stage_registry=cli_helpers.get_registry(),
         force=force,
         allow_missing=allow_missing,
         graph=graph,
@@ -168,6 +169,7 @@ def _dry_run(
         allow_missing=allow_missing,
         graph=graph,
         all_stages=all_stages,
+        stage_registry=cli_helpers.get_registry(),
     )
 
     if not explanations:

--- a/src/pivot/cli/status.py
+++ b/src/pivot/cli/status.py
@@ -77,11 +77,19 @@ def status(
 
         if explain:
             pipeline_explanations = status_mod.get_pipeline_explanations(
-                stages_list, single_stage=False, all_stages=all_stages, graph=graph
+                stages_list,
+                single_stage=False,
+                all_stages=all_stages,
+                stage_registry=cli_helpers.get_registry(),
+                graph=graph,
             )
         else:
             pipeline_status, _ = status_mod.get_pipeline_status(
-                stages_list, single_stage=False, all_stages=all_stages, graph=graph
+                stages_list,
+                single_stage=False,
+                all_stages=all_stages,
+                stage_registry=cli_helpers.get_registry(),
+                graph=graph,
             )
 
     if show_tracked:

--- a/src/pivot/cli/verify.py
+++ b/src/pivot/cli/verify.py
@@ -282,6 +282,7 @@ def verify(
         stages_list,
         single_stage=False,
         all_stages=all_stages,
+        stage_registry=cli_helpers.get_registry(),
         allow_missing=allow_missing,
     )
 

--- a/src/pivot/engine/agent_rpc.py
+++ b/src/pivot/engine/agent_rpc.py
@@ -264,6 +264,10 @@ class AgentRpcHandler:
                 return QueryStagesResult(stages=pipeline.list_stages())
             case "explain":
                 stage, reg_info = self._get_stage_info(params)
+                pipeline = self._engine._pipeline  # pyright: ignore[reportPrivateUsage]
+                if pipeline is None:
+                    raise ValueError("No pipeline loaded")
+                fingerprint = pipeline._registry.ensure_fingerprint(stage)  # pyright: ignore[reportPrivateUsage]
 
                 def _get_explanation() -> StageExplanation:
                     try:
@@ -272,7 +276,7 @@ class AgentRpcHandler:
                         raise ValueError(f"Failed to load params.yaml: {e}") from e
                     return explain_mod.get_stage_explanation(
                         stage_name=stage,
-                        fingerprint=reg_info["fingerprint"],
+                        fingerprint=fingerprint,
                         deps=reg_info["deps_paths"],
                         outs_paths=reg_info["outs_paths"],
                         params_instance=reg_info["params"],

--- a/src/pivot/executor/core.py
+++ b/src/pivot/executor/core.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Literal, TypedDict
 
 import loky
 
-from pivot import config, discovery, exceptions, outputs, parameters
+from pivot import config, discovery, exceptions, outputs, parameters, registry
 from pivot.executor import worker
 from pivot.storage import cache, lock, track
 from pivot.storage import state as state_mod
@@ -315,6 +315,7 @@ def create_executor(max_workers: int) -> concurrent.futures.Executor:
 
 def prepare_worker_info(
     stage_info: RegistryStageInfo,
+    stage_registry: registry.StageRegistry,
     overrides: parameters.ParamsOverrides,
     checkout_modes: list[cache.CheckoutMode],
     run_id: str,
@@ -336,7 +337,7 @@ def prepare_worker_info(
 
     return worker.WorkerStageInfo(
         func=stage_info["func"],
-        fingerprint=stage_info["fingerprint"],
+        fingerprint=stage_registry.ensure_fingerprint(stage_info["name"]),
         deps=stage_info["deps_paths"],
         outs=stage_info["outs"],
         signature=stage_info["signature"],

--- a/src/pivot/tui/diff_panels.py
+++ b/src/pivot/tui/diff_panels.py
@@ -436,9 +436,10 @@ class InputDiffPanel(_SelectableExpandablePanel):
 
         state_dir = config.get_state_dir()
         try:
+            fingerprint = cli_helpers.get_registry().ensure_fingerprint(stage_name)
             self._explanation = explain.get_stage_explanation(
                 stage_name=stage_name,
-                fingerprint=self._registry_info["fingerprint"],
+                fingerprint=fingerprint,
                 deps=self._registry_info["deps_paths"],
                 outs_paths=self._registry_info["outs_paths"],
                 params_instance=self._registry_info["params"],

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -571,10 +571,11 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
         input_snapshot = None
         try:
             registry_info = cli_helpers.get_stage(stage_name)
+            fingerprint = cli_helpers.get_registry().ensure_fingerprint(stage_name)
             state_dir = config.get_state_dir()
             input_snapshot = explain.get_stage_explanation(
                 stage_name=stage_name,
-                fingerprint=registry_info["fingerprint"],
+                fingerprint=fingerprint,
                 deps=registry_info["deps_paths"],
                 outs_paths=registry_info["outs_paths"],
                 params_instance=registry_info["params"],

--- a/tests/core/test_explain.py
+++ b/tests/core/test_explain.py
@@ -703,7 +703,10 @@ def test_get_pipeline_explanations_upstream_propagation(
 
         # Get pipeline explanations
         explanations = status.get_pipeline_explanations(
-            stages=None, single_stage=False, all_stages=pipeline.snapshot()
+            stages=None,
+            single_stage=False,
+            all_stages=pipeline.snapshot(),
+            stage_registry=pipeline._registry,
         )
 
         # Find stage_b's explanation

--- a/tests/execution/test_executor_worker.py
+++ b/tests/execution/test_executor_worker.py
@@ -2531,6 +2531,7 @@ def test_prepare_worker_info_uses_stage_state_dir(
     stage_info = test_registry.get("stage_with_custom_state")
     worker_info = executor_core.prepare_worker_info(
         stage_info=stage_info,
+        stage_registry=test_registry,
         overrides={},
         checkout_modes=[],
         run_id="test-run",
@@ -2559,6 +2560,7 @@ def test_prepare_worker_info_uses_default_state_dir_when_stage_has_none(
     default_state_dir = set_project_root / ".pivot"
     worker_info = executor_core.prepare_worker_info(
         stage_info=stage_info,
+        stage_registry=test_registry,
         overrides={},
         checkout_modes=[],
         run_id="test-run",

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -603,9 +603,15 @@ def test_pipeline_include_preserves_all_metadata(set_project_root: pathlib.Path)
     assert included_info["outs_paths"] == original_info["outs_paths"]
     assert included_info["mutex"] == original_info["mutex"]
     assert included_info["variant"] == original_info["variant"]
-    assert included_info["fingerprint"] == original_info["fingerprint"]
     assert included_info["signature"] == original_info["signature"]
     assert included_info["func"] == original_info["func"]
+
+    # Fingerprints are lazy (None after registration) — verify both registries
+    # compute the same fingerprint for the included stage
+    original_fp = sub._registry.ensure_fingerprint("complex_stage")
+    included_fp = main._registry.ensure_fingerprint("complex_stage")
+    assert original_fp == included_fp
+    assert original_fp, "fingerprint should be non-empty"
 
 
 def test_pipeline_include_isolates_nested_mutations(set_project_root: pathlib.Path) -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -73,7 +73,12 @@ def test_pipeline_status_all_cached(
     monkeypatch.chdir(set_project_root)
     executor.run(pipeline=test_pipeline)
     all_stages = test_pipeline.snapshot()
-    results, _ = status.get_pipeline_status(None, single_stage=False, all_stages=all_stages)
+    results, _ = status.get_pipeline_status(
+        None,
+        single_stage=False,
+        all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
+    )
 
     assert len(results) == 1
     assert results[0]["name"] == "stage_a"
@@ -91,7 +96,12 @@ def test_pipeline_status_some_stale(
     register_test_stage(_helper_stage_a, name="stage_a")
 
     all_stages = test_pipeline.snapshot()
-    results, _ = status.get_pipeline_status(None, single_stage=False, all_stages=all_stages)
+    results, _ = status.get_pipeline_status(
+        None,
+        single_stage=False,
+        all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
+    )
 
     assert len(results) == 1
     assert results[0]["name"] == "stage_a"
@@ -110,7 +120,12 @@ def test_pipeline_status_upstream_stale(
     register_test_stage(_helper_stage_b, name="stage_b")
 
     all_stages = test_pipeline.snapshot()
-    results, _ = status.get_pipeline_status(None, single_stage=False, all_stages=all_stages)
+    results, _ = status.get_pipeline_status(
+        None,
+        single_stage=False,
+        all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
+    )
 
     assert len(results) == 2
 
@@ -135,7 +150,12 @@ def test_pipeline_status_specific_stages(
     register_test_stage(_helper_stage_b, name="stage_b")
 
     all_stages = test_pipeline.snapshot()
-    results, _ = status.get_pipeline_status(["stage_a"], single_stage=False, all_stages=all_stages)
+    results, _ = status.get_pipeline_status(
+        ["stage_a"],
+        single_stage=False,
+        all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
+    )
 
     assert len(results) == 1
     assert results[0]["name"] == "stage_a"
@@ -451,6 +471,7 @@ def test_get_pipeline_status_uses_provided_graph(
         stages=["test_stage"],
         single_stage=False,
         all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
         graph=external_graph,
     )
 
@@ -485,6 +506,7 @@ def test_get_pipeline_explanations_uses_provided_graph(
         stages=["test_stage"],
         single_stage=False,
         all_stages=all_stages,
+        stage_registry=test_pipeline._registry,
         graph=external_graph,
     )
 


### PR DESCRIPTION
## Summary

- Defer fingerprint computation from `registry.register()` to first access via `StageRegistry.ensure_fingerprint()`, eliminating ~666ms from the registration path for a 108-stage pipeline
- Graph availability is now immediate after registration — fingerprints computed just-in-time when the engine dispatches each stage
- Add `cli_helpers.get_registry()` accessor to centralize private attribute access

## Design

`RegistryStageInfo["fingerprint"]` becomes `dict[str, str] | None`. A new `ensure_fingerprint()` method on `StageRegistry` computes lazily on first access and caches back onto the stage info dict. All ~8 consumer sites migrated.

Key concurrency constraint: `pivot.fingerprint` caches are not thread-safe, so fingerprints are always computed on the main thread before any parallel work (`ThreadPoolExecutor` in status, process pool in engine).

Watch mode reload calls `ensure_fingerprint()` on both old and new registries, catches errors gracefully, and conservatively treats failed stages as modified.

Design doc: `docs/plans/2026-02-05-lazy-fingerprinting-design.md`

Related: #358 (selective re-fingerprinting — future optimization)

## Test plan

- [x] New test: `test_register_defers_fingerprint_until_requested` verifies lazy behavior (None after register, computed after ensure, cached)
- [x] Strengthened `test_pipeline_include_preserves_all_metadata` to verify computed fingerprints match across registries
- [x] All existing tests pass (178 tests across affected modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)