### PR TITLE
chore: follow-up fixes — canonical source docs, sync auto-discovery, TUI commit, StateDB hoist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ src/pivot/
 ## Core Design
 
 - **Artifact-first**: The DAG emerges from artifact dependencies, not explicit wiring
+- **Pipeline is canonical**: The registry (from `pivot.yaml`/`pipeline.py`) is the single source of truth for stage metadata — deps, outs, cache flags, params. Lock files record execution state (hashes, generations), not stage definitions. Never infer stage properties from lock files.
 - Per-stage lock files, automatic code fingerprinting, warm worker pools
 - `ProcessPoolExecutor` for true parallelism (GIL would serialize threads)
 - Invalidation is content-addressed: same inputs + same code = same outputs

--- a/src/pivot/cli/AGENTS.md
+++ b/src/pivot/cli/AGENTS.md
@@ -38,7 +38,9 @@ Set `auto_discover=False` only for commands that don't use the stage registry:
 | checkout, track | True (default) | Need registry for validation |
 | init | False | Creates new project (no pipeline yet) |
 | schema | False | Outputs JSON schema only |
-| push, pull | False | Read from lock files, not registry |
+| push, pull, fetch | True (default) | Need registry for output cache filtering |
+
+**Principle:** The pipeline registry is the canonical source of stage metadata. Commands that inspect stage properties (cache flags, dep/out paths) must use auto-discovery. Only commands that truly don't touch stage data (init, schema, history) should use `auto_discover=False`.
 
 ### Why this matters
 

--- a/src/pivot/cli/remote.py
+++ b/src/pivot/cli/remote.py
@@ -40,7 +40,7 @@ def _get_targets_list(targets: tuple[str, ...]) -> list[str] | None:
     return list(targets) if targets else None
 
 
-@cli_decorators.pivot_command(auto_discover=False)
+@cli_decorators.pivot_command()
 @click.argument("targets", nargs=-1, shell_complete=completion.complete_targets)
 @click.option("-r", "--remote", "remote_name", help="Remote name (uses default if not specified)")
 @click.option("--dry-run", "-n", is_flag=True, help="Show what would be pushed")
@@ -109,7 +109,7 @@ def push(
         raise SystemExit(1)
 
 
-@cli_decorators.pivot_command(auto_discover=False)
+@cli_decorators.pivot_command()
 @click.argument("targets", nargs=-1, shell_complete=completion.complete_targets)
 @click.option("-r", "--remote", "remote_name", help="Remote name (uses default if not specified)")
 @click.option("--dry-run", "-n", is_flag=True, help="Show what would be fetched")
@@ -180,7 +180,7 @@ def fetch(
         raise SystemExit(1)
 
 
-@cli_decorators.pivot_command(auto_discover=False)
+@cli_decorators.pivot_command()
 @click.argument("targets", nargs=-1, shell_complete=completion.complete_targets)
 @click.option("-r", "--remote", "remote_name", help="Remote name (uses default if not specified)")
 @click.option("--dry-run", "-n", is_flag=True, help="Show what would be pulled")

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -236,7 +236,7 @@ class StorageLockData(TypedDict):
     params: dict[str, Any]
     deps: list[DepEntry]
     outs: list[OutEntry]
-    # Stored at execution time for --no-commit mode (used by commit to record correct generations)
+    # Always empty in lock files; dep generations are tracked in StateDB
     dep_generations: dict[str, int]
 
 
@@ -247,7 +247,7 @@ class LockData(TypedDict):
     params: dict[str, Any]
     dep_hashes: dict[str, HashInfo]
     output_hashes: dict[str, HashInfo]
-    # Stored at execution time for --no-commit mode (used by commit to record correct generations)
+    # Always empty in lock files; dep generations are tracked in StateDB
     dep_generations: dict[str, int]
 
 


### PR DESCRIPTION
## Summary

Follow-up to #386 (rearchitect commit). Addresses deferred items from that PR.

## Changes

- **Document canonical source principle** — Added to AGENTS.md Core Design: the pipeline registry is the single source of truth for stage metadata, not lock files. Updated CLI AGENTS.md auto_discover table.

- **Enable auto-discovery for push/pull/fetch** — These commands need the registry for output cache filtering. Removed `auto_discover=False` from `remote.py`. Cleaned up the try/except fallback hack in `sync.py` (kept narrow `except KeyError` in `_get_file_hash_from_stages` for stale lock files).

- **Fix stale comments** — Updated `dep_generations` comments on both `StorageLockData` and `LockData` to reflect current architecture (always empty in lock files, tracked in StateDB).

- **Hoist StateDB open outside commit loop** — `commit_stages()` now opens StateDB once for all stages instead of per-stage. Also passes `state_db` to `hash_dependencies` for hash caching.

- **Wire TUI `action_commit()`** — Replaced placeholder with real implementation using `asyncio.to_thread(commit.commit_stages)`. Guards against concurrent execution.

## Test plan

- [x] basedpyright: 0 errors, 0 warnings
- [x] ruff format + check: clean
- [x] 3432 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)