### PR TITLE
docs: document pipeline discovery learnings and critical patterns

### DIFF
--- a/docs/solutions/logic-errors/dry-run-bypasses-resolution-20260206.md
+++ b/docs/solutions/logic-errors/dry-run-bypasses-resolution-20260206.md
@@ -1,0 +1,82 @@
+---
+module: CLI
+date: 2026-02-06
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "pivot repro --dry-run shows only local stages, not cross-pipeline dependencies"
+  - "Dry-run output differs from actual execution in multi-pipeline setups"
+  - "Cross-pipeline stages missing from dry-run DAG visualization"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [cli, dry-run, resolution, discovery, dag, build-dag, pivot]
+---
+
+# Troubleshooting: --dry-run Bypasses External Dependency Resolution
+
+## Problem
+
+The `--dry-run` code path in the CLI called `get_all_stages()` and `build_graph()` directly, bypassing `build_dag()` which is the method that triggers `resolve_external_dependencies()`. This meant dry-run output only showed locally-registered stages, not cross-pipeline dependencies that would be resolved during actual execution.
+
+## Environment
+
+- Module: CLI (`src/pivot/cli/repro.py`)
+- Functions: `_dry_run()`, `_output_explain()`
+- Python Version: 3.13+
+- Date: 2026-02-06
+
+## Symptoms
+
+- `pivot repro --dry-run` shows only stages from the current `pipeline.py`
+- Stages from parent/sibling pipelines that would be included during execution are missing
+- Dry-run reports fewer stages than actual `pivot repro`
+- Misleading "all stages would skip" output when cross-pipeline deps haven't been resolved
+- Problem is invisible in single-pipeline projects (no external deps to resolve)
+
+## Root Cause: Parallel Code Paths
+
+Two separate code paths existed for building the stage graph:
+
+```python
+# Normal execution path (correct):
+pipeline.build_dag()  # calls resolve_external_dependencies() internally
+# ... then executes stages
+
+# Dry-run path (broken):
+stages = cli_helpers.get_all_stages()  # reads registry directly
+graph = engine_graph.build_graph(stages)  # builds graph from local-only stages
+# ... displays what would run
+```
+
+The dry-run path was written before external dependency resolution existed and was never updated.
+
+## Solution
+
+Call `resolve_external_dependencies()` before `get_all_stages()` in both dry-run code paths:
+
+```python
+# After (fixed):
+cli_helpers.resolve_external_dependencies()  # new: ensure cross-pipeline deps resolved
+stages = cli_helpers.get_all_stages()
+graph = engine_graph.build_graph(stages)
+```
+
+A `cli_helpers.resolve_external_dependencies()` helper was added to encapsulate the call.
+
+## Why This Works
+
+- `resolve_external_dependencies()` populates the registry with external stages before the graph is built
+- The dry-run path now sees the same stages as the execution path
+- Idempotent: if resolution already ran (e.g., during a previous `build_dag()` call), the `_external_deps_resolved` flag skips redundant work
+
+## Prevention
+
+- **All code paths that read the stage registry should go through `build_dag()`** (or at minimum call `resolve_external_dependencies()` first). Direct access to `get_all_stages()` skips resolution.
+- **When adding new CLI commands or output modes**, verify they use the same graph construction path as the execution engine. A common pattern is to copy-paste the graph building code without the resolution step.
+- **Test CLI output modes with multi-pipeline setups** — single-pipeline tests won't catch code paths that skip resolution since there are no external deps to resolve.
+
+## Related Issues
+
+- See also: [exists-check-prevents-reresolution-20260206.md](./exists-check-prevents-reresolution-20260206.md) (same feature area)
+- See also: [output-index-state-dir-shared-root-20260206.md](./output-index-state-dir-shared-root-20260206.md) (same feature area)

