### PR TITLE
feat(cli): add --all flag for multi-pipeline commands

### DIFF
--- a/docs/plans/2026-02-06-all-pipelines-flag-design.md
+++ b/docs/plans/2026-02-06-all-pipelines-flag-design.md
@@ -1,0 +1,243 @@
+# `--all` Flag: Run Commands Across All Pipelines
+
+**Goal:** Add an `--all` flag to CLI commands (`repro`, `status`, `verify`, `commit`, `push`, `pull`) that discovers every pipeline in the project, merges them into one unified DAG, and executes as normal. No change to runtime behavior — parallelism, dependency resolution, and error handling work identically to today, just with a bigger graph.
+
+**Problem:** A project can contain multiple pipelines (e.g., `eval-pipeline/pivot` has six). Today, each command operates on the single pipeline discovered from the current directory. To run the full project, users must `cd` into each pipeline directory and run commands separately.
+
+**Constraints:**
+- No new concepts or commands — just a flag on existing commands
+- One big DAG, not sequential per-pipeline execution
+- Each pipeline's state directory must be respected (lock files, StateDB)
+- Watch mode must reload correctly with `--all`
+- Default behavior (without `--all`) is unchanged
+
+---
+
+## 1. Discovery: `discover_pipeline(all_pipelines=True)`
+
+Extend the existing `discover_pipeline()` function with an `all_pipelines` parameter:
+
+```python
+def discover_pipeline(
+    project_root: pathlib.Path | None = None,
+    *,
+    all_pipelines: bool = False,
+) -> Pipeline | None:
+```
+
+When `all_pipelines=True`:
+
+1. Call `_glob_all_pipelines(project_root)` to find all `pipeline.py` / `pivot.yaml` / `pivot.yml` files (already implemented, skips `.venv`, `.git`, `.pivot`, etc.)
+2. Load each via `load_pipeline_from_path()` (already implemented)
+3. Create a synthetic root: `Pipeline("all", root=project_root)`
+4. Call `combined.include(other)` for each discovered pipeline
+
+`include()` provides:
+- **Auto-prefix on name collision** — when a stage name already exists, incoming stages are prefixed with `{pipeline_name}/` to disambiguate. The first pipeline's stages keep their bare names. This avoids errors when pipelines share common stage names like `train`.
+- **Deep copies** preserving each stage's original `state_dir`
+
+When `all_pipelines=False` (default): today's behavior, unchanged.
+
+The combined pipeline goes into the Click context like today's single pipeline. All downstream code (`build_dag`, `get_all_stages`, etc.) works unchanged. `resolve_external_dependencies()` becomes a no-op since all stages are already present.
+
+### External dependency behavior
+
+When `--all` is active, all stages from all discovered pipelines are present in the combined registry. After merging, `_discover_all_pipelines` checks for unresolved dependencies (deps not produced by any discovered pipeline) and logs a warning listing them. This surfaces misconfiguration early without blocking execution.
+
+### Existing code reused
+
+| Function | Location | Status |
+|----------|----------|--------|
+| `_glob_all_pipelines()` | `pipeline/pipeline.py` | Exists (private, used by tier-3 scan) |
+| `load_pipeline_from_path()` | `discovery.py` | Exists |
+| `Pipeline.include()` | `pipeline/pipeline.py` | Exists |
+
+---
+
+## 2. CLI Integration
+
+Add `--all` to the `@pivot_command()` decorator, since that's where auto-discovery already happens. The decorator:
+
+1. Reads the `--all` flag from the Click context
+2. Calls `discover_pipeline(root, all_pipelines=True)` instead of `discover_pipeline(root)`
+3. Stores the pipeline in context as usual — downstream code is unchanged
+
+Gate exposure with `pivot_command(allow_all=True)` so only opted-in commands accept the flag. Phase 1 enables it on `verify` only; Phase 2 enables the rest.
+
+### Commands receiving `--all`
+
+| Command | Phase | Notes |
+|---------|-------|-------|
+| `verify` | 1 | First milestone — harden plumbing before broad exposure |
+| `repro` | 2 | Run all pipelines as one DAG |
+| `status` | 2 | Show status across all pipelines |
+| `commit` | 2 | Commit pending locks from all pipelines |
+| `push` | 2 | Push cached outputs from all pipelines (switch to `auto_discover=True`) |
+| `pull` | 2 | Pull outputs for all pipelines (switch to `auto_discover=True`) |
+
+`push` and `pull` currently use `auto_discover=False` because they read from lock files directly. With `--all`, they switch to `auto_discover=True` so the registry is loaded and per-stage `state_dir` is available for lock file resolution. If registry load fails, surface a clear error rather than breaking the existing locks-only flow.
+
+---
+
+## 3. State-Dir Awareness (Core Refactor)
+
+### Problem
+
+The coordinator (engine, CLI commands) uses `config.get_state_dir()` as a single global path for StateDB, lock files, and pending locks. Workers already use per-stage `state_dir` correctly. When `--all` combines stages from pipelines with different `state_dir` values, the coordinator writes to the wrong location.
+
+Example: `eval_pipeline/base/` uses `root=project.get_project_root()` (shared `.pivot/`), but `model_reports/time_horizon_1_0/` uses its own root (separate `.pivot/`). Combining them into one DAG means lock files and StateDB writes must go to the correct location per stage.
+
+### Fix
+
+Centralize per-stage `state_dir` lookup in a helper function to avoid missed call sites:
+
+```python
+def get_stage_state_dir(stage_info: RegistryStageInfo) -> pathlib.Path:
+    """Get the state directory for a stage, falling back to project config."""
+    return stage_info["state_dir"] or config.get_state_dir()
+```
+
+Replace `config.get_state_dir()` with this helper at every affected call site. The data is already available — every call site has access to `RegistryStageInfo` (which carries `state_dir`) via the stage map or registry.
+
+### Affected call sites
+
+**Engine (`engine.py`) — has `stage_info` via `self._get_stage(name)`:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 533 | `state_dir = config.get_state_dir()` | Use per-stage `state_dir` from `stage_info` | 2 |
+| 557 | `state_db_path = config.get_state_db_path()` | Cache StateDB connections per unique `state_dir` | 2 |
+| 1081 | `state_dir = config.get_state_dir()` | Look up `stage_info["state_dir"]` per stage in loop | 2 |
+| 1111 | `StateDB(config.get_state_db_path())` | Write run history to appropriate DB | 2 |
+
+**Executor (`executor/core.py`) — has `all_stages` dict:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 410 | `cache_dir = config.get_cache_dir()` | Cache dir is shared — no change needed | — |
+| 412 | `StateDB(config.get_state_db_path())` | Use per-stage `state_dir` | 2 |
+| 457 | `state_dir = config.get_state_dir()` | Use `all_stages[stage_name]["state_dir"]` | 2 |
+
+**Executor (`executor/commit.py`):**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 27 | `state_dir = config.get_state_dir()` | Accept `state_dir` as parameter or look up per stage | 2 |
+| 30 | `StateDB(config.get_state_db_path())` | Use per-stage `state_dir` | 2 |
+
+**CLI verify (`cli/verify.py`) — has `all_stages` dict:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 308 | `state_dir = config.get_state_dir()` | Use per-stage `state_dir` via helper | 1 |
+
+**CLI remote (`cli/remote.py`) — needs registry access with `--all`:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 66, 141, 229 | `state_dir = config.get_state_dir()` | Look up per-stage `state_dir` from registry | 2 |
+| 86, 158, 248 | `StateDB(config.get_state_db_path())` | Use per-stage `state_dir` | 2 |
+
+**CLI checkout (`cli/checkout.py`) — has stage info available:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 336 | `state_dir = config.get_state_dir()` | Use per-stage `state_dir` | 2 |
+
+**Status (`status.py`) — has `all_stages` dict:**
+
+| Line | Current | Fix | Phase |
+|------|---------|-----|-------|
+| 197 | `state_dir = config.get_state_dir()` | Use `all_stages[stage_name]["state_dir"]` | 1 (verify uses this) |
+| 295 | `state_dir = config.get_state_dir()` | Same | 1 |
+| 346, 405 | `StateDB(config.get_state_db_path())` | Use per-stage `state_dir` | 1 |
+
+### Not affected
+
+- `config.get_cache_dir()` calls — cache is shared across all pipelines
+- `cli/history.py` — run history is project-level
+- `cli/doctor.py` — health check on shared cache
+- `show/` commands — read-only display
+- `cli/data.py`, `cli/track.py` — shared cache/tracking
+- TUI code — can be a follow-up
+
+### StateDB connection cache
+
+The engine holds a `dict[Path, StateDB]` mapping `state_dir → connection`, lazily opened. In the common case (all pipelines share one `state_dir`), this dict has one entry — zero overhead vs today.
+
+---
+
+## 4. Watch Mode (Phase 2)
+
+When the engine is initialized with `--all`, it stores that flag (e.g., `_stored_all_pipelines: bool`). On code/config change:
+
+- **`_reload_registry`** calls `discovery.discover_pipeline(root, all_pipelines=self._stored_all_pipelines)` instead of `discovery.discover_pipeline(root)`. Since both paths go through `discover_pipeline()`, the logic is centralized.
+
+- **Watch paths**: Add pipeline config files (`pipeline.py`, `pivot.yaml`/`yml`) to watch paths so that adding/removing a pipeline triggers a reload. Artifact watch paths already work for free — `get_watch_paths()` extracts them from the bipartite graph, which in `--all` mode includes artifacts from all pipelines.
+
+- **`_clear_project_modules`** works for free — it removes all modules under the project root, covering all sub-pipeline directories.
+
+---
+
+## 5. Testing Strategy
+
+### Existing fixtures to reuse
+
+| Fixture | Location | Use |
+|---------|----------|-----|
+| `test_pipeline_include_preserves_state_dir*` | `tests/pipeline/test_pipeline.py:338-376` | Template for state-dir isolation tests |
+| `test_lazy_resolution_*` | `tests/integration/test_lazy_resolution.py` | Multi-pipeline integration patterns |
+| `create_pipeline_py()` | `tests/helpers.py` | Generate `pipeline.py` files in subdirectories |
+| `isolated_pivot_dir` | `tests/conftest.py:354` | Full filesystem isolation for CLI tests |
+| `make_valid_lock_content` | `tests/conftest.py:305` | Factory for lock file data |
+| `pipeline_dir` | `tests/conftest.py:326` | Creates `.pivot` directory per pipeline |
+
+### Phase 1 tests
+
+**Unit: `discover_pipeline(all_pipelines=True)`**
+- Temp project with 2-3 sub-pipelines (some sharing root, some with separate roots)
+- Combined pipeline contains all stages from all discovered pipelines
+- Name collisions raise `PipelineConfigError` with pipeline file paths
+- Empty project returns None
+- Collision error message includes both pipeline paths
+
+**Integration: `verify --all` across mixed state_dir roots**
+- Two pipelines: one sharing project root, one with separate root
+- Lock files in each pipeline's own `.pivot/stages/`
+- `verify --all` reads lock files from correct state dirs
+- StateDB reads from correct databases per stage
+
+### Phase 2 tests
+
+- Watch mode: reload preserves `--all`, pipeline config file changes trigger reload
+- Push/pull across multiple state dirs: targeted and untargeted
+- Collision diagnostics: clear errors with pipeline file paths
+- Mixed shared vs isolated roots: stages execute with correct state isolation
+- `repro --all`: lock files written to correct per-stage state dirs, deferred writes routed correctly
+
+Existing tests continue passing since default behavior (`all_pipelines=False`) is unchanged.
+
+---
+
+## Implementation Phases
+
+### Phase 1: `verify --all` (first milestone)
+
+Harden the discovery and state-dir plumbing before broad exposure.
+
+1. **Extend `discover_pipeline(all_pipelines=True)`** — centralize all-pipeline discovery, include collision errors with pipeline file paths
+2. **Gate `--all` in `pivot_command`** — add `allow_all=True` parameter, enable on `verify` only
+3. **Centralize per-stage state_dir helper** — `get_stage_state_dir()` to avoid missed call sites
+4. **Update `cli/verify.py` and `status.py`** — use helper for lock/StateDB access
+5. **Define external-dep behavior** — warn or error if deps are outside discovered pipelines
+6. **Tests** — unit discovery + name collision; integration `verify --all` across mixed state_dir roots
+
+### Phase 2: Remaining commands
+
+Enable `--all` across all commands using the proven plumbing.
+
+1. **Enable `--all` on `repro`, `status`, `commit`, `push`, `pull`** — same discovery path
+2. **Apply per-stage state_dir helper at all remaining call sites** — engine, executor, remote, checkout
+3. **Watch mode** — persist `all_pipelines` flag, add pipeline config files to watch paths
+4. **Push/pull resilience** — if registry load fails with `--all`, surface clear error rather than breaking locks-only flows
+5. **Tests** — watch reload, push/pull across multiple state_dirs, collision diagnostics, mixed roots

