### PR TITLE
fix: address issue #369 follow-ups (7 items)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ def train(
 - Zero tolerance for basedpyright warnings—use targeted ignores: `# type: ignore[code] - reason`
 - Prefer type stubs (`pandas-stubs`, `types-PyYAML`) over ignores
 - Check `typings/` first for untyped packages; use `scripts/generate_stubs.py` if needed
+- **aioboto3/S3 types:** Use `types_aiobotocore_s3.S3Client` (not `Any`) for S3 client parameters. Import under `TYPE_CHECKING`. The `types-aioboto3[all]` stubs are in dev deps.
+- **aioboto3 sessions:** Create one `aioboto3.Session()` per `S3Remote` instance (in `__init__`), not per method call. Sessions are credential-management objects — recreating them re-reads credential chains and env vars. Each method creates its own client via `async with self._session.client("s3")`, which is lightweight but gets a fresh connection pool. Batch methods share one client across concurrent tasks via `asyncio.gather`.
 
 ## Python 3.13+ Types
 

--- a/src/pivot/cli/completion.py
+++ b/src/pivot/cli/completion.py
@@ -49,7 +49,7 @@ def _get_config_keys() -> dict[str, str]:
             remotes: object = typed_data.get("remotes")
             if isinstance(remotes, dict):
                 for remote_name in cast("dict[str, Any]", remotes):
-                    if VALID_REMOTE_NAME.match(remote_name):
+                    if isinstance(remote_name, str) and VALID_REMOTE_NAME.match(remote_name):  # pyright: ignore[reportUnnecessaryIsInstance] - YAML can parse non-string keys
                         keys[f"remotes.{remote_name}"] = f"Remote '{remote_name}'"
         except Exception:
             logger.debug("Config completion: failed to load %s", path, exc_info=True)

--- a/src/pivot/engine/engine.py
+++ b/src/pivot/engine/engine.py
@@ -272,8 +272,14 @@ class Engine:
             # The dispatcher sets _dispatch_complete when it exits (after the
             # async for loop ends due to channel closure).
             # Use a timeout to prevent infinite hang if dispatcher gets stuck.
+            timed_out = True
             with anyio.move_on_after(5.0):
                 await self._dispatch_complete.wait()
+                timed_out = False
+            if timed_out:
+                _logger.warning(
+                    "Dispatcher drain timed out after 5s — events may have been dropped"
+                )
 
             # Cancel remaining tasks (sources and possibly stuck dispatcher)
             tg.cancel_scope.cancel()


### PR DESCRIPTION
## Summary

Addresses all 7 confirmed follow-up items from #369:

**`src/pivot/remote/storage.py`** (4 fixes + 1 improvement)
- Guard `aioboto3` import — lazy import in `S3Remote.__init__()` instead of top-level
- Replace `Any` with proper types (`S3Client`, `AioConfig`, `ClientError`) imported under `TYPE_CHECKING`
- Wrap `metrics.end()` in `finally` blocks for `bulk_exists()`, `upload_batch()`, `download_batch()`
- Reuse `aioboto3.Session()` across all `S3Remote` methods (one session per instance, not per call)

**`src/pivot/cli/verify.py`** (2 fixes)
- Resolve dep paths relative to project root instead of cwd in `_get_stage_missing_hashes()`
- Wrap `transfer.create_remote_from_name()` and `remote.bulk_exists()` with `RemoteError`

**`src/pivot/cli/completion.py`** (1 fix)
- Add `isinstance(remote_name, str)` guard before `VALID_REMOTE_NAME.match()` for non-string YAML keys

**`src/pivot/engine/engine.py`** (1 fix)
- Log warning when dispatcher drain times out after 5s

**`AGENTS.md`**
- Document aioboto3 S3 typing convention and session reuse pattern

**Not a bug:** `textwrap.dedent()` in `fingerprint.py:917` — required for `ast.parse()` on indented source; doesn't affect AST string constants or final hash.

## Test plan

- [x] `uv run pytest tests/ -x -n auto` — 3443 passed
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run basedpyright` — 0 errors

Closes #369