--- a/docs/solutions/logic-errors/exists-check-prevents-reresolution-20260206.md
+++ b/docs/solutions/logic-errors/exists-check-prevents-reresolution-20260206.md
@@ -1,0 +1,81 @@
+---
+module: Pipeline
+date: 2026-02-06
+problem_type: logic_error
+component: pipeline_discovery
+symptoms:
+  - "Producer stage not included in DAG when output file exists from previous run"
+  - "Re-running pipeline after successful first run skips dependency resolution"
+  - "Changes to producer stage not detected on subsequent runs"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [pipeline, discovery, resolution, exists-check, skip-detection, dag, pivot]
+---
+
+# Troubleshooting: exists() Check Prevents Re-Resolution of External Dependencies
+
+## Problem
+
+`resolve_external_dependencies()` skipped dependency resolution for any output file that already existed on disk. After a successful first run, all output files exist, so the method skipped finding their producing stages entirely. This meant the producer stages were never included in the DAG on subsequent runs.
+
+## Environment
+
+- Module: Pipeline (`src/pivot/pipeline/pipeline.py`)
+- Method: `resolve_external_dependencies()`, line ~367
+- Python Version: 3.13+
+- Date: 2026-02-06
+
+## Symptoms
+
+- First `pivot repro` works correctly (producer stages found and included)
+- Second `pivot repro` skips producer stages (they're not in the DAG)
+- Changes to producer source code don't trigger re-execution of consumers
+- Debug logs show no resolution activity on warm runs
+- Problem only visible in multi-pipeline setups where producers are in separate `pipeline.py` files
+
+## Root Cause: Conflation of "File Exists" with "No Producer Needed"
+
+The original resolution loop had:
+
+```python
+# Before (broken):
+if dep_path in local_outputs or pathlib.Path(dep_path).exists():
+    continue  # Skip if already resolved OR exists on disk
+```
+
+The `exists()` check was intended as an optimization: if a file exists and has no local producer, it's probably raw input data. But this conflates two distinct concepts:
+
+1. **File has a producer in another pipeline** — should be included in the DAG
+2. **File is raw input data** — genuinely has no producer, safe to skip
+
+After a successful first run, ALL output files exist on disk, so the method treats every cross-pipeline dependency as "raw input data" and skips resolution entirely.
+
+## Solution
+
+Remove the `exists()` check. Only skip deps that are already satisfied by a locally-registered stage:
+
+```python
+# After (fixed):
+if dep_path in local_outputs:
+    continue  # Skip only if a local stage produces this
+```
+
+The three-tier discovery system handles the rest: if no pipeline produces the dep, it's genuinely external input and resolution simply doesn't find a producer (no error).
+
+## Why This Works
+
+- **`local_outputs`** tracks what THIS pipeline (including already-resolved external stages) produces — safe to skip
+- **File existence** says nothing about whether a producer exists in another pipeline
+- The resolution tiers (traverse-up, index cache, full scan) handle the "does a producer exist?" question
+- If no producer is found, the dep is treated as external input (same end result as before, but correct)
+
+## Prevention
+
+- **Don't use filesystem state to short-circuit DAG construction** — the DAG should reflect the logical dependency graph, not the current state of output files on disk. Filesystem state is for skip detection (at execution time), not for graph construction.
+- **Test with warm cache** — always test pipeline resolution with output files already present from a previous run. A cold-start test (no files on disk) can pass while warm-start behavior is broken.
+
+## Related Issues
+
+- See also: [output-index-state-dir-shared-root-20260206.md](./output-index-state-dir-shared-root-20260206.md) (same feature area, discovered in same session)
+- **Critical Pattern #2** in [critical-patterns.md](../patterns/critical-patterns.md)

--- a/docs/solutions/logic-errors/output-index-state-dir-shared-root-20260206.md
+++ b/docs/solutions/logic-errors/output-index-state-dir-shared-root-20260206.md
@@ -1,0 +1,96 @@
+---
+module: Pipeline
+date: 2026-02-06
+problem_type: logic_error
+component: pipeline_discovery
+symptoms:
+  - "Output index cache always writes '.' as pipeline directory"
+  - "Tier 2 cache lookups always fail, falling through to expensive tier 3 full scan"
+  - "All sub-pipelines sharing project root produce identical index entries"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [pipeline, discovery, output-index, state-dir, shared-root, three-tier, pivot]
+---
+
+# Troubleshooting: Output Index Writes Wrong Pipeline Directory for Shared-Root Pipelines
+
+## Problem
+
+The `_write_output_index()` method in `Pipeline` derived the producing pipeline's directory from `state_dir.parent`. When multiple sub-pipelines share the same project root (via `root=project.get_project_root()`), they all share `state_dir = <project_root>/.pivot`, so `state_dir.parent` always resolves to the project root, and the index entry is always `.`.
+
+## Environment
+
+- Module: Pipeline (`src/pivot/pipeline/pipeline.py`)
+- Method: `_write_output_index()`
+- Python Version: 3.13+
+- Date: 2026-02-06
+
+## Symptoms
+
+- Every output index file at `.pivot/cache/outputs/{dep_path}` contains `.` instead of the actual sub-pipeline directory (e.g., `eval_pipeline/difficulty`)
+- Tier 2 (output index cache) lookups fail 100% of the time: index says `.` -> looks for `pipeline.py` in project root -> no root `pipeline.py` in split layout -> falls through to tier 3
+- Tier 3 (full scan) fires on every dependency resolution, adding ~10-400ms per `build_dag()` call
+
+## Root Cause: `state_dir` Is Shared
+
+The `state_dir` property is derived from the pipeline's `root`:
+
+```python
+@property
+def state_dir(self) -> pathlib.Path:
+    return self._root / ".pivot"
+```
+
+When sub-pipelines use `root=project.get_project_root()`, all share the same `state_dir`. The original index writer assumed each pipeline had a unique `state_dir`:
+
+```python
+# Before (broken):
+pipeline_dir = str(info["state_dir"].parent.relative_to(project_root))
+# Always produces "." when state_dir is <project_root>/.pivot
+```
+
+## Solution
+
+Derive the pipeline directory from the stage function's source file using `inspect.getfile()`, then walk up to find the nearest directory containing a pipeline config:
+
+```python
+# After (fixed):
+def _find_pipeline_dir_for_stage(
+    info: registry.RegistryStageInfo,
+    project_root: pathlib.Path,
+) -> str | None:
+    try:
+        source_file = pathlib.Path(inspect.getfile(info["func"])).resolve()
+        current = source_file.parent
+        project_root_resolved = project_root.resolve()
+        while current.is_relative_to(project_root_resolved):
+            if discovery.find_config_in_dir(current) is not None:
+                return str(current.relative_to(project_root_resolved))
+            if current == project_root_resolved:
+                break
+            current = current.parent
+    except (TypeError, OSError, ValueError):
+        pass
+    # Fall back to state_dir derivation
+    ...
+```
+
+This correctly identifies `eval_pipeline/difficulty` for a stage function defined in `eval_pipeline/difficulty/compute.py`, regardless of what `state_dir` is.
+
+## Why This Works
+
+1. Stage functions are always defined in source files within their pipeline's directory tree
+2. `inspect.getfile()` gives the actual source file, not the shared state directory
+3. Walking up finds the nearest `pipeline.py` or `pivot.yaml`, which is the pipeline's config
+4. Falls back to `state_dir` derivation for functions that can't be inspected (builtins, exec'd code)
+
+## Prevention
+
+- **Don't use `state_dir` as a proxy for "pipeline directory"** — `state_dir` is about state storage, not source code location. These are different concepts that happen to coincide for single-pipeline projects but diverge for multi-pipeline setups.
+- **Test with shared-root sub-pipelines** — the split pipeline architecture (code in `eval_pipeline/X/`, data in `data/X/`, shared project root) is the primary use case. Always include a test where `root=project.get_project_root()` is used by multiple pipelines.
+
+## Related Issues
+
+- See also: [exists-check-prevents-reresolution-20260206.md](./exists-check-prevents-reresolution-20260206.md) (same feature area, discovered in same session)
+- **Critical Pattern #3** in [critical-patterns.md](../patterns/critical-patterns.md)