--- a/docs/plans/2026-02-07-all-pipelines-phase1.md
+++ b/docs/plans/2026-02-07-all-pipelines-phase1.md
@@ -1,0 +1,703 @@
+# `--all` Flag Phase 1: `verify --all` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `--all` flag to `pivot verify` that discovers all pipelines in the project, merges them into one unified DAG, and verifies all stages — with correct per-stage `state_dir` routing for lock files and StateDB access.
+
+**Architecture:** Extend `discover_pipeline()` with `all_pipelines=True` that globs all pipeline configs, loads each, and `include()`s them into a synthetic root Pipeline. Gate `--all` in the `pivot_command` decorator via `allow_all=True`. Replace `config.get_state_dir()` in verify/status code paths with per-stage `state_dir` from `RegistryStageInfo`.
+
+**Tech Stack:** Python 3.13+, Click, pytest
+
+**Design doc:** `docs/plans/2026-02-06-all-pipelines-flag-design.md`
+
+---
+
+### Task 1: Make `_glob_all_pipelines` public and deduplicate by directory
+
+The existing `_glob_all_pipelines` in `pipeline.py` is private and has a bug: it can return both `pipeline.py` AND `pivot.yaml` from the same directory (the bug-finder flagged this). We need to make it public, move it to `discovery.py`, and deduplicate.
+
+**Files:**
+- Modify: `src/pivot/discovery.py`
+- Modify: `src/pivot/pipeline/pipeline.py`
+- Test: `tests/core/test_discovery.py`
+
+**Step 1: Write failing tests for `glob_all_pipelines`**
+
+Add to `tests/core/test_discovery.py`:
+
+```python
+# =============================================================================
+# glob_all_pipelines Tests
+# =============================================================================
+
+
+def test_glob_all_pipelines_finds_pipeline_py(set_project_root: pathlib.Path) -> None:
+    """glob_all_pipelines discovers pipeline.py files in subdirectories."""
+    sub = set_project_root / "sub"
+    sub.mkdir()
+    (sub / "pipeline.py").write_text("pipeline = None")
+
+    result = discovery.glob_all_pipelines(set_project_root)
+
+    assert len(result) == 1
+    assert result[0] == sub / "pipeline.py"
+
+
+def test_glob_all_pipelines_finds_pivot_yaml(set_project_root: pathlib.Path) -> None:
+    """glob_all_pipelines discovers pivot.yaml files in subdirectories."""
+    sub = set_project_root / "sub"
+    sub.mkdir()
+    (sub / "pivot.yaml").write_text("stages: {}")
+
+    result = discovery.glob_all_pipelines(set_project_root)
+
+    assert len(result) == 1
+    assert result[0] == sub / "pivot.yaml"
+
+
+def test_glob_all_pipelines_skips_excluded_dirs(set_project_root: pathlib.Path) -> None:
+    """glob_all_pipelines skips .venv, __pycache__, .git, etc."""
+    venv = set_project_root / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "pipeline.py").write_text("pipeline = None")
+
+    result = discovery.glob_all_pipelines(set_project_root)
+
+    assert len(result) == 0
+
+
+def test_glob_all_pipelines_deduplicates_by_directory(
+    set_project_root: pathlib.Path,
+) -> None:
+    """glob_all_pipelines raises DiscoveryError if directory has both config types.
+
+    A directory with both pipeline.py and pivot.yaml is ambiguous. This is the
+    same constraint as find_config_in_dir but applied during project-wide scan.
+    """
+    sub = set_project_root / "sub"
+    sub.mkdir()
+    (sub / "pipeline.py").write_text("pipeline = None")
+    (sub / "pivot.yaml").write_text("stages: {}")
+
+    with pytest.raises(discovery.DiscoveryError, match="both"):
+        discovery.glob_all_pipelines(set_project_root)
+
+
+def test_glob_all_pipelines_finds_multiple_pipelines(
+    set_project_root: pathlib.Path,
+) -> None:
+    """glob_all_pipelines finds pipelines in multiple subdirectories."""
+    for name in ("alpha", "beta", "gamma"):
+        sub = set_project_root / name
+        sub.mkdir()
+        (sub / "pipeline.py").write_text("pipeline = None")
+
+    result = discovery.glob_all_pipelines(set_project_root)
+
+    assert len(result) == 3
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_discovery.py -k "glob_all_pipelines" -v`
+Expected: FAIL — `discovery.glob_all_pipelines` does not exist
+
+**Step 3: Implement `glob_all_pipelines` in discovery.py**
+
+Add to `src/pivot/discovery.py` after `load_pipeline_from_path`:
+
+```python
+# Directories excluded from all-pipelines scan
+_SCAN_EXCLUDE_DIRS = frozenset(
+    {
+        ".pivot",
+        ".git",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "node_modules",
+        ".tox",
+        ".nox",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
+
+
+def glob_all_pipelines(project_root: pathlib.Path) -> list[pathlib.Path]:
+    """Find all pipeline config files in the project.
+
+    Scans project_root recursively for pipeline.py and pivot.yaml/yml files,
+    skipping common non-project directories (.venv, __pycache__, etc.).
+
+    Deduplicates by directory: if a directory contains both pipeline.py and
+    pivot.yaml, raises DiscoveryError (same constraint as find_config_in_dir).
+
+    Args:
+        project_root: Project root directory to scan.
+
+    Returns:
+        List of paths to pipeline config files.
+
+    Raises:
+        DiscoveryError: If any directory has both pipeline.py and pivot.yaml.
+    """
+    # Collect all candidate paths grouped by directory
+    by_dir: dict[pathlib.Path, list[pathlib.Path]] = {}
+    target_names = (PIPELINE_PY_NAME, *PIVOT_YAML_NAMES)
+    for name in target_names:
+        for path in project_root.rglob(name):
+            if any(part in _SCAN_EXCLUDE_DIRS for part in path.parts):
+                continue
+            by_dir.setdefault(path.parent, []).append(path)
+
+    # Validate: no directory should have both config types
+    results = list[pathlib.Path]()
+    for directory, paths in by_dir.items():
+        if len(paths) > 1:
+            # Use find_config_in_dir which raises DiscoveryError for ambiguity
+            find_config_in_dir(directory)
+        results.append(paths[0])
+
+    return results
+```
+
+**Step 4: Update `_glob_all_pipelines` in pipeline.py to call the public version**
+
+In `src/pivot/pipeline/pipeline.py`, replace the private `_glob_all_pipelines` function (lines 148-156) with a delegation to the new public function:
+
+```python
+def _glob_all_pipelines(project_root: pathlib.Path) -> list[pathlib.Path]:
+    """Glob all pipeline.py and pivot.yaml/yml files in the project."""
+    return discovery.glob_all_pipelines(project_root)
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_discovery.py -k "glob_all_pipelines" -v`
+Expected: PASS
+
+**Step 6: Run full test suite to check for regressions**
+
+Run: `uv run pytest tests/core/test_discovery.py tests/pipeline/test_pipeline.py -v`
+Expected: All pass
+
+---
+
+### Task 2: Extend `discover_pipeline` with `all_pipelines` parameter
+
+**Files:**
+- Modify: `src/pivot/discovery.py:55-119` (`discover_pipeline` function)
+- Test: `tests/core/test_discovery.py`
+
+**Step 1: Write failing tests for `discover_pipeline(all_pipelines=True)`**
+
+Add to `tests/core/test_discovery.py`:
+
+```python
+# =============================================================================
+# discover_pipeline(all_pipelines=True) Tests
+# =============================================================================
+
+
+def test_discover_all_pipelines_combines_stages(
+    set_project_root: pathlib.Path,
+) -> None:
+    """discover_pipeline(all_pipelines=True) creates a combined pipeline with all stages."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    # Create two sub-pipelines with distinct stages
+    for name, stage_name in [("alpha", "stage_a"), ("beta", "stage_b")]:
+        sub = set_project_root / name
+        sub.mkdir()
+        code = f"""\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("{name}", root=__import__("pathlib").Path(__file__).parent)
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="{stage_name}")
+"""
+        (sub / "pipeline.py").write_text(code)
+
+    result = discovery.discover_pipeline(set_project_root, all_pipelines=True)
+
+    assert result is not None
+    assert isinstance(result, Pipeline)
+    assert "stage_a" in result.list_stages()
+    assert "stage_b" in result.list_stages()
+
+
+def test_discover_all_pipelines_preserves_state_dir(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Each included stage retains its original pipeline's state_dir."""
+    alpha_dir = set_project_root / "alpha"
+    alpha_dir.mkdir()
+    code_a = """\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("alpha", root=__import__("pathlib").Path(__file__).parent)
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="stage_a")
+"""
+    (alpha_dir / "pipeline.py").write_text(code_a)
+
+    result = discovery.discover_pipeline(set_project_root, all_pipelines=True)
+
+    assert result is not None
+    info = result.get("stage_a")
+    assert info["state_dir"] == alpha_dir / ".pivot"
+
+
+def test_discover_all_pipelines_name_collision_auto_prefixes(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Name collisions across pipelines are resolved by auto-prefixing with pipeline name.
+
+    Note: The original plan specified PipelineConfigError on collision, but the
+    implementation uses auto-prefix instead — this avoids errors when pipelines
+    share common stage names like 'train'.
+    """
+    for name in ("alpha", "beta"):
+        sub = set_project_root / name
+        sub.mkdir()
+        code = f"""\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("{name}", root=__import__("pathlib").Path(__file__).parent)
+
+def _stage():
+    pass
+
+pipeline.register(_stage, name="duplicate_name")
+"""
+        (sub / "pipeline.py").write_text(code)
+
+    result = discovery.discover_pipeline(set_project_root, all_pipelines=True)
+    assert result is not None
+    # One pipeline gets bare name, the other gets prefixed
+    assert "duplicate_name" in result.list_stages()
+
+
+def test_discover_all_pipelines_returns_none_when_empty(
+    set_project_root: pathlib.Path,
+) -> None:
+    """discover_pipeline(all_pipelines=True) returns None when no pipelines found."""
+    result = discovery.discover_pipeline(set_project_root, all_pipelines=True)
+
+    assert result is None
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_discovery.py -k "discover_all_pipelines" -v`
+Expected: FAIL — `discover_pipeline` does not accept `all_pipelines`
+
+**Step 3: Implement the `all_pipelines` parameter**
+
+Modify `discover_pipeline` in `src/pivot/discovery.py:55`:
+
+```python
+def discover_pipeline(
+    project_root: pathlib.Path | None = None,
+    *,
+    all_pipelines: bool = False,
+) -> Pipeline | None:
+    """Discover and return Pipeline from pivot.yaml or pipeline.py.
+
+    Looks for pipeline config in this order:
+    1. Current working directory (if within project root)
+    2. Project root
+
+    In each location, checks for:
+    - pivot.yaml (or pivot.yml) - creates implicit Pipeline
+    - pipeline.py - looks for `pipeline` variable (Pipeline instance)
+
+    When all_pipelines=True, discovers ALL pipeline config files in the project,
+    loads each, and merges them into a single Pipeline via include(). The combined
+    pipeline contains stages from all discovered pipelines, each retaining its
+    original state_dir.
+
+    Args:
+        project_root: Override project root (default: auto-detect)
+        all_pipelines: If True, discover and combine all pipelines in project.
+
+    Returns:
+        Pipeline instance, or None if nothing found
+
+    Raises:
+        DiscoveryError: If discovery fails, or if both config types exist
+    """
+    _t = metrics.start()
+    try:
+        root = project_root or project.get_project_root()
+
+        if all_pipelines:
+            return _discover_all_pipelines(root)
+
+        # ... existing single-pipeline discovery logic unchanged ...
+```
+
+Add the new private function:
+
+```python
+def _discover_all_pipelines(root: pathlib.Path) -> Pipeline | None:
+    """Discover all pipelines and combine into one.
+
+    Globs all pipeline config files, loads each, and merges via include().
+    """
+    from pivot.pipeline.pipeline import Pipeline
+
+    config_paths = glob_all_pipelines(root)
+    if not config_paths:
+        return None
+
+    pipelines = list[Pipeline]()
+    for path in config_paths:
+        pipeline = load_pipeline_from_path(path)
+        if pipeline is not None:
+            pipelines.append(pipeline)
+
+    if not pipelines:
+        return None
+
+    combined = Pipeline("all", root=root)
+    for pipeline in pipelines:
+        combined.include(pipeline)  # Auto-prefixes on name collision
+
+    logger.info(
+        f"Discovered {len(pipelines)} pipelines with {len(combined.list_stages())} total stages"
+    )
+    return combined
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_discovery.py -k "discover_all_pipelines" -v`
+Expected: PASS
+
+**Step 5: Run full discovery test suite**
+
+Run: `uv run pytest tests/core/test_discovery.py -v`
+Expected: All pass (existing tests unchanged since default `all_pipelines=False`)
+
+---
+
+### Task 3: Add `--all` flag to `pivot_command` decorator (gated with `allow_all`)
+
+**Files:**
+- Modify: `src/pivot/cli/decorators.py:55-103`
+- Test: `tests/cli/test_cli_decorators.py` (or whatever file tests decorators — check first)
+
+**Step 1: Write failing test**
+
+Check which file tests the decorator, then add:
+
+```python
+def test_pivot_command_all_flag_when_allowed(
+    runner: CliRunner, set_project_root: pathlib.Path
+) -> None:
+    """Commands with allow_all=True accept --all flag."""
+    from pivot.cli import decorators as cli_decorators
+
+    @cli_decorators.pivot_command(auto_discover=False, allow_all=True)
+    @click.pass_context
+    def test_cmd(ctx: click.Context) -> None:
+        click.echo("ok")
+
+    result = runner.invoke(test_cmd, ["--all"])
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+def test_pivot_command_all_flag_when_not_allowed(runner: CliRunner) -> None:
+    """Commands without allow_all=True do not accept --all flag."""
+    from pivot.cli import decorators as cli_decorators
+
+    @cli_decorators.pivot_command(auto_discover=False)
+    def test_cmd() -> None:
+        click.echo("ok")
+
+    result = runner.invoke(test_cmd, ["--all"])
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower() or "Error" in result.output
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/cli/ -k "pivot_command_all_flag" -v`
+Expected: FAIL
+
+**Step 3: Implement the `allow_all` parameter**
+
+Modify `pivot_command` in `src/pivot/cli/decorators.py:55`:
+
+```python
+def pivot_command(
+    name: str | None = None,
+    *,
+    auto_discover: bool = True,
+    allow_all: bool = False,
+    **attrs: Any,
+) -> Callable[[Callable[..., Any]], click.Command]:
+    """Create a Click command with Pivot error handling and optional auto-discovery.
+
+    Args:
+        name: Optional command name (defaults to function name)
+        auto_discover: If True (default), automatically discover and register
+            stages before running the command.
+        allow_all: If True, add --all flag for multi-pipeline discovery.
+        **attrs: Additional arguments passed to click.command()
+    """
+
+    def decorator(func: Callable[..., Any]) -> click.Command:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            _t_total = metrics.start()
+            try:
+                # Check if Pipeline is already in context (e.g., when invoking subcommand)
+                if auto_discover and not _has_pipeline_in_context():
+                    try:
+                        _t_discover = metrics.start()
+                        try:
+                            # Check for --all flag in Click context
+                            ctx = click.get_current_context(silent=True)
+                            use_all = (
+                                allow_all
+                                and ctx is not None
+                                and ctx.params.get("all_pipelines", False)
+                            )
+                            pipeline = discovery.discover_pipeline(
+                                all_pipelines=use_all,
+                            )
+                            if pipeline is not None:
+                                store_pipeline_in_context(pipeline)
+                        finally:
+                            metrics.end("cli.discover", _t_discover)
+                    except discovery.DiscoveryError as e:
+                        raise click.ClickException(str(e)) from e
+                return func(*args, **kwargs)
+            finally:
+                metrics.end("cli.total", _t_total)
+                if os.environ.get("PIVOT_METRICS"):
+                    _print_metrics_summary()
+
+        wrapped = with_error_handling(wrapper)
+        cmd = click.command(name=name, **attrs)(wrapped)
+
+        # Add --all option if allowed
+        if allow_all:
+            cmd = click.option(
+                "--all",
+                "all_pipelines",
+                is_flag=True,
+                default=False,
+                help="Run across all pipelines in the project.",
+            )(cmd)
+
+        return cmd
+
+    return decorator
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/ -k "pivot_command_all_flag" -v`
+Expected: PASS
+
+---
+
+### Task 4: Per-stage `state_dir` in `status.py`
+
+The `verify` command calls `status.get_pipeline_status()` and `status.get_pipeline_explanations()` which both use a global `config.get_state_dir()`. Fix them to use per-stage `state_dir` from `all_stages`.
+
+**Files:**
+- Modify: `src/pivot/status.py:197,295`
+- Test: `tests/status/test_status.py` (check existing tests first)
+
+**Step 1: Write failing test**
+
+```python
+def test_get_pipeline_status_uses_per_stage_state_dir(
+    set_project_root: pathlib.Path,
+) -> None:
+    """get_pipeline_status uses each stage's state_dir, not the global one.
+
+    When stages from different pipelines have different state_dirs,
+    the status check must read lock files from the correct location.
+    """
+    # This test verifies the state_dir is passed from stage_info, not config.
+    # Create a stage whose state_dir differs from config.get_state_dir().
+    # The lock file is in the stage's state_dir — if status reads from the
+    # global state_dir, it won't find the lock and will report stale.
+    ...
+```
+
+Note: The exact test setup depends on existing test patterns in `tests/status/`. Read those first and follow the same fixture patterns.
+
+**Step 2: Implement the fix**
+
+In `src/pivot/status.py`, change both `get_pipeline_explanations` (line 197) and `get_pipeline_status` (line 295) to pass per-stage `state_dir`:
+
+```python
+# In _get_explanations_in_parallel, line 129 changes from:
+#     state_dir,
+# to:
+#     stage_info["state_dir"],
+```
+
+The key change: in `_get_explanations_in_parallel` (line 102), instead of passing the same `state_dir` to every `pool.submit(explain.get_stage_explanation, ...)` call, pass `stage_info["state_dir"]`:
+
+```python
+def _get_explanations_in_parallel(
+    execution_order: list[str],
+    overrides: parameters.ParamsOverrides | None,
+    all_stages: dict[str, RegistryStageInfo],
+    force: bool = False,
+    allow_missing: bool = False,
+    tracked_files: dict[str, PvtData] | None = None,
+    tracked_trie: pygtrie.Trie[str] | None = None,
+) -> dict[str, StageExplanation]:
+```
+
+Remove the `state_dir` parameter from `_get_explanations_in_parallel` entirely — each stage's `state_dir` comes from `all_stages[stage_name]["state_dir"]`.
+
+Update both callers (`get_pipeline_explanations` line 200 and `get_pipeline_status` line 298) to stop passing `state_dir`.
+
+**Step 3: Update `get_pipeline_explanations` and `get_pipeline_status`**
+
+Remove the `state_dir = config.get_state_dir()` line from both functions (lines 197 and 295). The `state_dir` is no longer needed at that level — it's read per-stage inside `_get_explanations_in_parallel`.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/status/ -v`
+Expected: All pass
+
+---
+
+### Task 5: Per-stage `state_dir` in `cli/verify.py`
+
+**Files:**
+- Modify: `src/pivot/cli/verify.py:65-101,159-164,308`
+- Test: `tests/cli/test_verify.py`
+
+**Step 1: Write failing integration test**
+
+Add to `tests/cli/test_verify.py`:
+
+```python
+def test_verify_all_flag_multi_pipeline(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """verify --all discovers all pipelines and checks each one's lock files.
+
+    Sets up two pipelines with different state_dirs, creates lock files in each,
+    and verifies that --all finds and checks both.
+    """
+    with isolated_pivot_dir(runner, tmp_path):
+        # Create two sub-pipelines
+        for name, stage_name in [("alpha", "stage_a"), ("beta", "stage_b")]:
+            sub = tmp_path / name
+            sub.mkdir()
+            (sub / ".pivot").mkdir()
+            # ... create pipeline.py, register stage, create lock file ...
+
+        result = runner.invoke(cli.cli, ["verify", "--all"])
+
+        assert "stage_a" in result.output
+        assert "stage_b" in result.output
+```
+
+Note: The exact test setup depends heavily on existing `test_verify.py` patterns. Read them first and replicate the lock file creation pattern from `make_valid_lock_content`.
+
+**Step 2: Update `verify` command to accept `--all`**
+
+In `src/pivot/cli/verify.py:270`, change:
+
+```python
+@cli_decorators.pivot_command()
+```
+
+to:
+
+```python
+@cli_decorators.pivot_command(allow_all=True)
+```
+
+**Step 3: Update `_get_stage_lock_hashes` to use per-stage `state_dir`**
+
+In `src/pivot/cli/verify.py:65-67`, change `_get_stage_lock_hashes` to get `state_dir` from the stage's registry info instead of a parameter:
+
+```python
+def _get_stage_lock_hashes(
+    stage_name: str,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Get output and dep file hashes from a stage's lock file."""
+    stage_info = cli_helpers.get_stage(stage_name)
+    state_dir = stage_info["state_dir"]
+    stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
+    ...
+```
+
+Update `_get_stage_missing_hashes` (line 104) similarly — remove the `state_dir` parameter, get it from the registry.
+
+Update `_verify_stages` (line 159) — remove the `state_dir` parameter.
+
+Update the call in `verify()` (line 324) — remove `state_dir` argument.
+
+Remove the `state_dir = config.get_state_dir()` line at line 308.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/cli/test_verify.py -v`
+Expected: All pass
+
+---
+
+### Task 6: Quality checks and final verification
+
+**Files:** None (validation only)
+
+**Step 1: Run full test suite**
+
+Run: `uv run pytest tests/ -n auto`
+Expected: All pass, no regressions
+
+**Step 2: Run type checker**
+
+Run: `uv run basedpyright`
+Expected: No new errors
+
+**Step 3: Run linter and formatter**
+
+Run: `uv run ruff format . && uv run ruff check .`
+Expected: Clean
+
+**Step 4: Manual smoke test on eval-pipeline**
+
+```bash
+cd ~/eval-pipeline/pivot
+uv run pivot verify --all
+```
+
+Expected: Discovers all 6 pipelines, verifies stages from each with correct state_dir routing.
+
+---
+
+## Summary of changes by file
+
+| File | Change |
+|------|--------|
+| `src/pivot/discovery.py` | Add `glob_all_pipelines()`, `_discover_all_pipelines()`, extend `discover_pipeline()` signature |
+| `src/pivot/cli/decorators.py` | Add `allow_all` param, `--all` Click option, pass `all_pipelines` to discovery |
+| `src/pivot/cli/verify.py` | Add `allow_all=True`, remove global `state_dir`, use per-stage lookup |
+| `src/pivot/status.py` | Remove `state_dir` param from `_get_explanations_in_parallel`, use per-stage |
+| `src/pivot/pipeline/pipeline.py` | Delegate `_glob_all_pipelines` to `discovery.glob_all_pipelines` |
+| `tests/core/test_discovery.py` | Tests for `glob_all_pipelines`, `discover_pipeline(all_pipelines=True)` |
+| `tests/cli/test_verify.py` | Integration test for `verify --all` with mixed state_dirs |

--- a/docs/plans/2026-02-07-all-pipelines-phase2.md
+++ b/docs/plans/2026-02-07-all-pipelines-phase2.md
@@ -1,0 +1,704 @@
+# `--all` Flag Phase 2: Enable Remaining Commands
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable `--all` on `repro`, `status`, `commit`, `push`, `pull` and fix all remaining per-stage `state_dir` call sites so the coordinator correctly routes lock files and StateDB writes for multi-pipeline projects.
+
+**Architecture:** Apply the same `allow_all=True` gating from Phase 1 to the remaining commands. Replace every `config.get_state_dir()` in engine, executor, checkout, and remote code with per-stage `state_dir` from `RegistryStageInfo`. Store `all_pipelines` flag in the engine for watch mode reload. Add pipeline config files to watch paths.
+
+**Tech Stack:** Python 3.13+, Click, anyio, loky, pytest
+
+**Depends on:** Phase 1 plan (`docs/plans/2026-02-07-all-pipelines-phase1.md`) must be complete.
+
+**Design doc:** `docs/plans/2026-02-06-all-pipelines-flag-design.md`
+
+---
+
+### Task 1: Enable `--all` on `repro`, `status`, `commit`
+
+These commands already use `@cli_decorators.pivot_command()` with `auto_discover=True`, so adding `allow_all=True` is a one-line change per command.
+
+**Files:**
+- Modify: `src/pivot/cli/repro.py:741`
+- Modify: `src/pivot/cli/status.py:29`
+- Modify: `src/pivot/cli/commit.py:12`
+- Test: `tests/cli/test_repro.py`, `tests/cli/test_cli_status.py`, `tests/cli/test_cli_commit.py`
+
+**Step 1: Write failing tests**
+
+Add to each CLI test file a test that `--all` is accepted:
+
+```python
+# In tests/cli/test_repro.py
+def test_repro_accepts_all_flag(runner: CliRunner, tmp_path: pathlib.Path) -> None:
+    """repro --all is accepted and triggers all-pipeline discovery."""
+    with isolated_pivot_dir(runner, tmp_path):
+        # Create two sub-pipelines
+        for name, stage_name in [("alpha", "stage_a"), ("beta", "stage_b")]:
+            sub = tmp_path / name
+            sub.mkdir()
+            (sub / ".pivot").mkdir()
+            create_pipeline_py(
+                [_helper_noop_stage],
+                path=sub,
+                names={"_helper_noop_stage": stage_name},
+            )
+
+        result = runner.invoke(cli.cli, ["repro", "--all", "--dry-run"])
+        assert result.exit_code == 0
+        assert "stage_a" in result.output
+        assert "stage_b" in result.output
+```
+
+Similar tests for `status --all` and `commit --all`.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/cli/test_repro.py -k "all_flag" -v`
+Expected: FAIL — `--all` not recognized
+
+**Step 3: Add `allow_all=True` to each command**
+
+In `src/pivot/cli/repro.py:741`:
+```python
+@cli_decorators.pivot_command(allow_all=True)
+```
+
+In `src/pivot/cli/status.py:29`:
+```python
+@cli_decorators.pivot_command(allow_all=True)
+```
+
+In `src/pivot/cli/commit.py:12`:
+```python
+@cli_decorators.pivot_command("commit", allow_all=True)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/cli/test_repro.py tests/cli/test_cli_status.py tests/cli/test_cli_commit.py -k "all_flag" -v`
+Expected: PASS
+
+---
+
+### Task 2: Engine per-stage StateDB — deferred writes
+
+The engine opens a single StateDB at `config.get_state_db_path()` (line 557) and applies all deferred writes there. When stages from different pipelines have different `state_dir` values, writes go to the wrong database.
+
+**The worker already uses per-stage `state_dir`** (via `prepare_worker_info` line 333). The coordinator just needs to route deferred writes correctly.
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py:533,557,567,607-613`
+- Test: `tests/engine/test_engine.py`
+
+**Step 1: Write failing test**
+
+```python
+def test_deferred_writes_go_to_correct_state_db(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Deferred writes for stages with different state_dirs go to the right DB.
+
+    When stage_a has state_dir=alpha/.pivot and stage_b has state_dir=beta/.pivot,
+    deferred writes from stage_a must go to alpha/.pivot/state.db, not the
+    project-level state.db.
+    """
+    ...
+```
+
+Note: The exact test depends on existing engine test patterns. The key assertion is that after applying deferred writes, the generation bump appears in the stage's own StateDB, not the project-level one.
+
+**Step 2: Implement per-stage StateDB routing**
+
+In `src/pivot/engine/engine.py`, the `_orchestrate_execution` method (line 460+):
+
+Replace the single StateDB with a cache of StateDB connections keyed by `state_dir`:
+
+```python
+# Line 533: remove global state_dir assignment
+# state_dir = config.get_state_dir()  # DELETE this line
+# Keep it only for default_state_dir fallback:
+default_state_dir = config.get_state_dir()
+
+# Line 557: remove single state_db_path
+# state_db_path = config.get_state_db_path()  # DELETE this line
+```
+
+Replace the single `with state_mod.StateDB(state_db_path) as state_db:` block (line 567) with a StateDB connection cache:
+
+```python
+# Instead of opening one StateDB, manage a cache
+state_dbs = dict[pathlib.Path, state_mod.StateDB]()
+
+def _get_state_db(stage_state_dir: pathlib.Path) -> state_mod.StateDB:
+    """Get or open a StateDB for the given state_dir."""
+    if stage_state_dir not in state_dbs:
+        db_path = stage_state_dir / "state.db"
+        state_dbs[stage_state_dir] = state_mod.StateDB(db_path)
+        state_dbs[stage_state_dir].open()
+    return state_dbs[stage_state_dir]
+```
+
+At the deferred writes application (lines 607-613), look up the stage's `state_dir`:
+
+```python
+if result["status"] == StageStatus.RAN and not no_commit:
+    stage_info = self._get_stage(stage_name)
+    output_paths = [str(out.path) for out in stage_info["outs"]]
+    stage_state_dir = stage_info["state_dir"] or default_state_dir
+    stage_db = _get_state_db(stage_state_dir)
+    executor_core.apply_deferred_writes(
+        stage_name, output_paths, result, stage_db
+    )
+```
+
+Ensure all StateDBs are closed in the `finally` block:
+
+```python
+finally:
+    for db in state_dbs.values():
+        db.close()
+```
+
+Update `_start_ready_stages` call (line 580) to pass `default_state_dir` instead of `state_dir`:
+
+```python
+state_dir=default_state_dir,
+```
+
+Ensure `default_state_dir.mkdir(parents=True, exist_ok=True)` still happens (line 537).
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: All pass
+
+---
+
+### Task 3: Engine per-stage StateDB — run history
+
+The `_write_run_history` method (line 1066) reads lock files from the global `state_dir` and writes the run manifest to a single StateDB. Fix both.
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py:1066-1113`
+- Test: `tests/engine/test_engine.py`
+
+**Step 1: Implement the fix**
+
+In `_write_run_history` (line 1081), replace:
+
+```python
+state_dir = config.get_state_dir()
+```
+
+with per-stage lookup:
+
+```python
+# Read lock files from each stage's own state_dir
+for name, summary in results.items():
+    stage_info = self._get_stage(name)
+    stage_state_dir = stage_info["state_dir"] or config.get_state_dir()
+    stage_lock = lock.StageLock(name, lock.get_stages_dir(stage_state_dir))
+    ...
+```
+
+For the run manifest write (line 1111), write to the project-level StateDB since run history is project-scoped:
+
+```python
+with state_mod.StateDB(config.get_state_db_path()) as state_db:
+    state_db.write_run(manifest)
+    state_db.prune_runs(retention)
+```
+
+This line stays unchanged — run history is intentionally project-level.
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: All pass
+
+---
+
+### Task 4: `executor/core.py` — per-stage `state_dir` for incremental output check
+
+`check_uncached_incremental_outputs` (line 448) uses `config.get_state_dir()` for all stages. It already has `all_stages` dict with per-stage `state_dir`.
+
+**Files:**
+- Modify: `src/pivot/executor/core.py:448-477`
+- Test: `tests/execution/test_executor_core.py` (check existing file name)
+
+**Step 1: Implement the fix**
+
+Replace line 457:
+
+```python
+state_dir = config.get_state_dir()
+```
+
+with per-stage lookup inside the loop (line 460):
+
+```python
+for stage_name in execution_order:
+    stage_info = all_stages[stage_name]
+    stage_state_dir = stage_info["state_dir"] or config.get_state_dir()
+    stage_outs = stage_info["outs"]
+
+    # Read lock file from stage's state_dir
+    stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(stage_state_dir))
+    ...
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/execution/ -v`
+Expected: All pass
+
+---
+
+### Task 5: `executor/commit.py` — per-stage `state_dir` for pending lock commit
+
+`commit_pending` (line 14) writes production locks to a single `state_dir` and opens one StateDB. When stages from different pipelines have different state dirs, locks go to the wrong place.
+
+**Files:**
+- Modify: `src/pivot/executor/commit.py:14-61`
+- Test: `tests/execution/test_executor_commit.py` (check existing)
+
+**Step 1: Understand the current flow**
+
+`commit_pending` reads pending locks from `project_root / ".pivot" / "pending" / "stages"` (project-level), then writes production locks to `state_dir / "stages"`. The pending lock location is already project-level and shared. The production lock needs to go to the stage's own `state_dir`.
+
+The challenge: pending locks don't carry `state_dir` info. We need to look up the stage in the registry to find its `state_dir`.
+
+**Step 2: Implement the fix**
+
+Modify `commit_pending` to accept an optional `all_stages` dict for per-stage `state_dir` lookup. When `all_stages` is provided, use `all_stages[stage_name]["state_dir"]` for the production lock path. When not provided (backward compat), fall back to `config.get_state_dir()`.
+
+```python
+def commit_pending(
+    all_stages: dict[str, RegistryStageInfo] | None = None,
+) -> list[str]:
+    """Promote pending locks to production and update StateDB."""
+    project_root = project.get_project_root()
+    pending_stages = lock.list_pending_stages(project_root)
+    if not pending_stages:
+        return []
+
+    default_state_dir = config.get_state_dir()
+    committed = list[str]()
+
+    # Group stages by state_dir for efficient StateDB access
+    stages_by_state_dir = dict[pathlib.Path, list[str]]()
+    for stage_name in pending_stages:
+        if all_stages and stage_name in all_stages:
+            state_dir = all_stages[stage_name]["state_dir"] or default_state_dir
+        else:
+            state_dir = default_state_dir
+        stages_by_state_dir.setdefault(state_dir, []).append(stage_name)
+
+    for state_dir, stage_names in stages_by_state_dir.items():
+        with state_mod.StateDB(state_dir / "state.db") as state_db:
+            for stage_name in stage_names:
+                pending_lock = lock.get_pending_lock(stage_name, project_root)
+                pending_data = pending_lock.read()
+                if pending_data is None:
+                    continue
+
+                production_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
+                production_lock.write(pending_data)
+
+                # ... rest of logic unchanged ...
+                committed.append(stage_name)
+
+    return committed
+```
+
+Update the caller in `src/pivot/cli/commit.py` to pass `all_stages` when the pipeline is available:
+
+```python
+# In commit_command, after the pending_state_lock:
+try:
+    all_stages = cli_helpers.get_all_stages()
+except Exception:
+    all_stages = None  # Graceful fallback if pipeline not loaded
+committed = commit.commit_pending(all_stages=all_stages)
+```
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/execution/ tests/cli/test_cli_commit.py -v`
+Expected: All pass
+
+---
+
+### Task 6: `cli/checkout.py` — per-stage `state_dir` for output restoration
+
+`checkout` (line 336) uses `config.get_state_dir()` to find lock files. Fix `_get_stage_output_info` to use per-stage `state_dir`.
+
+**Files:**
+- Modify: `src/pivot/cli/checkout.py:35-64,336`
+- Test: `tests/cli/test_cli_checkout.py`
+
+**Step 1: Implement the fix**
+
+In `_get_stage_output_info` (line 35), replace the `state_dir` parameter with per-stage lookup:
+
+```python
+def _get_stage_output_info() -> dict[str, OutputHash]:
+    """Get output hash info from lock files for cached stage outputs only."""
+    result = dict[str, OutputHash]()
+
+    for stage_name in cli_helpers.list_stages():
+        stage_info = cli_helpers.get_stage(stage_name)
+        state_dir = stage_info["state_dir"]
+        cached_paths = {
+            ...  # unchanged
+        }
+
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
+        ...  # rest unchanged
+```
+
+Remove `state_dir = config.get_state_dir()` at line 336 and update the call at line 347:
+
+```python
+stage_outputs = _get_stage_output_info()  # no state_dir param
+```
+
+**Step 2: Run tests**
+
+Run: `uv run pytest tests/cli/test_cli_checkout.py -v`
+Expected: All pass
+
+---
+
+### Task 7: `cli/remote.py` — enable `--all` on `push` and `pull`
+
+`push` and `pull` use `auto_discover=False` because they work from lock files. With `--all`, they need the registry to resolve per-stage `state_dir`. Switch to `auto_discover=True` (which is fine even without `--all` — it just becomes a no-op if no pipeline is found) or gate auto-discovery on the `--all` flag.
+
+**Files:**
+- Modify: `src/pivot/cli/remote.py:43,112,183`
+- Modify: `src/pivot/remote/sync.py:132-185`
+- Test: `tests/remote/test_remote_cli.py` (check existing)
+
+**Step 1: Enable `--all` on push, pull, fetch**
+
+Change the decorators:
+
+```python
+# push (line 43):
+@cli_decorators.pivot_command(allow_all=True)
+
+# fetch (line 112):
+@cli_decorators.pivot_command(allow_all=True)
+
+# pull (line 183):
+@cli_decorators.pivot_command(allow_all=True)
+```
+
+Note: Setting `allow_all=True` without changing `auto_discover` from `False` means we need to handle discovery in the decorator. Looking at the Phase 1 decorator implementation: the `auto_discover` check gates discovery. For push/pull, we want discovery to happen only when `--all` is passed. Update the decorator logic:
+
+```python
+# In the decorator wrapper:
+if (auto_discover or use_all) and not _has_pipeline_in_context():
+```
+
+This way, push/pull with `--all` triggers discovery, but without `--all` they skip it (existing behavior).
+
+**Step 2: Update `get_target_hashes` for per-stage `state_dir`**
+
+In `src/pivot/remote/sync.py:132`, when the registry is available (i.e., `--all` mode), use per-stage `state_dir` for lock file lookup:
+
+```python
+def get_target_hashes(
+    targets: list[str],
+    state_dir: pathlib.Path,
+    include_deps: bool = False,
+    all_stages: dict[str, RegistryStageInfo] | None = None,
+) -> set[str]:
+    """Resolve targets to cache hashes.
+
+    When all_stages is provided, uses per-stage state_dir for lock file lookup.
+    Otherwise falls back to the provided state_dir.
+    """
+    ...
+    for target in targets:
+        if "/" not in target and "\\" not in target:
+            # Determine state_dir for this stage
+            if all_stages and target in all_stages:
+                target_state_dir = all_stages[target]["state_dir"] or state_dir
+            else:
+                target_state_dir = state_dir
+            stage_lock = lock.StageLock(target, lock.get_stages_dir(target_state_dir))
+            ...
+```
+
+Update callers in `cli/remote.py` to pass `all_stages` when available:
+
+```python
+# In push command:
+try:
+    all_stages = cli_helpers.get_all_stages()
+except Exception:
+    all_stages = None
+local_hashes = transfer.get_target_hashes(
+    targets_list, state_dir, include_deps=False, all_stages=all_stages
+)
+```
+
+**Step 3: Run tests**
+
+Run: `uv run pytest tests/remote/ tests/cli/ -k "push or pull or fetch" -v`
+Expected: All pass
+
+---
+
+### Task 8: Watch mode — persist `all_pipelines` flag and reload correctly
+
+The engine's `_reload_registry` (line 1301) calls `discover_pipeline(root)` which only finds one pipeline. In `--all` mode, it needs to re-discover all pipelines.
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py:114-116,1301-1332,1162-1192`
+- Test: `tests/engine/test_engine.py`
+
+**Step 1: Add `all_pipelines` flag to Engine**
+
+In `Engine.__init__` (line 114), add:
+
+```python
+def __init__(self, *, pipeline: Pipeline | None = None, all_pipelines: bool = False) -> None:
+    self._pipeline = pipeline
+    self._all_pipelines = all_pipelines
+    ...
+```
+
+**Step 2: Update `_reload_registry` to use the flag**
+
+In `_reload_registry` (line 1321), change:
+
+```python
+new_pipeline = discovery.discover_pipeline(root)
+```
+
+to:
+
+```python
+new_pipeline = discovery.discover_pipeline(root, all_pipelines=self._all_pipelines)
+```
+
+**Step 3: Add pipeline config files to watch paths**
+
+In `_handle_code_or_config_changed` (line 1186-1192), after updating watch paths from the graph, also add pipeline config files when in `--all` mode:
+
+```python
+# After existing watch path update:
+if self._all_pipelines:
+    from pivot import discovery
+    config_paths = discovery.glob_all_pipelines(project.get_project_root())
+    watch_paths.extend(p.parent for p in config_paths)
+```
+
+This ensures that adding/removing a `pipeline.py` or `pivot.yaml` triggers a reload.
+
+**Step 4: Pass `all_pipelines` from CLI to Engine**
+
+In `src/pivot/cli/repro.py`, where the Engine is created, pass the flag. Find where `engine.Engine(pipeline=...)` is called and add `all_pipelines`:
+
+```python
+# Need to read the --all flag from context and pass to Engine
+eng = engine.Engine(pipeline=pipeline, all_pipelines=use_all_pipelines)
+```
+
+Check how the repro CLI creates the engine and threads the flag through.
+
+**Step 5: Run tests**
+
+Run: `uv run pytest tests/engine/ -v`
+Expected: All pass
+
+---
+
+### Task 9: Integration test — `repro --all` with mixed state_dirs
+
+End-to-end test that exercises the full pipeline: discovery, DAG building, execution, lock file writing, and StateDB routing.
+
+**Files:**
+- Test: `tests/integration/test_all_pipelines.py` (new file)
+
+**Step 1: Write the integration test**
+
+Create `tests/integration/test_all_pipelines.py`:
+
+```python
+"""Integration tests for --all flag across multiple pipelines."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from click.testing import CliRunner
+
+from conftest import isolated_pivot_dir
+from helpers import create_pipeline_py
+from pivot import cli
+from pivot.storage import lock
+
+
+def _helper_stage_a() -> None:
+    """Stage for pipeline alpha."""
+    pass
+
+
+def _helper_stage_b() -> None:
+    """Stage for pipeline beta."""
+    pass
+
+
+def _setup_multi_pipeline_project(
+    root: pathlib.Path,
+) -> None:
+    """Create a project with two pipelines using different state_dirs."""
+    # Alpha: uses project root as its root (shared .pivot)
+    alpha = root / "alpha"
+    alpha.mkdir()
+    create_pipeline_py(
+        [_helper_stage_a],
+        path=alpha,
+        names={"_helper_stage_a": "stage_a"},
+        extra_code='pipeline = Pipeline("alpha", root=__import__("pathlib").Path(__file__).parent)\n',
+    )
+
+    # Beta: uses its own root (separate .pivot)
+    beta = root / "beta"
+    beta.mkdir()
+    (beta / ".pivot").mkdir()
+    create_pipeline_py(
+        [_helper_stage_b],
+        path=beta,
+        names={"_helper_stage_b": "stage_b"},
+        extra_code='pipeline = Pipeline("beta", root=__import__("pathlib").Path(__file__).parent)\n',
+    )
+
+
+def test_repro_all_executes_stages_from_all_pipelines(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """repro --all runs stages from all discovered pipelines."""
+    with isolated_pivot_dir(runner, tmp_path):
+        _setup_multi_pipeline_project(tmp_path)
+
+        result = runner.invoke(cli.cli, ["repro", "--all"])
+
+        assert result.exit_code == 0
+        assert "stage_a" in result.output
+        assert "stage_b" in result.output
+
+
+def test_repro_all_writes_locks_to_correct_state_dir(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Lock files are written to each pipeline's own .pivot/stages/."""
+    with isolated_pivot_dir(runner, tmp_path):
+        _setup_multi_pipeline_project(tmp_path)
+
+        runner.invoke(cli.cli, ["repro", "--all"])
+
+        # Beta's lock file should be in beta/.pivot/stages/
+        beta_lock = lock.StageLock("stage_b", lock.get_stages_dir(tmp_path / "beta" / ".pivot"))
+        assert beta_lock.read() is not None, "Lock file not found in beta's state_dir"
+
+
+def test_status_all_shows_all_pipelines(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """status --all shows stages from all pipelines."""
+    with isolated_pivot_dir(runner, tmp_path):
+        _setup_multi_pipeline_project(tmp_path)
+
+        result = runner.invoke(cli.cli, ["status", "--all"])
+
+        assert result.exit_code == 0
+        assert "stage_a" in result.output
+        assert "stage_b" in result.output
+
+
+def test_verify_all_with_mixed_state_dirs(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """verify --all reads lock files from correct per-pipeline state_dirs."""
+    with isolated_pivot_dir(runner, tmp_path):
+        _setup_multi_pipeline_project(tmp_path)
+
+        # Run first to create locks
+        runner.invoke(cli.cli, ["repro", "--all"])
+
+        result = runner.invoke(cli.cli, ["verify", "--all"])
+
+        assert result.exit_code == 0
+        assert "stage_a" in result.output
+        assert "stage_b" in result.output
+```
+
+Note: The exact `create_pipeline_py` usage depends on the existing helper's interface. Adjust `extra_code` to match how pipelines are constructed in test helpers.
+
+**Step 2: Run the integration tests**
+
+Run: `uv run pytest tests/integration/test_all_pipelines.py -v`
+Expected: All pass
+
+---
+
+### Task 10: Quality checks and smoke test
+
+**Step 1: Run full test suite**
+
+Run: `uv run pytest tests/ -n auto`
+Expected: All pass, no regressions
+
+**Step 2: Run type checker**
+
+Run: `uv run basedpyright`
+Expected: No new errors
+
+**Step 3: Run linter and formatter**
+
+Run: `uv run ruff format . && uv run ruff check .`
+Expected: Clean
+
+**Step 4: Manual smoke test on eval-pipeline**
+
+```bash
+cd ~/eval-pipeline/pivot
+
+# Test each command
+uv run pivot status --all
+uv run pivot verify --all
+uv run pivot repro --all --dry-run
+uv run pivot repro --all
+uv run pivot push --all --dry-run
+```
+
+Expected: All commands discover all 6 pipelines and operate correctly across shared and separate state_dirs.
+
+---
+
+## Summary of changes by file
+
+| File | Change | Task |
+|------|--------|------|
+| `src/pivot/cli/repro.py:741` | `allow_all=True` | 1 |
+| `src/pivot/cli/status.py:29` | `allow_all=True` | 1 |
+| `src/pivot/cli/commit.py:12` | `allow_all=True` | 1 |
+| `src/pivot/engine/engine.py:114` | Add `all_pipelines` param to `__init__` | 8 |
+| `src/pivot/engine/engine.py:533,557,567` | StateDB connection cache per `state_dir` | 2 |
+| `src/pivot/engine/engine.py:607-613` | Per-stage StateDB for deferred writes | 2 |
+| `src/pivot/engine/engine.py:1081-1085` | Per-stage `state_dir` for lock file reads | 3 |
+| `src/pivot/engine/engine.py:1301-1332` | Use `all_pipelines` flag in reload | 8 |
+| `src/pivot/engine/engine.py:1186-1192` | Add pipeline config files to watch paths | 8 |
+| `src/pivot/executor/core.py:448-477` | Per-stage `state_dir` for incremental check | 4 |
+| `src/pivot/executor/commit.py:14-61` | Per-stage `state_dir` for production locks | 5 |
+| `src/pivot/cli/checkout.py:35-64,336` | Per-stage `state_dir` for output restoration | 6 |
+| `src/pivot/cli/remote.py:43,112,183` | `allow_all=True` on push/pull/fetch | 7 |
+| `src/pivot/cli/decorators.py` | Discovery when `use_all` even if `auto_discover=False` | 7 |
+| `src/pivot/remote/sync.py:132-185` | Per-stage `state_dir` for target hash resolution | 7 |
+| `tests/integration/test_all_pipelines.py` | New: E2E tests for `--all` with mixed state_dirs | 9 |

--- a/src/pivot/cli/commit.py
+++ b/src/pivot/cli/commit.py
@@ -7,7 +7,7 @@ from pivot.cli import helpers as cli_helpers
 from pivot.executor import commit
 
 
-@cli_decorators.pivot_command("commit")
+@cli_decorators.pivot_command("commit", allow_all=True)
 @click.argument("stages", nargs=-1)
 @click.pass_context
 def commit_command(ctx: click.Context, stages: tuple[str, ...]) -> None:

--- a/src/pivot/cli/status.py
+++ b/src/pivot/cli/status.py
@@ -26,7 +26,7 @@ from pivot.types import (
 )
 
 
-@cli_decorators.pivot_command()
+@cli_decorators.pivot_command(allow_all=True)
 @click.argument("stages", nargs=-1, shell_complete=completion.complete_stages)
 @click.option("--verbose", "-v", is_flag=True, help="Show all stages, not just stale")
 @click.option(

--- a/src/pivot/registry.py
+++ b/src/pivot/registry.py
@@ -955,3 +955,8 @@ def _normalize_deps_dict(
             normalized = _normalize_paths([value], path_policy.PathType.DEP, validation_mode)
             result[name] = normalized[0]
     return result
+
+
+def get_stage_state_dir(stage_info: RegistryStageInfo, default: pathlib.Path) -> pathlib.Path:
+    """Return the stage's state_dir, falling back to the given default."""
+    return stage_info["state_dir"] or default

--- a/src/pivot/tui/diff_panels.py
+++ b/src/pivot/tui/diff_panels.py
@@ -20,7 +20,7 @@ import textual.containers
 import textual.css.query
 import textual.widgets
 
-from pivot import config, explain, outputs, parameters, project
+from pivot import config, explain, outputs, parameters, project, registry
 from pivot.cli import helpers as cli_helpers
 from pivot.show import data as data_mod
 from pivot.show import metrics as metrics_mod
@@ -447,7 +447,7 @@ class InputDiffPanel(_SelectableExpandablePanel):
             logger.debug("Stage %s not in registry", stage_name)
             return
 
-        state_dir = config.get_state_dir()
+        state_dir = registry.get_stage_state_dir(self._registry_info, config.get_state_dir())
         try:
             fingerprint = self._stage_data_provider.ensure_fingerprint(stage_name)
             self._explanation = explain.get_stage_explanation(
@@ -770,7 +770,7 @@ class OutputDiffPanel(_SelectableExpandablePanel):
             logger.debug("Stage %s not in registry", stage_name)
             return
 
-        state_dir = config.get_state_dir()
+        state_dir = registry.get_stage_state_dir(self._registry_info, config.get_state_dir())
         stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
         try:
             lock_data = stage_lock.read()

--- a/src/pivot/tui/run.py
+++ b/src/pivot/tui/run.py
@@ -32,7 +32,7 @@ import textual.timer
 import textual.widget
 import textual.widgets
 
-from pivot import config, explain, parameters, project
+from pivot import config, explain, parameters, project, registry
 from pivot.executor import ExecutionSummary
 from pivot.storage import lock
 from pivot.tui import diff_panels, rpc_client
@@ -581,7 +581,11 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
             try:
                 registry_info = self._stage_data_provider.get_stage(stage_name)
                 fingerprint = self._stage_data_provider.ensure_fingerprint(stage_name)
-                state_dir = config.get_state_dir()
+                state_dir = (
+                    registry.get_stage_state_dir(registry_info, config.get_state_dir())
+                    if "state_dir" in registry_info
+                    else config.get_state_dir()
+                )
                 input_snapshot = explain.get_stage_explanation(
                     stage_name=stage_name,
                     fingerprint=fingerprint,
@@ -638,7 +642,11 @@ class PivotApp(textual.app.App[dict[str, ExecutionSummary] | None]):
             if self._stage_data_provider is not None:
                 try:
                     registry_info = self._stage_data_provider.get_stage(stage_name)
-                    state_dir = config.get_state_dir()
+                    state_dir = (
+                        registry.get_stage_state_dir(registry_info, config.get_state_dir())
+                        if "state_dir" in registry_info
+                        else config.get_state_dir()
+                    )
                     stages_dir = lock.get_stages_dir(state_dir)
                     lock_data = lock.StageLock(stage_name, stages_dir).read()
                     output_snapshot = diff_panels.compute_output_changes(lock_data, registry_info)

--- a/tests/config/test_registry.py
+++ b/tests/config/test_registry.py
@@ -1098,3 +1098,70 @@ def test_registry_add_existing_invalidates_dag_cache(set_project_root: pathlib.P
     dag2 = reg.build_dag(validate=False)
     assert len(dag2.nodes) == 2
     assert "added_stage" in dag2.nodes
+
+
+# =============================================================================
+# get_stage_state_dir Tests
+# =============================================================================
+
+
+def test_get_stage_state_dir_returns_custom_when_set(set_project_root: pathlib.Path) -> None:
+    """get_stage_state_dir returns the stage's state_dir when it is set.
+
+    Stages from included pipelines have a per-stage state_dir pointing to
+    the original pipeline's .pivot directory. This overrides the default.
+    """
+    custom_dir = set_project_root / "sub" / ".pivot"
+    # Construct a minimal RegistryStageInfo-like dict with state_dir set
+    stage_info = RegistryStageInfo(
+        func=lambda: None,
+        name="test",
+        deps={},
+        deps_paths=[],
+        outs=[],
+        outs_paths=[],
+        params=None,
+        mutex=[],
+        variant=None,
+        signature=None,
+        fingerprint={},
+        dep_specs={},
+        out_specs={},
+        params_arg_name=None,
+        state_dir=custom_dir,
+    )
+    default_dir = set_project_root / ".pivot"
+
+    result = registry.get_stage_state_dir(stage_info, default_dir)
+
+    assert result == custom_dir
+
+
+def test_get_stage_state_dir_returns_default_when_none(set_project_root: pathlib.Path) -> None:
+    """get_stage_state_dir returns the default when stage's state_dir is None.
+
+    Stages from the primary pipeline have state_dir=None, meaning they use
+    the project's default .pivot directory.
+    """
+    stage_info = RegistryStageInfo(
+        func=lambda: None,
+        name="test",
+        deps={},
+        deps_paths=[],
+        outs=[],
+        outs_paths=[],
+        params=None,
+        mutex=[],
+        variant=None,
+        signature=None,
+        fingerprint={},
+        dep_specs={},
+        out_specs={},
+        params_arg_name=None,
+        state_dir=None,
+    )
+    default_dir = set_project_root / ".pivot"
+
+    result = registry.get_stage_state_dir(stage_info, default_dir)
+
+    assert result == default_dir

--- a/tests/integration/test_all_pipelines.py
+++ b/tests/integration/test_all_pipelines.py
@@ -1,0 +1,189 @@
+"""Integration tests for --all flag across multiple pipelines."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from conftest import isolated_pivot_dir
+from pivot import cli
+from pivot.storage import lock
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from click.testing import CliRunner
+
+
+# =============================================================================
+# Pipeline code generators
+# =============================================================================
+
+
+def _make_noop_pipeline_code(
+    name: str, stage_name: str, out_annotation: str, write_path: str
+) -> str:
+    """Generate a simple pipeline with one stage that writes an output file.
+
+    Args:
+        name: Pipeline name.
+        stage_name: Name of the stage function.
+        out_annotation: Output path for Out() annotation (pipeline-relative).
+        write_path: Path the stage writes to (project-relative, since workers
+            chdir to project root).
+    """
+    return f'''
+from typing import Annotated, TypedDict
+from pathlib import Path
+from pivot.pipeline import Pipeline
+from pivot import loaders
+from pivot.outputs import Out
+
+pipeline = Pipeline("{name}")
+
+class _Output(TypedDict):
+    data: Annotated[Path, Out("{out_annotation}", loaders.PathOnly())]
+
+def {stage_name}() -> _Output:
+    Path("{write_path}").parent.mkdir(parents=True, exist_ok=True)
+    Path("{write_path}").write_text("{stage_name} output")
+    return _Output(data=Path("{write_path}"))
+
+pipeline.register({stage_name})
+'''
+
+
+def _setup_multi_pipeline_project(root: pathlib.Path) -> None:
+    """Create a project with two sub-pipelines using different state_dirs.
+
+    - alpha/: pipeline with stage_a, uses root .pivot (default state_dir)
+    - beta/: pipeline with stage_b, uses beta/.pivot (separate state_dir)
+    """
+    # Alpha pipeline — uses project root .pivot
+    alpha = root / "alpha"
+    alpha.mkdir()
+    (alpha / "pipeline.py").write_text(
+        _make_noop_pipeline_code("alpha", "stage_a", "output_a.txt", "alpha/output_a.txt")
+    )
+
+    # Beta pipeline — uses its own .pivot
+    beta = root / "beta"
+    beta.mkdir()
+    (beta / ".pivot").mkdir()
+    (beta / "pipeline.py").write_text(
+        _make_noop_pipeline_code("beta", "stage_b", "output_b.txt", "beta/output_b.txt")
+    )
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+def test_repro_all_discovers_stages_from_all_pipelines(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """repro --all --dry-run discovers stages from all sub-pipelines."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        result = runner.invoke(cli.cli, ["repro", "--all", "--dry-run"])
+
+        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+        assert "stage_a" in result.output, "stage_a from alpha pipeline not found"
+        assert "stage_b" in result.output, "stage_b from beta pipeline not found"
+
+
+def test_repro_all_executes_stages_from_all_pipelines(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """repro --all runs stages from all discovered pipelines."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        result = runner.invoke(cli.cli, ["repro", "--all"])
+
+        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+        assert "stage_a" in result.output, "stage_a not in output"
+        assert "stage_b" in result.output, "stage_b not in output"
+
+        # Verify output files were created
+        assert (cwd / "alpha" / "output_a.txt").exists(), "Alpha output not created"
+        assert (cwd / "beta" / "output_b.txt").exists(), "Beta output not created"
+
+
+def test_repro_all_writes_locks_to_correct_state_dir(
+    runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Lock files are written to each pipeline's own .pivot/stages/."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        result = runner.invoke(cli.cli, ["repro", "--all"])
+        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+
+        # Beta's lock file should be in beta/.pivot/stages/
+        beta_stages_dir = lock.get_stages_dir(cwd / "beta" / ".pivot")
+        beta_lock = lock.StageLock("stage_b", beta_stages_dir)
+        assert beta_lock.read() is not None, "Lock file not found in beta's state_dir"
+
+
+def test_status_all_shows_all_pipelines(runner: CliRunner, tmp_path: pathlib.Path) -> None:
+    """status --all shows stages from all pipelines."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        result = runner.invoke(cli.cli, ["status", "--all"])
+
+        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+        assert "stage_a" in result.output, "stage_a not in status output"
+        assert "stage_b" in result.output, "stage_b not in status output"
+
+
+def test_verify_all_with_mixed_state_dirs(runner: CliRunner, tmp_path: pathlib.Path) -> None:
+    """verify --all reads lock files from correct per-pipeline state_dirs."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        # Run first to create locks
+        run_result = runner.invoke(cli.cli, ["repro", "--all"])
+        assert run_result.exit_code == 0, f"repro failed: {run_result.output}"
+
+        result = runner.invoke(cli.cli, ["verify", "--all"])
+
+        assert result.exit_code == 0, f"Expected success, got: {result.output}"
+        assert "stage_a" in result.output, "stage_a not in verify output"
+        assert "stage_b" in result.output, "stage_b not in verify output"
+
+
+def test_commit_all_after_no_commit_run(runner: CliRunner, tmp_path: pathlib.Path) -> None:
+    """commit --all promotes pending locks to correct per-stage state_dirs."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        _setup_multi_pipeline_project(cwd)
+
+        # Run with --no-commit to create pending locks
+        run_result = runner.invoke(cli.cli, ["repro", "--all", "--no-commit"])
+        assert run_result.exit_code == 0, f"repro failed: {run_result.output}"
+
+        # Commit pending locks
+        commit_result = runner.invoke(cli.cli, ["commit", "--all"])
+        assert commit_result.exit_code == 0, f"commit failed: {commit_result.output}"
+
+        # Verify beta's production lock is in beta/.pivot/stages/
+        beta_stages_dir = lock.get_stages_dir(cwd / "beta" / ".pivot")
+        beta_lock = lock.StageLock("stage_b", beta_stages_dir)
+        assert beta_lock.read() is not None, "Production lock not in beta's state_dir after commit"
+
+
+def test_all_flag_with_single_pipeline(runner: CliRunner, tmp_path: pathlib.Path) -> None:
+    """--all works gracefully when the project has only one pipeline."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        alpha = cwd / "alpha"
+        alpha.mkdir()
+        (alpha / "pipeline.py").write_text(
+            _make_noop_pipeline_code("alpha", "stage_a", "alpha_out.txt", "alpha_out.txt")
+        )
+
+        result = runner.invoke(cli.cli, ["status", "--all"])
+
+        assert result.exit_code == 0, f"status --all failed: {result.output}"
+        assert "stage_a" in result.output

--- a/tests/remote/test_cli_remote.py
+++ b/tests/remote/test_cli_remote.py
@@ -197,7 +197,9 @@ def test_push_with_targets(
         result = runner.invoke(cli.cli, ["push", "train_model"])
 
         assert result.exit_code == 0
-        mock_target_hashes.assert_called_once_with(["train_model"], state_dir, include_deps=False)
+        mock_target_hashes.assert_called_once_with(
+            ["train_model"], state_dir, include_deps=False, all_stages=None
+        )
 
 
 # =============================================================================

--- a/tests/tui/test_diff_panels.py
+++ b/tests/tui/test_diff_panels.py
@@ -815,6 +815,7 @@ def test_input_panel_load_uses_provider(mocker: MockerFixture) -> None:
         "deps_paths": [],
         "outs_paths": [],
         "params": None,
+        "state_dir": None,
     }
     mock_provider.ensure_fingerprint.return_value = {"func": "abc"}
 
@@ -853,6 +854,7 @@ def test_output_panel_load_uses_provider(mocker: MockerFixture) -> None:
         "outs_paths": [],
         "outs": [],
         "params": None,
+        "state_dir": None,
     }
 
     panel = diff_panels.OutputDiffPanel(stage_data_provider=mock_provider)


### PR DESCRIPTION
## Summary

Add `--all` flag to CLI commands (`repro`, `status`, `verify`, `commit`, `push`, `pull`, `fetch`) that discovers every pipeline in the project, merges them into a single DAG, and executes as normal — same parallelism, dependency resolution, and error handling, just with a bigger graph.

### Key changes

- **Discovery**: `discover_pipeline(all_pipelines=True)` globs all pipeline configs, loads each, and `include()`s them into a synthetic root Pipeline
- **CLI decorator**: `pivot_command(allow_all=True)` gates the `--all` flag per command
- **Per-stage state_dir**: Centralized `registry.get_stage_state_dir()` helper routes lock files and StateDB writes to each pipeline's own `.pivot/` directory
- **Engine StateDB cache**: `dict[Path, StateDB]` connection cache for multi-state_dir support
- **Watch mode**: Persists `all_pipelines` flag for correct reload, adds pipeline config files to watch paths
- **Auto-prefix collision**: `Pipeline.include()` auto-prefixes colliding stage names with `{pipeline_name}/` instead of erroring
- **External-dep warning**: Warns when `--all` has dependencies not produced by any discovered pipeline
- **Lock file subdirectory support**: `list_pending_stages` uses `rglob` to find pipeline-prefixed lock files in subdirectories

### Files changed

**Core**: `discovery.py`, `registry.py`, `pipeline/pipeline.py`, `storage/lock.py`
**CLI**: `decorators.py`, `repro.py`, `status.py`, `verify.py`, `commit.py`, `checkout.py`, `remote.py`
**Engine/Executor**: `engine/engine.py`, `executor/core.py`, `executor/commit.py`, `remote/sync.py`
**Status**: `status.py`
**Tests**: 8 new tests + integration test suite (`test_all_pipelines.py`)
**Docs**: Design doc + Phase 1/2 implementation plans

### Quality

- basedpyright: 0 errors, 0 warnings
- ruff: All checks passed
- pytest: 3491 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)