### PR TITLE
fix(pipeline): resolve sibling pipeline deps when output files exist on disk

### DIFF
--- a/src/pivot/engine/engine.py
+++ b/src/pivot/engine/engine.py
@@ -1171,11 +1171,13 @@ class Engine:
         old_stages, old_registry = reload_result
         await self._emit_reload_event(old_stages, old_registry)
 
-        # Rebuild graph
+        # Resolve external deps (e.g. sibling pipelines) before reading stages.
+        # Reload bypasses Pipeline.build_dag() so we must resolve explicitly.
+        self._require_pipeline().resolve_external_dependencies()
         all_stages = self._get_all_stages()
         self._graph = engine_graph.build_graph(all_stages)
 
-        # Update watch paths if we have an FilesystemSource
+        # Update watch paths if we have a FilesystemSource
         from pivot.engine.sources import FilesystemSource
 
         watch_paths = engine_graph.get_watch_paths(self._graph)


### PR DESCRIPTION
## Summary

- **Bug fix**: Remove `.exists()` early-return in `resolve_external_dependencies()` that skipped sibling pipeline discovery when output files already existed on disk (e.g. from a previous run)
- **Performance**: Add `_external_deps_resolved` caching flag to `Pipeline` so resolution is O(1) on repeated `build_dag()` calls, with resets consolidated in `_reset_resolution_cache()` helper
- **Watch-mode fix**: Call `resolve_external_dependencies()` on fresh pipeline in the engine's reload handler, so sibling stages aren't lost after code-change reloads

## Root cause

`resolve_external_dependencies()` checked `pathlib.Path(dep_path).exists()` and treated any file present on disk as an external input, skipping the search for a producing pipeline. When `data/difficulty/processed/task_difficulty.yaml` existed from a prior run, the base pipeline never discovered the difficulty pipeline that produces it.

## Test plan

- [x] `test_resolve_external_dependencies_when_output_exists_on_disk` — regression test for the `.exists()` bug
- [x] `test_resolution_skipped_after_first_build_dag` — verifies caching via spy (no filesystem traversal on second call)
- [x] `test_resolution_resets_after_invalidate_dag_cache` — verifies invalidation forces re-resolution
- [x] `test_resolution_resets_after_clear` — verifies `clear()` resets the flag
- [x] `test_resolution_resets_after_restore` — verifies `restore()` resets the flag
- [x] `test_resolution_resets_after_include` — verifies `include()` resets when new stages bring unresolved deps
- [x] 3407 tests pass, 0 basedpyright errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)