--- a/docs/solutions/patterns/critical-patterns.md
+++ b/docs/solutions/patterns/critical-patterns.md
@@ -52,3 +52,75 @@ def test_serve_mode_cli_responds_to_status_query(tmp_path):
 **Placement/Context:** Required for any major feature: new CLI modes, protocols, architectural components. Add E2E test that starts the actual CLI (subprocess if async) and exercises through public interface.
 
 **Documented in:** `docs/solutions/integration-issues/missing-e2e-test-cli-serve-mode-20260201.md`
+
+---
+
+## 2. Don't Use Filesystem State to Short-Circuit DAG Construction (ALWAYS REQUIRED)
+
+### ❌ WRONG (Producers silently disappear from DAG after first successful run)
+```python
+def resolve_external_dependencies(self) -> None:
+    while work:
+        dep_path = work.pop()
+        # Skip if file already exists on disk
+        if dep_path in local_outputs or pathlib.Path(dep_path).exists():
+            continue  # BUG: skips finding the producer stage
+        # ... resolution logic ...
+```
+
+### ✅ CORRECT
+```python
+def resolve_external_dependencies(self) -> None:
+    while work:
+        dep_path = work.pop()
+        # Skip only if a LOCAL stage already produces this
+        if dep_path in local_outputs:
+            continue
+        # Always search for the producer — file existence is irrelevant
+        # ... resolution logic (three-tier discovery) ...
+```
+
+**Why:** File existence on disk tells you nothing about whether a producer stage exists in another pipeline. After a successful first run, ALL output files exist, so an `exists()` check makes the resolver skip every cross-pipeline dependency. The DAG loses its producer stages, changes to producers stop triggering consumer re-execution, and skip detection breaks silently. Filesystem state is for skip detection at execution time, not for graph construction.
+
+**Placement/Context:** Any code that builds or modifies the dependency graph. Never use `os.path.exists()`, `pathlib.Path.exists()`, or similar checks to decide whether to include a stage in the DAG. The DAG should reflect the logical dependency graph, not the current state of files on disk.
+
+**Documented in:** `docs/solutions/logic-errors/exists-check-prevents-reresolution-20260206.md`
+
+---
+
+## 3. Don't Use `state_dir` as a Proxy for Pipeline Source Directory (ALWAYS REQUIRED)
+
+### ❌ WRONG (All sub-pipelines write "." to output index)
+```python
+def _write_output_index(self) -> None:
+    for stage_name in self.list_stages():
+        info = self.get(stage_name)
+        # Derive pipeline dir from state_dir
+        pipeline_dir = str(info["state_dir"].parent.relative_to(project_root))
+        # BUG: state_dir is <root>/.pivot for ALL sub-pipelines using
+        # root=project.get_project_root(), so pipeline_dir is always "."
+```
+
+### ✅ CORRECT
+```python
+def _write_output_index(self) -> None:
+    for stage_name in self.list_stages():
+        info = self.get(stage_name)
+        # Derive pipeline dir from the stage function's source file
+        pipeline_dir = _find_pipeline_dir_for_stage(info, project_root)
+        # Uses inspect.getfile() + walk-up to find nearest pipeline.py
+
+def _find_pipeline_dir_for_stage(info, project_root) -> str | None:
+    source_file = pathlib.Path(inspect.getfile(info["func"])).resolve()
+    current = source_file.parent
+    while current.is_relative_to(project_root):
+        if discovery.find_config_in_dir(current) is not None:
+            return str(current.relative_to(project_root))
+        current = current.parent
+```
+
+**Why:** `state_dir` is about state storage location (`.pivot/`), not source code location. These coincide for single-pipeline projects but diverge when sub-pipelines share a project root via `root=project.get_project_root()`. The stage function's source file is the reliable indicator of which pipeline directory a stage belongs to.
+
+**Placement/Context:** Any code that needs to determine which pipeline a stage came from — output index writing, logging, error messages. Use `inspect.getfile(func)` and walk up to find the nearest `pipeline.py`/`pivot.yaml`, never `state_dir`.
+
+**Documented in:** `docs/solutions/logic-errors/output-index-state-dir-shared-root-20260206.md`


### PR DESCRIPTION
## Summary
- Add 3 solution docs for bugs found during three-tier discovery implementation
- Add 2 critical patterns to required reading

### Solution Docs
- `exists-check-prevents-reresolution` — filesystem state conflated with "no producer needed"
- `output-index-state-dir-shared-root` — `state_dir.parent` is identical for all shared-root sub-pipelines
- `dry-run-bypasses-resolution` — parallel code path never updated when resolution was added

### Critical Patterns
- **#2:** Don't use filesystem state to short-circuit DAG construction
- **#3:** Don't use `state_dir` as a proxy for pipeline source directory

## Test plan
- [x] Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)