### PR TITLE
refactor: stage definition, graph model, and TUI decoupling (#380, #381, #382)

### DIFF
--- a/docs/plans/2026-02-07-graph-model-adapter.md
+++ b/docs/plans/2026-02-07-graph-model-adapter.md
@@ -1,0 +1,551 @@
+# Graph Model Adapter: Decouple Renderer from Engine Node Encoding
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Decouple `dag/render.py` from engine-specific string-encoded node IDs (`parse_node`, `NodeType`) by introducing a `GraphView` adapter that exposes nodes and edges as plain data.
+
+**Architecture:** Add an `extract_graph_view()` function to `engine/graph.py` that converts the bipartite `nx.DiGraph[str]` into a `GraphView` TypedDict containing pre-extracted stage names, artifact paths, and edges. The renderer consumes `GraphView` instead of walking the raw NetworkX graph with `parse_node`. The bipartite graph and `parse_node` remain internal to `engine/graph.py`—only `GraphView` crosses the boundary.
+
+**Tech Stack:** NetworkX (existing), TypedDict for the adapter contract
+
+---
+
+## Current State
+
+`dag/render.py` directly imports:
+- `engine_graph.parse_node` — to decode `"stage:train"` → `(NodeType.STAGE, "train")`
+- `engine_types.NodeType` — to filter nodes by type
+
+The coupling is in `_extract_nodes_and_edges()` (render.py:56-110), which walks every node and edge in the bipartite graph, calling `parse_node` on each to determine type and extract labels.
+
+## Target State
+
+`dag/render.py` receives a `GraphView` (TypedDict with `stages`, `artifacts`, `stage_edges`, `artifact_edges` lists) and renders from that — no imports from `engine/graph.py` or `engine/types.py`.
+
+The `extract_graph_view()` function lives in `engine/graph.py` and encapsulates the `parse_node`/`NodeType` logic. `dag/render.py` only imports and consumes `GraphView`.
+
+**Edge direction semantics (documented in docstrings):**
+- `stage_edges`: `(producer, consumer)` — data-flow direction (matches the bipartite graph's stage→artifact→stage flow)
+- `artifact_edges`: `(input, output)` — data-flow direction (artifact consumed by stage that produces another artifact)
+
+---
+
+## Task 1: Add `GraphView` TypedDict and `extract_graph_view()` to `engine/graph.py`
+
+**Files:**
+- Modify: `src/pivot/engine/graph.py`
+- Test: `tests/engine/test_graph.py`
+
+### Step 1: Write failing tests for `extract_graph_view`
+
+Add to `tests/engine/test_graph.py`:
+
+```python
+# --- extract_graph_view tests ---
+
+
+@pytest.mark.usefixtures("clean_registry")
+def test_extract_graph_view_empty() -> None:
+    """extract_graph_view on empty graph returns empty lists."""
+    g = graph.build_graph({})
+    view = graph.extract_graph_view(g)
+
+    assert view["stages"] == []
+    assert view["artifacts"] == []
+    assert view["stage_edges"] == []
+    assert view["artifact_edges"] == []
+
+
+@pytest.mark.usefixtures("clean_registry")
+def test_extract_graph_view_single_stage(tmp_path: Path) -> None:
+    """extract_graph_view extracts stage and artifact from single-stage graph."""
+    input_file = tmp_path / "input.csv"
+    output_file = tmp_path / "output.csv"
+    input_file.touch()
+
+    stages = {
+        "stage_a": _create_stage("stage_a", [str(input_file)], [str(output_file)]),
+    }
+    g = graph.build_graph(stages)
+    view = graph.extract_graph_view(g)
+
+    assert view["stages"] == ["stage_a"]
+    assert set(view["artifacts"]) == {str(input_file), str(output_file)}
+    # Single stage with no downstream — no stage edges
+    assert view["stage_edges"] == []
+    # Artifact edges: input -> output (through stage_a)
+    assert (str(input_file), str(output_file)) in view["artifact_edges"]
+
+
+@pytest.mark.usefixtures("clean_registry")
+def test_extract_graph_view_linear_chain(tmp_path: Path) -> None:
+    """extract_graph_view extracts correct edges for a linear chain."""
+    input_file = tmp_path / "input.csv"
+    intermediate = tmp_path / "intermediate.csv"
+    output_file = tmp_path / "output.csv"
+    input_file.touch()
+
+    stages = {
+        "stage_a": _create_stage("stage_a", [str(input_file)], [str(intermediate)]),
+        "stage_b": _create_stage("stage_b", [str(intermediate)], [str(output_file)]),
+    }
+    g = graph.build_graph(stages)
+    view = graph.extract_graph_view(g)
+
+    assert set(view["stages"]) == {"stage_a", "stage_b"}
+    assert set(view["artifacts"]) == {str(input_file), str(intermediate), str(output_file)}
+    # stage_a -> stage_b (producer -> consumer, data-flow direction)
+    assert ("stage_a", "stage_b") in view["stage_edges"]
+    # artifact edges: input -> intermediate, intermediate -> output
+    assert (str(input_file), str(intermediate)) in view["artifact_edges"]
+    assert (str(intermediate), str(output_file)) in view["artifact_edges"]
+
+
+@pytest.mark.usefixtures("clean_registry")
+def test_extract_graph_view_diamond(tmp_path: Path) -> None:
+    """extract_graph_view handles diamond DAG correctly."""
+    input_file = tmp_path / "input.csv"
+    clean = tmp_path / "clean.csv"
+    feats = tmp_path / "feats.csv"
+    model = tmp_path / "model.pkl"
+    input_file.touch()
+
+    stages = {
+        "preprocess": _create_stage("preprocess", [str(input_file)], [str(clean)]),
+        "features": _create_stage("features", [str(input_file)], [str(feats)]),
+        "train": _create_stage("train", [str(clean), str(feats)], [str(model)]),
+    }
+    g = graph.build_graph(stages)
+    view = graph.extract_graph_view(g)
+
+    assert set(view["stages"]) == {"preprocess", "features", "train"}
+    # Stage edges (producer -> consumer)
+    assert ("preprocess", "train") in view["stage_edges"]
+    assert ("features", "train") in view["stage_edges"]
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/engine/test_graph.py -k "extract_graph_view" -v
+```
+
+Expected: FAIL — `AttributeError: module 'pivot.engine.graph' has no attribute 'extract_graph_view'`
+
+### Step 3: Add `GraphView` TypedDict and `extract_graph_view()` implementation
+
+In `src/pivot/engine/graph.py`, add the TypedDict near the top (after imports, before existing functions) and the function after `get_stage_dag`:
+
+```python
+class GraphView(TypedDict):
+    """Pre-extracted graph data for rendering.
+
+    Decouples renderers from the internal bipartite graph representation.
+    All node identifiers are plain strings (stage names, artifact paths)
+    with no encoding prefixes.
+
+    Edge direction is data-flow: producer → consumer / input → output.
+    """
+
+    stages: list[str]
+    artifacts: list[str]
+    stage_edges: list[tuple[str, str]]
+    artifact_edges: list[tuple[str, str]]
+```
+
+```python
+def extract_graph_view(g: nx.DiGraph[str]) -> GraphView:
+    """Extract a renderer-friendly view from the bipartite graph.
+
+    Walks the bipartite graph once, collecting stage names, artifact paths,
+    and derived edges without exposing the internal node encoding.
+
+    Edge semantics (data-flow direction):
+    - stage_edges: (producer_stage, consumer_stage)
+    - artifact_edges: (input_artifact, output_artifact)
+
+    Args:
+        g: Bipartite artifact-stage graph from build_graph().
+
+    Returns:
+        GraphView with plain-string nodes and edges.
+    """
+    stages = list[str]()
+    artifacts = list[str]()
+    stage_edges = list[tuple[str, str]]()
+    artifact_edges = list[tuple[str, str]]()
+
+    # Collect nodes by type
+    for node in g.nodes():
+        node_type, value = parse_node(node)
+        if node_type == NodeType.STAGE:
+            stages.append(value)
+        else:
+            artifacts.append(value)
+
+    # Derive stage-to-stage edges (producer -> consumer)
+    # Walk: stage -> artifact (produces) -> stage (consumes)
+    for node in g.nodes():
+        node_type, source_name = parse_node(node)
+        if node_type != NodeType.STAGE:
+            continue
+        for artifact_node_id in g.successors(node):
+            if g.nodes[artifact_node_id]["type"] != NodeType.ARTIFACT:
+                continue
+            for consumer_node in g.successors(artifact_node_id):
+                if g.nodes[consumer_node]["type"] == NodeType.STAGE:
+                    consumer_name = parse_node(consumer_node)[1]
+                    stage_edges.append((source_name, consumer_name))
+
+    # Derive artifact-to-artifact edges (input -> output)
+    # Walk: artifact -> stage (consumes) -> artifact (produces)
+    for node in g.nodes():
+        node_type, source_path = parse_node(node)
+        if node_type != NodeType.ARTIFACT:
+            continue
+        for stage_node_id in g.successors(node):
+            if g.nodes[stage_node_id]["type"] != NodeType.STAGE:
+                continue
+            for output_node in g.successors(stage_node_id):
+                if g.nodes[output_node]["type"] == NodeType.ARTIFACT:
+                    output_path = parse_node(output_node)[1]
+                    artifact_edges.append((source_path, output_path))
+
+    return GraphView(
+        stages=stages,
+        artifacts=artifacts,
+        stage_edges=stage_edges,
+        artifact_edges=artifact_edges,
+    )
+```
+
+Add `"GraphView"` and `"extract_graph_view"` to the `__all__` list.
+
+Add `TypedDict` to the imports from `typing`:
+```python
+from typing import TYPE_CHECKING, TypedDict
+```
+
+### Step 4: Run tests to verify they pass
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/engine/test_graph.py -k "extract_graph_view" -v
+```
+
+Expected: All 4 new tests PASS.
+
+### Step 5: Run full graph test suite (no regressions)
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/engine/test_graph.py -v
+```
+
+Expected: All tests PASS.
+
+---
+
+## Task 2: Update `dag/render.py` to consume `GraphView` instead of raw bipartite graph
+
+**Files:**
+- Modify: `src/pivot/dag/render.py`
+- Modify: `src/pivot/dag/__init__.py`
+- Test: `tests/core/test_dag_render.py`
+
+### Step 1: Replace `_extract_nodes_and_edges` with `GraphView`-based extraction
+
+Rewrite `dag/render.py` to:
+1. Remove imports of `engine_graph` and `engine_types`
+2. Import `GraphView` from `pivot.engine.graph` under `TYPE_CHECKING`
+3. Replace `_extract_nodes_and_edges(g, stages)` with a simple function that selects the right fields from `GraphView`
+4. Change all three render functions (`render_ascii`, `render_mermaid`, `render_dot`) to accept `GraphView` instead of `nx.DiGraph[str]`
+
+The full updated `render.py` top section and changed functions:
+
+**Remove these imports:**
+```python
+from pivot.engine import graph as engine_graph
+from pivot.engine import types as engine_types
+```
+And the conditional `import networkx as nx` in `TYPE_CHECKING`.
+
+**Add this import:**
+```python
+if TYPE_CHECKING:
+    from pivot.engine.graph import GraphView
+```
+
+**Replace `_extract_nodes_and_edges` with:**
+```python
+def _select_view(
+    view: GraphView,
+    stages: bool,
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Select nodes and edges for the requested view (stages or artifacts).
+
+    Args:
+        view: Pre-extracted graph data.
+        stages: If True, return stage nodes/edges; if False, artifact nodes/edges.
+
+    Returns:
+        Tuple of (node labels, edges between nodes).
+    """
+    if stages:
+        return view["stages"], view["stage_edges"]
+    return view["artifacts"], view["artifact_edges"]
+```
+
+**Update render function signatures** — change first parameter from `g: nx.DiGraph[str]` to `view: GraphView`:
+
+```python
+def render_ascii(view: GraphView, stages: bool = False) -> str:
+    """Render graph as ASCII art using grandalf Sugiyama layout.
+
+    Args:
+        view: GraphView from extract_graph_view().
+        stages: If True, render stage nodes; if False (default), render artifact nodes.
+
+    Returns:
+        ASCII art representation of the graph.
+    """
+    nodes, edges = _select_view(view, stages)
+    # ... rest unchanged ...
+```
+
+```python
+def render_mermaid(view: GraphView, stages: bool = False) -> str:
+    """Render graph as Mermaid flowchart TD format.
+
+    Args:
+        view: GraphView from extract_graph_view().
+        stages: If True, render stage nodes; if False (default), render artifact nodes.
+
+    Returns:
+        Mermaid flowchart string.
+    """
+    nodes, edges = _select_view(view, stages)
+    # ... rest unchanged ...
+```
+
+```python
+def render_dot(view: GraphView, stages: bool = False) -> str:
+    """Render graph as Graphviz DOT format.
+
+    Args:
+        view: GraphView from extract_graph_view().
+        stages: If True, render stage nodes; if False (default), render artifact nodes.
+
+    Returns:
+        DOT format string.
+    """
+    nodes, edges = _select_view(view, stages)
+    # ... rest unchanged ...
+```
+
+### Step 2: Update `dag/__init__.py` re-exports
+
+No changes needed — `render_ascii`, `render_mermaid`, `render_dot` names stay the same.
+
+### Step 3: Run render tests (expect failures from callers still passing raw graph)
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_dag_render.py -v
+```
+
+Expected: FAIL — tests still pass raw bipartite graphs to render functions.
+
+---
+
+## Task 3: Update render test helpers to use `GraphView`
+
+**Files:**
+- Modify: `tests/core/test_dag_render.py`
+
+### Step 1: Update test helper `_build_graph` to return `GraphView`
+
+Replace the existing `_build_graph` helper and imports:
+
+**Remove:**
+```python
+from pivot.engine import graph as engine_graph
+```
+
+**Add:**
+```python
+from pivot.engine import graph as engine_graph
+```
+
+**Replace `_build_graph`:**
+```python
+def _build_view(stages_dict: dict[str, RegistryStageInfo]) -> engine_graph.GraphView:
+    """Build GraphView from stages dict."""
+    bipartite = engine_graph.build_graph(stages_dict)
+    return engine_graph.extract_graph_view(bipartite)
+```
+
+**Update all test functions** that call `_build_graph` to call `_build_view` instead, and rename the local variable from `g` to `view`. For example:
+
+```python
+def test_render_ascii_empty_graph() -> None:
+    """Empty graph returns placeholder text."""
+    view = _build_view({})
+    result = dag.render_ascii(view)
+    assert result == "(empty graph)"
+```
+
+Apply this rename across all tests. The two subgraph tests (`test_render_ascii_subgraph`, `test_render_mermaid_subgraph`) need special handling — they manually build a subgraph from the bipartite graph. Update them to build the subgraph first, then extract a `GraphView` from it:
+
+```python
+def test_render_ascii_subgraph() -> None:
+    """Render a subgraph containing only part of the pipeline."""
+    stages = {
+        "extract": _create_stage("extract", [], ["raw.csv"]),
+        "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
+        "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
+    }
+    g = engine_graph.build_graph(stages)
+
+    # Get subgraph of just extract and transform
+    subgraph = g.subgraph(
+        [
+            engine_graph.stage_node("extract"),
+            engine_graph.stage_node("transform"),
+            engine_graph.artifact_node(pathlib.Path("raw.csv")),
+            engine_graph.artifact_node(pathlib.Path("clean.csv")),
+        ]
+    )
+    view = engine_graph.extract_graph_view(subgraph)
+
+    result = dag.render_ascii(view, stages=True)
+
+    assert "extract" in result
+    assert "transform" in result
+    assert "load" not in result
+```
+
+(Same pattern for `test_render_mermaid_subgraph`.)
+
+### Step 2: Run render tests
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_dag_render.py -v
+```
+
+Expected: All tests PASS.
+
+---
+
+## Task 4: Update `cli/dag.py` to pass `GraphView` to renderers
+
+**Files:**
+- Modify: `src/pivot/cli/dag.py`
+
+### Step 1: Update the `dag_cmd` function
+
+The `dag_cmd` function builds a bipartite graph, optionally filters it to a subgraph, then passes it to renderers. Update it to call `extract_graph_view()` before rendering.
+
+**Changes in `dag_cmd`:**
+
+After the subgraph filtering (line ~124), add:
+```python
+    # Extract view for rendering
+    view = engine_graph.extract_graph_view(bipartite_graph)
+```
+
+Then update the match block to pass `view` instead of `bipartite_graph`:
+```python
+    match output_format:
+        case "dot":
+            output = dag.render_dot(view, stages=show_stages)
+        case "mermaid":
+            output = dag.render_mermaid(view, stages=show_stages)
+        case "md":
+            mermaid = dag.render_mermaid(view, stages=show_stages)
+            output = f"```mermaid\n{mermaid}\n```"
+        case _:
+            output = dag.render_ascii(view, stages=show_stages)
+```
+
+Note: The rest of `dag_cmd` (target resolution, subgraph filtering) still operates on the raw bipartite graph — only the final rendering step uses the adapter.
+
+### Step 2: Run dag CLI tests
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/cli/test_dag_cmd.py -v
+```
+
+Expected: All tests PASS.
+
+---
+
+## Task 5: Remove `parse_node` from `__all__` and clean up
+
+**Files:**
+- Modify: `src/pivot/engine/graph.py`
+
+### Step 1: Remove `parse_node` from `__all__`
+
+`parse_node` is now only used internally within `engine/graph.py`. Remove it from `__all__` to signal it's not part of the public API. Keep the function itself (it's still used by `_check_acyclic`, `get_consumers`, `get_producer`, `get_watch_paths`, `get_downstream_stages`, `update_stage`, `get_upstream_stages`, `get_stage_dag`, and `extract_graph_view`).
+
+**Note:** `parse_node` is still imported by `cli/dag.py`'s `_get_upstream_subgraph` and `_resolve_targets_to_stages` — but those use `engine_graph.get_producer()` and `engine_graph.stage_node()`, not `parse_node` directly. Verify this.
+
+Actually, checking the code again: `cli/dag.py` does NOT import `parse_node` directly — it uses `engine_graph.get_producer()` and `engine_graph.stage_node()`. The imports of `engine_types.NodeType` in `cli/dag.py` are used for the `_get_upstream_subgraph` function (checking `bipartite_graph.nodes[succ]["type"] == engine_types.NodeType.ARTIFACT`). That's a separate concern and acceptable for now — it's the subgraph construction, not rendering.
+
+Remove `"parse_node"` from `__all__` in `engine/graph.py`.
+
+### Step 2: Verify no external callers of `parse_node` remain
+
+```bash
+cd /home/sami/pivot/roadmap-380 && grep -rn "parse_node" src/pivot/ --include="*.py" | grep -v "engine/graph.py"
+```
+
+Expected: No results (render.py no longer imports it, tests may reference it but that's fine).
+
+**If `parse_node` is still used in tests** (`tests/engine/test_graph.py` has 3 tests for it), those tests can remain — they test the internal function directly. No external production code should reference it.
+
+### Step 3: Run all tests
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/engine/test_graph.py tests/core/test_dag_render.py tests/cli/test_dag_cmd.py -v
+```
+
+Expected: All tests PASS.
+
+---
+
+## Task 6: Quality checks and final verification
+
+**Files:** None (verification only)
+
+### Step 1: Run full quality checks
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run ruff format . && uv run ruff check . && uv run basedpyright
+```
+
+Expected: No errors.
+
+### Step 2: Run full test suite
+
+```bash
+cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto
+```
+
+Expected: All tests PASS with no regressions.
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `src/pivot/engine/graph.py` | Add `GraphView` TypedDict, `extract_graph_view()` function; remove `parse_node` from `__all__` |
+| `src/pivot/dag/render.py` | Accept `GraphView` instead of `nx.DiGraph[str]`; remove `engine_graph`/`engine_types` imports; replace `_extract_nodes_and_edges` with `_select_view` |
+| `src/pivot/cli/dag.py` | Call `extract_graph_view()` before passing to renderers |
+| `tests/engine/test_graph.py` | Add `extract_graph_view` tests |
+| `tests/core/test_dag_render.py` | Update to build `GraphView` instead of passing raw bipartite graph |
+
+**What doesn't change:**
+- `engine/engine.py` — still uses bipartite graph internally for orchestration
+- `status.py`, `cli/status.py`, `cli/repro.py` — use `build_graph`/`get_stage_dag`/`get_execution_order` which are unchanged
+- `pipeline/pipeline.py`, `registry.py` — unchanged
+- Execution order, skip detection, watch mode — all unchanged

--- a/docs/plans/2026-02-07-single-stage-definition-extraction.md
+++ b/docs/plans/2026-02-07-single-stage-definition-extraction.md
@@ -1,0 +1,729 @@
+# Single StageDefinition Extraction Seam — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Parse stage function annotations exactly once per registration and make type-hint resolution failures explicit.
+
+**Architecture:** Introduce a `StageDefinition` dataclass in `stage_def.py` that bundles the results of all annotation parsing (dep specs, output specs, single output spec, placeholder dep names, params info) into one object. A single `extract_stage_definition()` function calls `get_type_hints()` once and produces the definition. Pipeline and Registry consume this pre-extracted definition instead of re-parsing annotations independently.
+
+**Tech Stack:** Python 3.13+, dataclasses, existing `stage_def` / `registry` / `pipeline` modules.
+
+---
+
+## Problem Analysis
+
+Currently, annotation parsing happens **redundantly** across three call sites:
+
+| Call site | Functions called | `get_type_hints()` calls |
+|-----------|-----------------|-------------------------|
+| `Pipeline.register()` | `get_dep_specs_from_signature`, `get_output_specs_from_return`, `get_single_output_spec_from_return` | 3 |
+| `Registry.register()` | `get_placeholder_dep_names`, `get_dep_specs_from_signature`, `get_output_specs_from_return`, `get_single_output_spec_from_return`, `find_params_in_signature` | 5+ |
+| `yaml.py` `_expand_simple_stage` / `_expand_matrix` | `get_output_specs_from_return`, `find_params_in_signature` | 2 |
+
+Additionally, `_get_type_hints_safe` silently returns `None` on failure, causing downstream functions to return empty dicts — a silent degradation the issue explicitly flags.
+
+## Design Decisions
+
+1. **`StageDefinition` is a dataclass** (not TypedDict) — it's an internal struct with methods disallowed on TypedDicts (potential future `validate()` etc.), and it's never serialized to JSON.
+
+2. **`extract_stage_definition()` takes `dep_path_overrides`** — because `get_dep_specs_from_signature` needs overrides to resolve `PlaceholderDep`. This means the extraction is override-aware from the start.
+
+3. **Hint resolution failures raise `StageDefinitionError`** by default — the current "return empty" behavior is replaced. A `strict=True` default parameter controls this; callers who genuinely need graceful degradation can pass `strict=False`.
+
+4. **Existing public functions stay but delegate** — `get_dep_specs_from_signature()`, `get_output_specs_from_return()`, etc. remain as thin wrappers calling `extract_stage_definition()` internally. This avoids breaking any external callers or tests, and they can be deprecated later.
+
+5. **Pipeline.register() passes `StageDefinition` to Registry** — Pipeline extracts once, resolves paths, then passes the definition. Registry receives it and skips re-extraction.
+
+---
+
+## Task 1: Add `StageDefinition` dataclass to `stage_def.py`
+
+**Files:**
+- Modify: `src/pivot/stage_def.py` (add dataclass near top, after `FuncDepSpec`)
+
+**Step 1: Define the dataclass**
+
+Add after the `FuncDepSpec` class (around line 434):
+
+```python
+@dataclasses.dataclass(frozen=True)
+class StageDefinition:
+    """Complete parsed definition of a stage function's annotations.
+
+    Produced once by extract_stage_definition() and consumed by Pipeline/Registry.
+    Avoids redundant get_type_hints() calls across registration layers.
+    """
+
+    dep_specs: dict[str, FuncDepSpec]
+    out_specs: dict[str, outputs.BaseOut]
+    single_out_spec: outputs.BaseOut | None
+    placeholder_dep_names: frozenset[str]
+    params_arg_name: str | None
+    params_type: type[StageParams] | None
+    hints_resolved: bool
+```
+
+Fields:
+- `dep_specs`: from `get_dep_specs_from_signature` — includes PlaceholderDep resolution
+- `out_specs`: from `get_output_specs_from_return` (TypedDict outputs)
+- `single_out_spec`: from `get_single_output_spec_from_return` (single-return outputs)
+- `placeholder_dep_names`: from `get_placeholder_dep_names`
+- `params_arg_name`: param name holding StageParams (or None)
+- `params_type`: StageParams subclass type (or None)
+- `hints_resolved`: True if type hints were successfully resolved
+
+**Step 2: Run type checker**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run basedpyright src/pivot/stage_def.py`
+Expected: PASS (new class is just a data definition)
+
+---
+
+## Task 2: Implement `extract_stage_definition()` in `stage_def.py`
+
+**Files:**
+- Modify: `src/pivot/stage_def.py`
+
+**Step 1: Write the failing test**
+
+Create test in existing test structure. Add a new test file:
+
+Create: `tests/core/test_stage_definition.py`
+
+```python
+# pyright: reportUnusedFunction=false
+from __future__ import annotations
+
+import pathlib
+from typing import Annotated, TypedDict
+
+import pytest
+
+from pivot import exceptions, loaders, outputs, stage_def
+
+
+class _SimpleOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+def _stage_with_dep(
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_no_annotations() -> None:
+    pass
+
+
+class _TestParams(stage_def.StageParams):
+    lr: float = 0.01
+
+
+def _stage_with_params(
+    params: _TestParams,
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_with_placeholder(
+    data: Annotated[pathlib.Path, outputs.PlaceholderDep(loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _single_output_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]:
+    return pathlib.Path("output.txt")
+
+
+class TestExtractStageDefinition:
+    def test_basic_extraction(self) -> None:
+        defn = stage_def.extract_stage_definition(_stage_with_dep, "test_stage")
+        assert defn.hints_resolved is True
+        assert "data" in defn.dep_specs
+        assert defn.dep_specs["data"].path == "input.csv"
+        assert "result" in defn.out_specs
+        assert defn.out_specs["result"].path == "result.txt"
+        assert defn.single_out_spec is None
+        assert defn.params_arg_name is None
+        assert defn.params_type is None
+
+    def test_no_annotations(self) -> None:
+        defn = stage_def.extract_stage_definition(_stage_no_annotations, "bare")
+        assert defn.hints_resolved is True
+        assert defn.dep_specs == {}
+        assert defn.out_specs == {}
+        assert defn.single_out_spec is None
+
+    def test_params_extraction(self) -> None:
+        defn = stage_def.extract_stage_definition(_stage_with_params, "with_params")
+        assert defn.params_arg_name == "params"
+        assert defn.params_type is _TestParams
+
+    def test_placeholder_dep_names(self) -> None:
+        defn = stage_def.extract_stage_definition(
+            _stage_with_placeholder,
+            "placeholder",
+            dep_path_overrides={"data": "override.csv"},
+        )
+        assert "data" in defn.placeholder_dep_names
+        assert defn.dep_specs["data"].path == "override.csv"
+
+    def test_placeholder_without_override_raises(self) -> None:
+        with pytest.raises(ValueError, match="PlaceholderDep"):
+            stage_def.extract_stage_definition(_stage_with_placeholder, "placeholder")
+
+    def test_single_output_extraction(self) -> None:
+        defn = stage_def.extract_stage_definition(_single_output_stage, "single")
+        assert defn.out_specs == {}
+        assert defn.single_out_spec is not None
+        assert defn.single_out_spec.path == "output.txt"
+
+    def test_hint_resolution_failure_raises(self) -> None:
+        """Type hint resolution failure should raise, not silently degrade."""
+        # Create a function with unresolvable type hint
+        ns: dict[str, object] = {}
+        exec(  # noqa: S102
+            "from typing import Annotated\n"
+            "from pivot import outputs, loaders\n"
+            "def bad_func(x: 'UnresolvableType') -> None: pass\n",
+            ns,
+        )
+        bad_func = ns["bad_func"]
+        with pytest.raises(exceptions.StageDefinitionError, match="resolve type hints"):
+            stage_def.extract_stage_definition(bad_func, "bad_stage")  # type: ignore[arg-type]
+
+    def test_hint_resolution_failure_lenient(self) -> None:
+        """With strict=False, hint failure returns hints_resolved=False."""
+        ns: dict[str, object] = {}
+        exec(  # noqa: S102
+            "def bad_func(x: 'UnresolvableType') -> None: pass\n",
+            ns,
+        )
+        bad_func = ns["bad_func"]
+        defn = stage_def.extract_stage_definition(bad_func, "bad_stage", strict=False)  # type: ignore[arg-type]
+        assert defn.hints_resolved is False
+        assert defn.dep_specs == {}
+        assert defn.out_specs == {}
+```
+
+**Step 2: Run the test to confirm it fails**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py -v`
+Expected: FAIL — `extract_stage_definition` does not exist yet.
+
+**Step 3: Implement `extract_stage_definition()`**
+
+Add to `src/pivot/stage_def.py` after the `StageDefinition` dataclass:
+
+```python
+def extract_stage_definition(
+    func: Callable[..., Any],
+    stage_name: str,
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+    *,
+    strict: bool = True,
+) -> StageDefinition:
+    """Extract complete stage definition from function annotations in a single pass.
+
+    Calls get_type_hints() once and derives all dep/output/params specs from the
+    result. This is the single extraction point — Pipeline and Registry should
+    call this instead of individual extraction functions.
+
+    Args:
+        func: Stage function to extract from.
+        stage_name: Name for error messages.
+        dep_path_overrides: Override paths for PlaceholderDep and Dep annotations.
+        strict: If True (default), raise StageDefinitionError when type hints
+            can't be resolved. If False, return a definition with hints_resolved=False
+            and empty specs.
+
+    Returns:
+        StageDefinition with all parsed annotation data.
+
+    Raises:
+        StageDefinitionError: If strict=True and type hints can't be resolved.
+        ValueError: If PlaceholderDep has no override in dep_path_overrides.
+    """
+    import inspect as inspect_module
+
+    hints = _get_type_hints_safe(func, func.__name__, include_extras=True)
+    if hints is None:
+        if strict:
+            raise exceptions.StageDefinitionError(
+                f"Stage '{stage_name}': failed to resolve type hints for '{func.__name__}'. "
+                + "Check that all type annotations are importable."
+            )
+        return StageDefinition(
+            dep_specs={},
+            out_specs={},
+            single_out_spec=None,
+            placeholder_dep_names=frozenset(),
+            params_arg_name=None,
+            params_type=None,
+            hints_resolved=False,
+        )
+
+    sig = inspect_module.signature(func)
+
+    # --- Extract deps, placeholders, and params from parameters ---
+    overrides = dep_path_overrides or {}
+    dep_specs = dict[str, FuncDepSpec]()
+    placeholder_dep_names = set[str]()
+    params_arg_name: str | None = None
+    params_type: type[StageParams] | None = None
+
+    # Also get non-extras hints for params detection
+    hints_no_extras = _get_type_hints_safe(func, func.__name__)
+
+    for param_name in sig.parameters:
+        if param_name not in hints:
+            continue
+
+        param_type = _unwrap_type_alias(hints[param_name])
+
+        # Check for StageParams (use non-extras hints to avoid Annotated wrapper)
+        if hints_no_extras and param_name in hints_no_extras:
+            raw_type = hints_no_extras[param_name]
+            if isinstance(raw_type, type) and issubclass(raw_type, StageParams):
+                params_arg_name = param_name
+                params_type = raw_type
+
+        # Check for Annotated deps
+        if get_origin(param_type) is not Annotated:
+            continue
+
+        args = get_args(param_type)
+        if len(args) < 2:
+            continue
+
+        for metadata in args[1:]:
+            if isinstance(metadata, outputs.PlaceholderDep):
+                placeholder_dep_names.add(param_name)
+                if param_name not in overrides:
+                    raise ValueError(
+                        f"PlaceholderDep '{param_name}' requires override in dep_path_overrides"
+                    )
+                override_path = overrides[param_name]
+                if isinstance(override_path, (list, tuple)):
+                    if not override_path or any(not p for p in override_path):
+                        raise ValueError(
+                            f"PlaceholderDep '{param_name}' override contains empty path"
+                        )
+                elif not override_path:
+                    raise ValueError(f"PlaceholderDep '{param_name}' override cannot be empty")
+                placeholder = cast("outputs.PlaceholderDep[Any]", metadata)
+                dep_specs[param_name] = FuncDepSpec(
+                    path=override_path,
+                    loader=placeholder.loader,
+                )
+                break
+            elif isinstance(metadata, outputs.Dep):
+                dep = cast("outputs.Dep[Any]", metadata)
+                path = overrides.get(param_name, dep.path)
+                dep_specs[param_name] = FuncDepSpec(path=path, loader=dep.loader)
+                break
+            elif isinstance(metadata, outputs.IncrementalOut):
+                inc = cast("outputs.IncrementalOut[Any]", metadata)
+                dep_specs[param_name] = FuncDepSpec(
+                    path=inc.path,
+                    loader=inc.loader,
+                    creates_dep_edge=False,
+                )
+                break
+
+    # --- Extract output specs from return type ---
+    out_specs = dict[str, outputs.BaseOut]()
+    single_out_spec: outputs.BaseOut | None = None
+
+    return_type = hints.get("return")
+    if return_type is not None and return_type is not type(None):
+        return_type = _unwrap_type_alias(return_type)
+
+        if is_typeddict(return_type):
+            out_specs = _extract_typeddict_outputs(return_type, stage_name)
+        elif get_origin(return_type) is Annotated:
+            rt_args = get_args(return_type)
+            if len(rt_args) >= 2:
+                for metadata in rt_args[1:]:
+                    if isinstance(metadata, (outputs.Out, outputs.IncrementalOut, outputs.DirectoryOut)):
+                        single_out_spec = cast("outputs.BaseOut", metadata)
+                        break
+
+    return StageDefinition(
+        dep_specs=dep_specs,
+        out_specs=out_specs,
+        single_out_spec=single_out_spec,
+        placeholder_dep_names=frozenset(placeholder_dep_names),
+        params_arg_name=params_arg_name,
+        params_type=params_type,
+        hints_resolved=True,
+    )
+```
+
+**Step 4: Run the tests**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py -v`
+Expected: ALL PASS
+
+**Step 5: Run existing tests to confirm no regressions**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto --timeout=120 -q`
+Expected: ALL PASS (no behavior changes yet)
+
+---
+
+## Task 3: Update `Pipeline.register()` to use `extract_stage_definition()`
+
+**Files:**
+- Modify: `src/pivot/pipeline/pipeline.py:329-391` (the `register` method)
+
+**Step 1: Write a focused test**
+
+Add to `tests/core/test_stage_definition.py`:
+
+```python
+class TestPipelineUsesExtraction:
+    """Verify Pipeline.register() uses extract_stage_definition internally."""
+
+    def test_pipeline_register_calls_extract_once(self, mocker: MockerFixture) -> None:
+        """Pipeline.register should call extract_stage_definition, not individual functions."""
+        spy = mocker.spy(stage_def, "extract_stage_definition")
+        p = Pipeline("test", root=pathlib.Path(__file__).parent)
+        p.register(_stage_with_dep)
+        spy.assert_called_once()
+```
+
+Add `MockerFixture` import:
+```python
+from pytest_mock import MockerFixture
+```
+
+Also add the `TYPE_CHECKING` guard for that import.
+
+**Step 2: Run to confirm it fails**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py::TestPipelineUsesExtraction -v`
+Expected: FAIL — `extract_stage_definition` is not called by Pipeline yet.
+
+**Step 3: Refactor `Pipeline.register()`**
+
+Replace the body of `Pipeline.register()` in `src/pivot/pipeline/pipeline.py`. The key change: call `stage_def.extract_stage_definition()` once, then use the result for path resolution and pass it to `Registry.register()`.
+
+```python
+def register(
+    self,
+    func: StageFunc,
+    *,
+    name: str | None = None,
+    params: registry.ParamsArg = None,
+    mutex: list[str] | None = None,
+    variant: str | None = None,
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+    out_path_overrides: Mapping[str, registry.OutOverrideInput] | None = None,
+) -> None:
+    """Register a stage with this pipeline.
+
+    Paths in annotations and overrides are resolved relative to pipeline root.
+    """
+
+    stage_name = name or func.__name__
+
+    # 1. Extract stage definition (single pass over annotations)
+    definition = stage_def.extract_stage_definition(func, stage_name, dep_path_overrides)
+
+    # 2. Resolve annotation paths relative to pipeline root
+    # Skip IncrementalOut - registry disallows path overrides for them
+    resolved_deps: dict[str, outputs.PathType] = {
+        dep_name: self._resolve_path_type(spec.path)
+        for dep_name, spec in definition.dep_specs.items()
+        if spec.creates_dep_edge
+    }
+
+    out_specs = definition.out_specs
+    if not out_specs and definition.single_out_spec is not None:
+        out_specs = {stage_def.SINGLE_OUTPUT_KEY: definition.single_out_spec}
+
+    resolved_outs: dict[str, registry.OutOverride] = {
+        out_name: registry.OutOverride(path=self._resolve_path_type(spec.path))
+        for out_name, spec in out_specs.items()
+        if not isinstance(spec, outputs.IncrementalOut)
+    }
+
+    # 3. Apply explicit overrides (also pipeline-relative)
+    if dep_path_overrides:
+        for dep_name, path in dep_path_overrides.items():
+            resolved_deps[dep_name] = self._resolve_path_type(path)
+    if out_path_overrides:
+        for out_name, override in out_path_overrides.items():
+            resolved_outs[out_name] = self._resolve_out_override(override)
+
+    # 4. Pass definition + resolved overrides to registry
+    self._registry.register(
+        func=func,
+        name=name,
+        params=params,
+        mutex=mutex,
+        variant=variant,
+        dep_path_overrides=resolved_deps,
+        out_path_overrides=resolved_outs,
+        state_dir=self.state_dir,
+        definition=definition,
+    )
+
+    self._reset_resolution_cache()
+```
+
+**Step 4: Run the test**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py::TestPipelineUsesExtraction -v`
+Expected: FAIL until Task 4 (Registry must accept `definition` parameter). Continue to Task 4.
+
+---
+
+## Task 4: Update `Registry.register()` to accept and use `StageDefinition`
+
+**Files:**
+- Modify: `src/pivot/registry.py:256-491` (the `register` method)
+
+**Step 1: Add `definition` parameter to `Registry.register()`**
+
+Add optional `definition: stage_def.StageDefinition | None = None` parameter. When provided, skip all annotation parsing and use the pre-extracted data. When `None` (direct registry usage, tests), extract internally.
+
+The key changes in `Registry.register()`:
+
+```python
+def register(
+    self,
+    func: Callable[..., Any],
+    name: str | None = None,
+    params: ParamsArg = None,
+    mutex: Sequence[str] | None = None,
+    variant: str | None = None,
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+    out_path_overrides: Mapping[str, OutOverrideInput] | None = None,
+    state_dir: pathlib.Path | None = None,
+    definition: stage_def.StageDefinition | None = None,
+) -> None:
+```
+
+Near the top of the method body, add:
+
+```python
+# Extract or reuse stage definition
+if definition is None:
+    definition = stage_def.extract_stage_definition(func, stage_name, dep_path_overrides)
+```
+
+Then replace all individual calls:
+- `stage_def.get_placeholder_dep_names(func)` → `definition.placeholder_dep_names`
+- `stage_def.get_dep_specs_from_signature(func, dep_path_overrides)` → `definition.dep_specs`
+- `stage_def.get_output_specs_from_return(func, stage_name)` → `definition.out_specs`
+- `stage_def.get_single_output_spec_from_return(func)` → `definition.single_out_spec`
+- `stage_def.find_params_in_signature(func)` → `(definition.params_arg_name, definition.params_type)`
+
+**Step 2: Run all tests**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto --timeout=120 -q`
+Expected: ALL PASS
+
+The spy test from Task 3 should now pass too:
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py -v`
+Expected: ALL PASS
+
+---
+
+## Task 5: Update `yaml.py` to use `extract_stage_definition()` for metrics/plots validation
+
+**Files:**
+- Modify: `src/pivot/pipeline/yaml.py:295-336` (`_expand_simple_stage`) and `440-465` (`_expand_matrix`)
+
+**Step 1: Update `_expand_simple_stage`**
+
+Replace:
+```python
+return_out_specs = stage_def.get_output_specs_from_return(func, name)
+```
+
+With:
+```python
+definition = stage_def.extract_stage_definition(func, name)
+return_out_specs = definition.out_specs
+```
+
+**Step 2: Update `_expand_matrix`**
+
+Similarly, inside the matrix combo loop replace:
+```python
+return_out_specs = stage_def.get_output_specs_from_return(func, full_name)
+```
+
+With:
+```python
+# Extract once before loop (for type validation of metrics/plots)
+definition = stage_def.extract_stage_definition(func, full_name)
+return_out_specs = definition.out_specs
+```
+
+Note: The `definition` extraction for the matrix loop should happen **once before the loop** (the function is the same for all combos), not per-combo. So extract before the `for combo in combinations:` loop and use `definition.out_specs` inside.
+
+**Step 3: Update `_resolve_params` in yaml.py**
+
+Replace:
+```python
+params_arg_name, params_type = stage_def.find_params_in_signature(func)
+```
+
+With accepting the definition as a parameter (or keeping as-is since `_resolve_params` is called from multiple sites and `find_params_in_signature` is cached). This is a judgment call — since `_resolve_params` in yaml.py is called after extraction, we could thread the definition through. But `find_params_in_signature` already uses a `WeakKeyDictionary` cache, so the redundancy is minimal. **Leave this call as-is** — it's already cached and changing it would require threading the definition through `_expand_variants` too, adding complexity for negligible gain.
+
+**Step 4: Run tests**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto --timeout=120 -q`
+Expected: ALL PASS
+
+---
+
+## Task 6: Make existing public functions delegate to `extract_stage_definition()`
+
+**Files:**
+- Modify: `src/pivot/stage_def.py`
+
+**Context:** The existing public functions (`get_dep_specs_from_signature`, `get_output_specs_from_return`, `get_single_output_spec_from_return`, `get_placeholder_dep_names`) are still called from tests and potentially external code. Make them delegate to `extract_stage_definition()` so there's truly a single parsing path.
+
+**Step 1: Rewrite delegating functions**
+
+Replace `get_dep_specs_from_signature`:
+```python
+def get_dep_specs_from_signature(
+    func: Callable[..., Any],
+    dep_path_overrides: Mapping[str, outputs.PathType] | None = None,
+) -> dict[str, FuncDepSpec]:
+    """Extract dependency specs from function annotations.
+
+    Delegates to extract_stage_definition() for single-pass extraction.
+    """
+    defn = extract_stage_definition(func, func.__name__, dep_path_overrides, strict=False)
+    return defn.dep_specs
+```
+
+Replace `get_output_specs_from_return`:
+```python
+def get_output_specs_from_return(
+    func: Callable[..., Any],
+    stage_name: str,
+) -> dict[str, outputs.BaseOut]:
+    """Extract output specs from return type annotation.
+
+    Delegates to extract_stage_definition() for single-pass extraction.
+    """
+    defn = extract_stage_definition(func, stage_name, strict=False)
+    return defn.out_specs
+```
+
+Replace `get_single_output_spec_from_return`:
+```python
+def get_single_output_spec_from_return(func: Callable[..., Any]) -> outputs.BaseOut | None:
+    """Extract single output spec from return annotation.
+
+    Delegates to extract_stage_definition() for single-pass extraction.
+    """
+    defn = extract_stage_definition(func, func.__name__, strict=False)
+    return defn.single_out_spec
+```
+
+Replace `get_placeholder_dep_names`:
+```python
+def get_placeholder_dep_names(func: Callable[..., Any]) -> set[str]:
+    """Get parameter names with PlaceholderDep annotations.
+
+    Delegates to extract_stage_definition() for single-pass extraction.
+    """
+    # Can't call extract_stage_definition with strict placeholders — we don't have overrides.
+    # Keep the original implementation for this one since it doesn't need overrides.
+```
+
+**Important:** `get_placeholder_dep_names` is special — it's called *before* overrides are known (to validate that overrides exist). It cannot delegate to `extract_stage_definition()` because that function raises on unresolved PlaceholderDep. **Keep the original implementation** for this function.
+
+Similarly, `get_output_specs_from_return` has a subtle difference — when called with `strict=False`, hint failures won't raise a `StageDefinitionError` which matches the current behavior of returning `{}`.
+
+**Step 2: Run all tests**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto --timeout=120 -q`
+Expected: ALL PASS
+
+---
+
+## Task 7: Add test for explicit hint-failure behavior in Registry
+
+**Files:**
+- Create: `tests/core/test_stage_definition.py` (add more tests)
+
+**Step 1: Test that Registry with strict extraction raises on bad hints**
+
+```python
+class TestHintResolutionExplicitFailure:
+    """Verify hint resolution failures are explicit, not silent."""
+
+    def test_registry_raises_on_unresolvable_hints(self) -> None:
+        """Registry should raise StageDefinitionError for bad type hints."""
+        ns: dict[str, object] = {}
+        exec(  # noqa: S102
+            "from typing import Annotated\n"
+            "from pivot import outputs, loaders\n"
+            "def bad_stage(x: 'CompletelyFakeType') -> None: pass\n",
+            ns,
+        )
+        bad_func = ns["bad_stage"]
+        reg = registry.StageRegistry()
+        with pytest.raises(exceptions.StageDefinitionError, match="resolve type hints"):
+            reg.register(bad_func, name="bad_stage")  # type: ignore[arg-type]
+```
+
+Add `registry` to the imports at the top of the test file.
+
+**Step 2: Run the test**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/core/test_stage_definition.py::TestHintResolutionExplicitFailure -v`
+Expected: PASS
+
+---
+
+## Task 8: Quality checks and final validation
+
+**Step 1: Run formatter and linter**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run ruff format . && uv run ruff check .`
+Expected: PASS
+
+**Step 2: Run type checker**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run basedpyright`
+Expected: PASS (fix any type issues found)
+
+**Step 3: Run full test suite**
+
+Run: `cd /home/sami/pivot/roadmap-380 && uv run pytest tests/ -n auto --timeout=120`
+Expected: ALL PASS
+
+---
+
+## Summary of Changes
+
+| File | Change |
+|------|--------|
+| `src/pivot/stage_def.py` | Add `StageDefinition` dataclass + `extract_stage_definition()` function. Delegate existing public functions. |
+| `src/pivot/pipeline/pipeline.py` | `register()` calls `extract_stage_definition()` once, passes result to Registry. |
+| `src/pivot/registry.py` | `register()` accepts optional `definition` param, skips re-extraction when provided. |
+| `src/pivot/pipeline/yaml.py` | `_expand_simple_stage` and `_expand_matrix` use `extract_stage_definition()` for output spec validation. |
+| `tests/core/test_stage_definition.py` | New test file for extraction, integration, and hint-failure behavior. |
+
+## Risk Areas
+
+1. **PlaceholderDep validation ordering** — `get_placeholder_dep_names` must still work without overrides (it's called before overrides are validated in Registry). The plan keeps this function's original implementation.
+
+2. **`strict=False` in delegating functions** — existing callers expect empty results on hint failure, not exceptions. The delegating wrappers use `strict=False` to preserve backward compatibility.
+
+3. **`_get_type_hints_safe` calls `get_type_hints` twice** — once with `include_extras=True` (for Annotated metadata) and once without (for params type detection). The new extraction function still needs both calls since params detection requires unwrapped types. This is still a reduction from 5+ calls to 2.

--- a/docs/plans/2026-02-07-tui-decoupling.md
+++ b/docs/plans/2026-02-07-tui-decoupling.md
@@ -1,0 +1,609 @@
+# TUI Decoupling: Remove CLI Context Dependency
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove all `pivot.cli.helpers` imports from TUI modules by passing registry lookups as explicit constructor arguments, so the TUI is no longer coupled to Click context.
+
+**Architecture:** Define a `StageDataProvider` Protocol in `tui/types.py` with two methods: `get_stage()` and `ensure_fingerprint()`. Pass a provider instance to `PivotApp`, which forwards it to `InputDiffPanel` and `OutputDiffPanel`. The CLI creates a concrete provider from the Pipeline it already holds. The TUI becomes a pure display client that receives data through explicit dependencies — no more reaching into Click context via `cli_helpers`.
+
+**Tech Stack:** Python 3.13+, Textual (existing), Protocol (typing)
+
+---
+
+## Current Coupling
+
+8 call sites in 2 TUI files reach through `cli_helpers` to the Click-context-bound Pipeline:
+
+| File | Line | Call | Purpose |
+|------|------|------|---------|
+| `run.py` | 573 | `cli_helpers.get_stage(name)` | Input snapshot for history |
+| `run.py` | 574 | `cli_helpers.get_registry().ensure_fingerprint(name)` | Input snapshot fingerprint |
+| `run.py` | 630 | `cli_helpers.get_stage(name)` | Output snapshot for history |
+| `diff_panels.py` | 432 | `cli_helpers.get_stage(name)` | InputDiffPanel load |
+| `diff_panels.py` | 439 | `cli_helpers.get_registry().ensure_fingerprint(name)` | InputDiffPanel fingerprint |
+| `diff_panels.py` | 692 | `cli_helpers.get_stage(name)` | InputDiffPanel snapshot |
+| `diff_panels.py` | 744 | `cli_helpers.get_stage(name)` | OutputDiffPanel load |
+| `diff_panels.py` | 1119 | `cli_helpers.get_stage(name)` | OutputDiffPanel snapshot |
+
+## Target State
+
+- Zero `pivot.cli.helpers` imports in `src/pivot/tui/`
+- `StageDataProvider` Protocol in `tui/types.py`
+- `PivotApp.__init__` accepts `stage_data_provider: StageDataProvider`
+- `InputDiffPanel` and `OutputDiffPanel` receive provider via constructor
+- CLI creates a `PipelineStageDataProvider` wrapper and passes it in
+
+---
+
+### Task 1: Add `StageDataProvider` Protocol to `tui/types.py`
+
+**Files:**
+- Modify: `src/pivot/tui/types.py`
+- Test: `tests/tui/test_run.py` (verify import works)
+
+**Step 1: Write the test**
+
+Add to `tests/tui/test_run.py` (new test at the bottom):
+
+```python
+def test_stage_data_provider_protocol_is_importable() -> None:
+    """StageDataProvider protocol can be imported from tui.types."""
+    from pivot.tui.types import StageDataProvider
+    assert hasattr(StageDataProvider, "get_stage")
+    assert hasattr(StageDataProvider, "ensure_fingerprint")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/tui/test_run.py::test_stage_data_provider_protocol_is_importable -xvs`
+Expected: FAIL with `ImportError`
+
+**Step 3: Add the Protocol to `tui/types.py`**
+
+Add these imports at the top of `src/pivot/tui/types.py` (after existing imports):
+
+```python
+from typing import Protocol
+```
+
+And under `TYPE_CHECKING`:
+
+```python
+if TYPE_CHECKING:
+    from pivot.registry import RegistryStageInfo
+```
+
+Then add the Protocol class after `parse_stage_name` but before `LogEntry`:
+
+```python
+class StageDataProvider(Protocol):
+    """Protocol for TUI to look up stage metadata without CLI context.
+
+    Decouples the TUI from pivot.cli.helpers by defining the two
+    operations the TUI actually needs from the registry.
+    """
+
+    def get_stage(self, name: str) -> RegistryStageInfo:
+        """Look up stage metadata by name. Raises KeyError if not found."""
+        ...
+
+    def ensure_fingerprint(self, name: str) -> dict[str, str]:
+        """Compute/return cached code fingerprint for a stage."""
+        ...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/tui/test_run.py::test_stage_data_provider_protocol_is_importable -xvs`
+Expected: PASS
+
+**Step 5: Run basedpyright**
+
+Run: `uv run basedpyright src/pivot/tui/types.py`
+Expected: 0 errors
+
+---
+
+### Task 2: Add `stage_data_provider` to `PivotApp.__init__`
+
+**Files:**
+- Modify: `src/pivot/tui/run.py`
+- Test: `tests/tui/test_run.py`
+
+**Step 1: Write the test**
+
+Add to `tests/tui/test_run.py`:
+
+```python
+def test_pivot_app_accepts_stage_data_provider() -> None:
+    """PivotApp stores stage_data_provider when passed."""
+    from pivot.tui.types import StageDataProvider
+
+    class FakeProvider:
+        def get_stage(self, name: str) -> dict:
+            return {}
+        def ensure_fingerprint(self, name: str) -> dict[str, str]:
+            return {}
+
+    provider: StageDataProvider = FakeProvider()
+    app = run_tui.PivotApp(stage_names=["s1"], stage_data_provider=provider)
+    assert app._stage_data_provider is provider
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/tui/test_run.py::test_pivot_app_accepts_stage_data_provider -xvs`
+Expected: FAIL with `TypeError` (unexpected keyword argument)
+
+**Step 3: Modify `PivotApp.__init__`**
+
+In `src/pivot/tui/run.py`:
+
+1. Add import in the existing `TYPE_CHECKING` block (or alongside the existing types import from `tui.types`):
+
+```python
+from pivot.tui.types import StageDataProvider
+```
+
+(Add `StageDataProvider` to the existing import line: `from pivot.tui.types import ExecutionHistoryEntry, LogEntry, PendingHistoryState, StageDataProvider, StageInfo`)
+
+2. Add `stage_data_provider` parameter to `__init__`:
+
+In the `__init__` signature (after `serve: bool = False`), add:
+```python
+stage_data_provider: StageDataProvider | None = None,
+```
+
+3. Store it in the body (after `self._quit_lock`):
+```python
+self._stage_data_provider: StageDataProvider | None = stage_data_provider
+```
+
+4. Add the instance attribute annotation at the class level (near `_cancel_event`):
+```python
+_stage_data_provider: StageDataProvider | None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/tui/test_run.py::test_pivot_app_accepts_stage_data_provider -xvs`
+Expected: PASS
+
+**Step 5: Run basedpyright**
+
+Run: `uv run basedpyright src/pivot/tui/run.py`
+Expected: 0 errors
+
+---
+
+### Task 3: Wire `stage_data_provider` into `run.py` history methods
+
+**Files:**
+- Modify: `src/pivot/tui/run.py` (lines 569-650)
+- Test: `tests/tui/test_run.py`
+
+This task replaces the 3 `cli_helpers` calls in `run.py` with `self._stage_data_provider`.
+
+**Step 1: Write the test**
+
+Add to `tests/tui/test_run.py`:
+
+```python
+def test_create_history_entry_uses_provider(mocker: MockerFixture) -> None:
+    """_create_history_entry uses stage_data_provider instead of cli_helpers."""
+    from pivot.tui.types import StageDataProvider
+
+    mock_provider = mocker.MagicMock(spec=StageDataProvider)
+    mock_provider.get_stage.return_value = {
+        "deps_paths": [],
+        "outs_paths": [],
+        "params": None,
+    }
+    mock_provider.ensure_fingerprint.return_value = {"func": "abc123"}
+
+    app = run_tui.PivotApp(
+        stage_names=["stage_a"],
+        watch_mode=True,
+        stage_data_provider=mock_provider,
+    )
+
+    # Mock explain to avoid real IO
+    mocker.patch("pivot.tui.run.explain.get_stage_explanation", return_value=None)
+    mocker.patch("pivot.tui.run.parameters.load_params_yaml", return_value={})
+    mocker.patch("pivot.tui.run.config.get_state_dir", return_value=pathlib.Path("/fake"))
+
+    app._create_history_entry("stage_a", "run-1")
+
+    mock_provider.get_stage.assert_called_with("stage_a")
+    mock_provider.ensure_fingerprint.assert_called_with("stage_a")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/tui/test_run.py::test_create_history_entry_uses_provider -xvs`
+Expected: FAIL (still calls `cli_helpers`)
+
+**Step 3: Replace `cli_helpers` calls in `_create_history_entry` and `_finalize_history_entry`**
+
+In `src/pivot/tui/run.py`, modify `_create_history_entry` (around line 569-592):
+
+Replace:
+```python
+        input_snapshot = None
+        try:
+            registry_info = cli_helpers.get_stage(stage_name)
+            fingerprint = cli_helpers.get_registry().ensure_fingerprint(stage_name)
+```
+
+With:
+```python
+        input_snapshot = None
+        if self._stage_data_provider is None:
+            self._pending_history[stage_name] = PendingHistoryState(
+                run_id=run_id,
+                timestamp=time.time(),
+            )
+            return
+        try:
+            registry_info = self._stage_data_provider.get_stage(stage_name)
+            fingerprint = self._stage_data_provider.ensure_fingerprint(stage_name)
+```
+
+Modify `_finalize_history_entry` (around line 628-634):
+
+Replace:
+```python
+            try:
+                registry_info = cli_helpers.get_stage(stage_name)
+```
+
+With:
+```python
+            if self._stage_data_provider is not None:
+              try:
+                registry_info = self._stage_data_provider.get_stage(stage_name)
+```
+
+(And adjust the indentation of the subsequent `state_dir`, `stages_dir`, `lock_data`, `output_snapshot` lines to be inside this new `if` block. If `_stage_data_provider` is None, `output_snapshot` stays None.)
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/tui/test_run.py::test_create_history_entry_uses_provider -xvs`
+Expected: PASS
+
+**Step 5: Run full TUI tests**
+
+Run: `uv run pytest tests/tui/ -x --tb=short`
+Expected: All pass (existing tests don't pass a provider, so `_stage_data_provider` is None and history capture gracefully degrades)
+
+---
+
+### Task 4: Add `stage_data_provider` to diff panels
+
+**Files:**
+- Modify: `src/pivot/tui/diff_panels.py`
+- Test: `tests/tui/test_diff_panels.py`
+
+This task replaces the 5 `cli_helpers` calls in `diff_panels.py`.
+
+**Step 1: Write the test**
+
+Add to `tests/tui/test_diff_panels.py`:
+
+```python
+def test_input_panel_load_uses_provider(mocker: MockerFixture) -> None:
+    """InputDiffPanel._load_stage_data uses provider instead of cli_helpers."""
+    from pivot.tui.types import StageDataProvider
+
+    mock_provider = mocker.MagicMock(spec=StageDataProvider)
+    mock_provider.get_stage.return_value = {
+        "deps_paths": [],
+        "outs_paths": [],
+        "params": None,
+    }
+    mock_provider.ensure_fingerprint.return_value = {"func": "abc"}
+
+    panel = diff_panels.InputDiffPanel(stage_data_provider=mock_provider)
+
+    # Mock explain to avoid real IO
+    mocker.patch("pivot.tui.diff_panels.explain.get_stage_explanation", return_value=None)
+    mocker.patch("pivot.tui.diff_panels.parameters.load_params_yaml", return_value={})
+    mocker.patch("pivot.tui.diff_panels.config.get_state_dir", return_value=pathlib.Path("/fake"))
+
+    panel._load_stage_data("my_stage")
+
+    mock_provider.get_stage.assert_called_with("my_stage")
+    mock_provider.ensure_fingerprint.assert_called_with("my_stage")
+
+
+def test_output_panel_load_uses_provider(mocker: MockerFixture) -> None:
+    """OutputDiffPanel._load_stage_data uses provider instead of cli_helpers."""
+    from pivot.tui.types import StageDataProvider
+
+    mock_provider = mocker.MagicMock(spec=StageDataProvider)
+    mock_provider.get_stage.return_value = {
+        "deps_paths": [],
+        "outs_paths": [],
+        "outs": [],
+        "params": None,
+    }
+
+    panel = diff_panels.OutputDiffPanel(stage_data_provider=mock_provider)
+
+    mocker.patch("pivot.tui.diff_panels.config.get_state_dir", return_value=pathlib.Path("/fake"))
+    mocker.patch("pivot.tui.diff_panels.lock.StageLock")
+
+    panel._load_stage_data("my_stage")
+
+    mock_provider.get_stage.assert_called_with("my_stage")
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/tui/test_diff_panels.py::test_input_panel_load_uses_provider tests/tui/test_diff_panels.py::test_output_panel_load_uses_provider -xvs`
+Expected: FAIL (no `stage_data_provider` parameter)
+
+**Step 3: Add `stage_data_provider` to diff panels**
+
+In `src/pivot/tui/diff_panels.py`:
+
+1. Add import (add `StageDataProvider` to existing import from `pivot.tui.types` — there's currently no import from `tui.types`, so add it under the existing TYPE_CHECKING block or as a runtime import):
+
+Under `TYPE_CHECKING`:
+```python
+from pivot.tui.types import StageDataProvider
+```
+
+2. Modify `InputDiffPanel.__init__`:
+
+Add parameter:
+```python
+def __init__(self, *, id: str | None = None, classes: str | None = None, stage_data_provider: StageDataProvider | None = None) -> None:
+```
+
+Store it:
+```python
+self._stage_data_provider: StageDataProvider | None = stage_data_provider
+```
+
+Add class-level annotation:
+```python
+_stage_data_provider: StageDataProvider | None
+```
+
+3. Replace `cli_helpers` calls in `InputDiffPanel._load_stage_data` (line 429-451):
+
+Replace `cli_helpers.get_stage(stage_name)` with:
+```python
+if self._stage_data_provider is None:
+    return
+self._registry_info = self._stage_data_provider.get_stage(stage_name)
+```
+
+Replace `cli_helpers.get_registry().ensure_fingerprint(stage_name)` with:
+```python
+fingerprint = self._stage_data_provider.ensure_fingerprint(stage_name)
+```
+
+4. Replace `cli_helpers.get_stage` in `InputDiffPanel.set_from_snapshot` (line 692):
+
+Replace:
+```python
+self._registry_info = cli_helpers.get_stage(snapshot["stage_name"])
+```
+With:
+```python
+if self._stage_data_provider is not None:
+    try:
+        self._registry_info = self._stage_data_provider.get_stage(snapshot["stage_name"])
+    except KeyError:
+        self._registry_info = None
+```
+
+5. Do the same for `OutputDiffPanel`:
+
+Add `stage_data_provider` to `__init__`, store it, add class annotation.
+
+Replace `cli_helpers.get_stage` in `_load_stage_data` (line 744) and `set_from_snapshot` (line 1119).
+
+6. Remove the import: `from pivot.cli import helpers as cli_helpers` from `diff_panels.py`.
+
+**Step 4: Run tests**
+
+Run: `uv run pytest tests/tui/test_diff_panels.py -x --tb=short`
+Expected: All pass
+
+**Step 5: Run basedpyright**
+
+Run: `uv run basedpyright src/pivot/tui/diff_panels.py`
+Expected: 0 errors
+
+---
+
+### Task 5: Wire provider through `PivotApp` to diff panels
+
+**Files:**
+- Modify: `src/pivot/tui/run.py` (the `_update_history_view` and `compose` or panel creation)
+- Modify: `src/pivot/tui/widgets/panels.py` (TabbedDetailPanel creates InputDiffPanel/OutputDiffPanel)
+
+The diff panels are created inside `TabbedDetailPanel.compose()`. We need to pass `stage_data_provider` through.
+
+**Step 1: Find where panels are created**
+
+Read `src/pivot/tui/widgets/panels.py` to find `TabbedDetailPanel.compose()` and how it creates `InputDiffPanel` and `OutputDiffPanel`.
+
+**Step 2: Add `stage_data_provider` to `TabbedDetailPanel.__init__`**
+
+Pass it through to `InputDiffPanel(stage_data_provider=...)` and `OutputDiffPanel(stage_data_provider=...)` in `compose()`.
+
+**Step 3: Pass it from `PivotApp.compose()`**
+
+In `PivotApp.compose()`, pass `stage_data_provider=self._stage_data_provider` when creating `TabbedDetailPanel`.
+
+**Step 4: Run full TUI tests**
+
+Run: `uv run pytest tests/tui/ -x --tb=short`
+Expected: All pass
+
+---
+
+### Task 6: Remove `cli_helpers` import from `run.py`
+
+**Files:**
+- Modify: `src/pivot/tui/run.py`
+
+**Step 1: Remove the import line**
+
+Remove: `from pivot.cli import helpers as cli_helpers`
+
+**Step 2: Verify no remaining references**
+
+Run: `uv run basedpyright src/pivot/tui/run.py`
+Expected: 0 errors
+
+Run: `grep -r "cli_helpers" src/pivot/tui/`
+Expected: No matches
+
+**Step 3: Run full test suite**
+
+Run: `uv run pytest tests/ -n auto --tb=short -q`
+Expected: All pass
+
+---
+
+### Task 7: Update CLI callers to pass provider
+
+**Files:**
+- Modify: `src/pivot/cli/run.py` (line ~103)
+- Modify: `src/pivot/cli/repro.py` (lines ~381, ~614)
+
+The CLI already has the Pipeline. Create a simple wrapper and pass it.
+
+**Step 1: Create `PipelineStageDataProvider` in CLI**
+
+In each CLI file that creates `PivotApp`, create the provider from the pipeline. Since this is a simple 2-method wrapper, don't create a separate module — just define it inline or in `cli/helpers.py`.
+
+Actually, simplest approach: add a factory function to `cli/helpers.py`:
+
+```python
+def make_stage_data_provider(pipeline: Pipeline) -> StageDataProvider:
+    """Create a StageDataProvider from a Pipeline for TUI use."""
+    class _Provider:
+        def get_stage(self, name: str) -> RegistryStageInfo:
+            return pipeline.get(name)
+        def ensure_fingerprint(self, name: str) -> dict[str, str]:
+            return pipeline._registry.ensure_fingerprint(name)
+    return _Provider()
+```
+
+Wait — that keeps the import in `cli/helpers.py`, which is fine since `cli/helpers.py` IS the CLI layer. But actually, `Pipeline` itself already has `get()` and access to `_registry`. The simplest approach is to make `Pipeline` satisfy the `StageDataProvider` protocol directly by adding an `ensure_fingerprint` method.
+
+**Actually, the cleanest approach:** Pipeline already has `get(name)` which returns `RegistryStageInfo`. It just needs `ensure_fingerprint(name)`. Let's add it.
+
+In `src/pivot/pipeline/pipeline.py`, add a public method:
+
+```python
+def ensure_fingerprint(self, stage_name: str) -> dict[str, str]:
+    """Compute/return cached code fingerprint for a stage."""
+    return self._registry.ensure_fingerprint(stage_name)
+```
+
+Then `Pipeline` structurally satisfies `StageDataProvider` (it has `get()` but we need `get_stage()` — ah, Pipeline uses `get()` not `get_stage()`).
+
+Two options:
+1. Name the Protocol method `get()` instead of `get_stage()` — but `get` is generic.
+2. Add a `get_stage()` alias to Pipeline.
+3. Use a simple lambda adapter in the CLI.
+
+**Best approach: Name the Protocol methods to match Pipeline's existing API.** Pipeline has:
+- `get(name) -> RegistryStageInfo`
+- (need to add) `ensure_fingerprint(name) -> dict[str, str]`
+
+So define the Protocol as:
+```python
+class StageDataProvider(Protocol):
+    def get(self, name: str) -> RegistryStageInfo: ...
+    def ensure_fingerprint(self, name: str) -> dict[str, str]: ...
+```
+
+Wait — but then all 8 call sites in the TUI use `provider.get(name)` which looks like `dict.get()`. That's confusing. Let's keep `get_stage` in the Protocol and add a one-line `get_stage` to Pipeline (it just delegates to `get`).
+
+**Revised approach in Task 1:** The Protocol uses `get_stage()`. In this task, add `get_stage()` and `ensure_fingerprint()` to Pipeline, so Pipeline structurally satisfies the protocol.
+
+**Step 1: Add methods to Pipeline**
+
+In `src/pivot/pipeline/pipeline.py`, add:
+
+```python
+def get_stage(self, name: str) -> RegistryStageInfo:
+    """Get stage info by name. Alias for get() to satisfy StageDataProvider."""
+    return self.get(name)
+
+def ensure_fingerprint(self, stage_name: str) -> dict[str, str]:
+    """Compute/return cached code fingerprint for a stage."""
+    return self._registry.ensure_fingerprint(stage_name)
+```
+
+**Step 2: Update CLI callers to pass pipeline as provider**
+
+In `src/pivot/cli/run.py` (around line 100-107):
+
+```python
+pipeline = cli_decorators.get_pipeline_from_context()
+
+app = tui_run.PivotApp(
+    stage_names=stages_list,
+    tui_log=tui_log,
+    cancel_event=cancel_event,
+    stage_data_provider=pipeline,
+)
+```
+
+In `src/pivot/cli/repro.py` (around line 381):
+
+```python
+app = tui_run.PivotApp(
+    stage_names=display_order,
+    tui_log=tui_log,
+    watch_mode=True,
+    no_commit=no_commit,
+    serve=serve,
+    stage_data_provider=pipeline,
+)
+```
+
+(And the other `PivotApp()` call in repro.py around line 614.)
+
+**Step 3: Run basedpyright on all modified files**
+
+Run: `uv run basedpyright src/pivot/pipeline/pipeline.py src/pivot/cli/run.py src/pivot/cli/repro.py`
+Expected: 0 errors
+
+**Step 4: Run full test suite**
+
+Run: `uv run pytest tests/ -n auto --tb=short -q`
+Expected: All pass
+
+---
+
+### Task 8: Verify zero `cli_helpers` imports in TUI and run quality checks
+
+**Step 1: Verify no TUI-to-CLI coupling remains**
+
+Run: `grep -r "from pivot.cli" src/pivot/tui/`
+Expected: No output
+
+Run: `grep -r "cli_helpers" src/pivot/tui/`
+Expected: No output
+
+**Step 2: Full quality checks**
+
+Run: `uv run ruff format .`
+Run: `uv run ruff check .`
+Run: `uv run basedpyright`
+Expected: 0 errors, 0 warnings
+
+**Step 3: Full test suite**
+
+Run: `uv run pytest tests/ -n auto --tb=short -q`
+Expected: All pass

--- a/src/pivot/cli/dag.py
+++ b/src/pivot/cli/dag.py
@@ -123,17 +123,20 @@ def dag_cmd(
             raise click.ClickException(msg)
         bipartite_graph = _get_upstream_subgraph(bipartite_graph, stage_names)
 
+    # Extract view for rendering
+    view = engine_graph.extract_graph_view(bipartite_graph)
+
     # Render the graph
     match output_format:
         case "dot":
-            output = dag.render_dot(bipartite_graph, stages=show_stages)
+            output = dag.render_dot(view, stages=show_stages)
         case "mermaid":
-            output = dag.render_mermaid(bipartite_graph, stages=show_stages)
+            output = dag.render_mermaid(view, stages=show_stages)
         case "md":
-            mermaid = dag.render_mermaid(bipartite_graph, stages=show_stages)
+            mermaid = dag.render_mermaid(view, stages=show_stages)
             output = f"```mermaid\n{mermaid}\n```"
         case _:
             # Default: ASCII
-            output = dag.render_ascii(bipartite_graph, stages=show_stages)
+            output = dag.render_ascii(view, stages=show_stages)
 
     click.echo(output)

--- a/src/pivot/cli/repro.py
+++ b/src/pivot/cli/repro.py
@@ -371,6 +371,7 @@ def _run_watch_mode(  # noqa: PLR0913 - many params needed for different modes
             watch_mode=True,
             no_commit=no_commit,
             serve=serve,
+            stage_data_provider=pipeline,
         )
 
         def engine_thread_target() -> None:
@@ -597,6 +598,7 @@ def _run_oneshot_mode(
             stage_names=display_order,
             tui_log=tui_log,
             cancel_event=cancel_event,
+            stage_data_provider=pipeline,
         )
 
         # Use Future for thread-safe result passing

--- a/src/pivot/cli/run.py
+++ b/src/pivot/cli/run.py
@@ -100,6 +100,7 @@ def _run_with_tui(
         stage_names=stages_list,
         tui_log=tui_log,
         cancel_event=cancel_event,
+        stage_data_provider=pipeline,
     )
 
     # Use Future for thread-safe result passing

--- a/src/pivot/tui/types.py
+++ b/src/pivot/tui/types.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import collections
 import dataclasses
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from pivot.types import OutputChange, StageExplanation, StageStatus
+
+if TYPE_CHECKING:
+    from pivot.registry import RegistryStageInfo
 
 
 def parse_stage_name(name: str) -> tuple[str, str]:
@@ -13,6 +16,22 @@ def parse_stage_name(name: str) -> tuple[str, str]:
         base, variant = name.split("@", 1)
         return (base, variant)
     return (name, "")
+
+
+class StageDataProvider(Protocol):
+    """Protocol for TUI to look up stage metadata without CLI context.
+
+    Decouples the TUI from pivot.cli.helpers by defining the two
+    operations the TUI actually needs from the registry.
+    """
+
+    def get_stage(self, name: str) -> RegistryStageInfo:
+        """Look up stage metadata by name. Raises KeyError if not found."""
+        ...
+
+    def ensure_fingerprint(self, name: str) -> dict[str, str]:
+        """Compute/return cached code fingerprint for a stage."""
+        ...
 
 
 class LogEntry(NamedTuple):

--- a/src/pivot/types.py
+++ b/src/pivot/types.py
@@ -572,16 +572,6 @@ def is_tui_log_message(msg: TuiMessage) -> TypeGuard[TuiLogMessage]:
     return msg is not None and msg["type"] == TuiMessageType.LOG
 
 
-def is_tui_watch_message(msg: TuiMessage) -> TypeGuard[TuiWatchMessage]:
-    """TypeGuard to narrow TuiMessage to TuiWatchMessage."""
-    return msg is not None and msg["type"] == TuiMessageType.WATCH
-
-
-def is_tui_reload_message(msg: TuiMessage) -> TypeGuard[TuiReloadMessage]:
-    """TypeGuard to narrow TuiMessage to TuiReloadMessage."""
-    return msg is not None and msg["type"] == TuiMessageType.RELOAD
-
-
 # =============================================================================
 # Watch Mode JSONL Events (--json output)
 # =============================================================================
@@ -822,7 +812,7 @@ class AgentStagesResult(TypedDict):
 #
 # Note: The constraint "TypedDict where all fields have Out annotations" cannot
 # be expressed in Python's type system. Validation is performed at registration
-# time in stage_def.get_output_specs_from_return().
+# time in stage_def.extract_stage_definition().
 #
 
 # Return type for stage functions. The actual constraint is validated at

--- a/tests/core/test_dag_render.py
+++ b/tests/core/test_dag_render.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING
 
 from pivot import dag, loaders, outputs
 from pivot.engine import graph as engine_graph
 from pivot.registry import RegistryStageInfo
-
-if TYPE_CHECKING:
-    import networkx as nx
-
 
 # =============================================================================
 # Helper functions for building test stages
@@ -47,11 +42,6 @@ def _create_stage(
     )
 
 
-def _build_graph(stages_dict: dict[str, RegistryStageInfo]) -> nx.DiGraph[str]:
-    """Build bipartite graph from stages dict."""
-    return engine_graph.build_graph(stages_dict)
-
-
 # =============================================================================
 # Empty pipeline tests
 # =============================================================================
@@ -59,43 +49,49 @@ def _build_graph(stages_dict: dict[str, RegistryStageInfo]) -> nx.DiGraph[str]:
 
 def test_render_ascii_empty_graph() -> None:
     """Empty graph returns placeholder text."""
-    g = _build_graph({})
-    result = dag.render_ascii(g)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_ascii(view)
     assert result == "(empty graph)"
 
 
 def test_render_ascii_empty_graph_stages() -> None:
     """Empty graph with stages=True returns placeholder text."""
-    g = _build_graph({})
-    result = dag.render_ascii(g, stages=True)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_ascii(view, stages=True)
     assert result == "(empty graph)"
 
 
 def test_render_mermaid_empty_graph() -> None:
     """Empty graph returns valid empty Mermaid flowchart."""
-    g = _build_graph({})
-    result = dag.render_mermaid(g)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_mermaid(view)
     assert result == "flowchart TD"
 
 
 def test_render_mermaid_empty_graph_stages() -> None:
     """Empty graph with stages=True returns valid empty Mermaid flowchart."""
-    g = _build_graph({})
-    result = dag.render_mermaid(g, stages=True)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_mermaid(view, stages=True)
     assert result == "flowchart TD"
 
 
 def test_render_dot_empty_graph() -> None:
     """Empty graph returns minimal DOT."""
-    g = _build_graph({})
-    result = dag.render_dot(g)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_dot(view)
     assert result == "digraph {\n}"
 
 
 def test_render_dot_empty_graph_stages() -> None:
     """Empty graph with stages=True returns minimal DOT."""
-    g = _build_graph({})
-    result = dag.render_dot(g, stages=True)
+    bipartite = engine_graph.build_graph({})
+    view = engine_graph.extract_graph_view(bipartite)
+    result = dag.render_dot(view, stages=True)
     assert result == "digraph {\n}"
 
 
@@ -107,9 +103,10 @@ def test_render_dot_empty_graph_stages() -> None:
 def test_render_ascii_single_stage_artifact_view() -> None:
     """Single stage shows output artifact in artifact view."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=False)
+    result = dag.render_ascii(view, stages=False)
 
     # Should contain the artifact path
     assert "data.csv" in result
@@ -121,9 +118,10 @@ def test_render_ascii_single_stage_artifact_view() -> None:
 def test_render_ascii_single_stage_stage_view() -> None:
     """Single stage shows stage name in stage view."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     # Should contain the stage name
     assert "load" in result
@@ -135,9 +133,10 @@ def test_render_ascii_single_stage_stage_view() -> None:
 def test_render_mermaid_single_stage_artifact_view() -> None:
     """Single stage shows artifact in Mermaid."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=False)
+    result = dag.render_mermaid(view, stages=False)
 
     assert "flowchart TD" in result
     assert "data.csv" in result
@@ -146,9 +145,10 @@ def test_render_mermaid_single_stage_artifact_view() -> None:
 def test_render_mermaid_single_stage_stage_view() -> None:
     """Single stage shows stage name in Mermaid."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     assert "flowchart TD" in result
     assert "load" in result
@@ -157,9 +157,10 @@ def test_render_mermaid_single_stage_stage_view() -> None:
 def test_render_dot_single_stage_artifact_view() -> None:
     """Single stage shows artifact in DOT."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=False)
+    result = dag.render_dot(view, stages=False)
 
     assert "digraph {" in result
     assert "data.csv" in result
@@ -169,9 +170,10 @@ def test_render_dot_single_stage_artifact_view() -> None:
 def test_render_dot_single_stage_stage_view() -> None:
     """Single stage shows stage name in DOT."""
     stages = {"load": _create_stage("load", [], ["data.csv"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     assert "digraph {" in result
     assert "load" in result
@@ -190,9 +192,10 @@ def test_render_ascii_linear_chain_artifact_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=False)
+    result = dag.render_ascii(view, stages=False)
 
     # Should contain all artifacts
     assert "raw.csv" in result
@@ -207,9 +210,10 @@ def test_render_ascii_linear_chain_stage_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     # Should contain all stages
     assert "extract" in result
@@ -224,9 +228,10 @@ def test_render_mermaid_linear_chain_artifact_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=False)
+    result = dag.render_mermaid(view, stages=False)
 
     # Should have flowchart and edges
     assert "flowchart TD" in result
@@ -244,9 +249,10 @@ def test_render_mermaid_linear_chain_stage_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     # Should have flowchart and edges
     assert "flowchart TD" in result
@@ -264,9 +270,10 @@ def test_render_dot_linear_chain_artifact_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=False)
+    result = dag.render_dot(view, stages=False)
 
     # Should have edges
     assert "->" in result
@@ -283,9 +290,10 @@ def test_render_dot_linear_chain_stage_view() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     # Should have edges
     assert "->" in result
@@ -308,9 +316,10 @@ def test_render_ascii_diamond_pattern_artifact_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=False)
+    result = dag.render_ascii(view, stages=False)
 
     # Should contain all artifacts
     assert "data.csv" in result
@@ -327,9 +336,10 @@ def test_render_ascii_diamond_pattern_stage_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     # Should contain all stages
     assert "source" in result
@@ -346,9 +356,10 @@ def test_render_mermaid_diamond_pattern_artifact_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=False)
+    result = dag.render_mermaid(view, stages=False)
 
     # Should have all artifacts
     assert "data.csv" in result
@@ -367,9 +378,10 @@ def test_render_mermaid_diamond_pattern_stage_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     # Should have all stages
     assert "source" in result
@@ -388,9 +400,10 @@ def test_render_dot_diamond_pattern_artifact_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=False)
+    result = dag.render_dot(view, stages=False)
 
     # Should have all artifacts
     assert "data.csv" in result
@@ -409,9 +422,10 @@ def test_render_dot_diamond_pattern_stage_view() -> None:
         "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
         "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     # Should have all stages
     assert "source" in result
@@ -430,9 +444,10 @@ def test_render_dot_diamond_pattern_stage_view() -> None:
 def test_render_ascii_stage_no_deps() -> None:
     """Stage with no deps renders as isolated box."""
     stages = {"generate": _create_stage("generate", [], ["output.txt"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     assert "generate" in result
     assert "+" in result
@@ -441,9 +456,10 @@ def test_render_ascii_stage_no_deps() -> None:
 def test_render_mermaid_stage_no_deps() -> None:
     """Stage with no deps renders as isolated node in Mermaid."""
     stages = {"generate": _create_stage("generate", [], ["output.txt"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     assert "generate" in result
     # No edges expected
@@ -453,9 +469,10 @@ def test_render_mermaid_stage_no_deps() -> None:
 def test_render_dot_stage_no_deps() -> None:
     """Stage with no deps renders as isolated node in DOT."""
     stages = {"generate": _create_stage("generate", [], ["output.txt"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     assert "generate" in result
     # Isolated node, no edges
@@ -473,9 +490,10 @@ def test_render_ascii_disconnected_components() -> None:
         "task_a": _create_stage("task_a", [], ["a.txt"]),
         "task_b": _create_stage("task_b", [], ["b.txt"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     # Both stages should appear
     assert "task_a" in result
@@ -488,9 +506,10 @@ def test_render_mermaid_disconnected_components() -> None:
         "task_a": _create_stage("task_a", [], ["a.txt"]),
         "task_b": _create_stage("task_b", [], ["b.txt"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     assert "task_a" in result
     assert "task_b" in result
@@ -504,9 +523,10 @@ def test_render_dot_disconnected_components() -> None:
         "task_a": _create_stage("task_a", [], ["a.txt"]),
         "task_b": _create_stage("task_b", [], ["b.txt"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     assert "task_a" in result
     assert "task_b" in result
@@ -522,9 +542,10 @@ def test_render_dot_disconnected_components() -> None:
 def test_render_mermaid_escapes_quotes_in_labels() -> None:
     """Mermaid output escapes quotes in artifact/stage labels using HTML entities."""
     stages = {"stage": _create_stage("stage", [], ['file"with"quotes.txt'])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=False)
+    result = dag.render_mermaid(view, stages=False)
 
     # Quotes should be escaped as HTML entities
     assert "&quot;" in result
@@ -534,9 +555,10 @@ def test_render_mermaid_escapes_quotes_in_labels() -> None:
 def test_render_dot_escapes_quotes_in_labels() -> None:
     """DOT output escapes quotes in artifact/stage labels."""
     stages = {"stage": _create_stage("stage", [], ['file"with"quotes.txt'])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=False)
+    result = dag.render_dot(view, stages=False)
 
     # Quotes should be escaped
     assert '\\"' in result
@@ -545,9 +567,10 @@ def test_render_dot_escapes_quotes_in_labels() -> None:
 def test_render_mermaid_escapes_newlines_and_hashes() -> None:
     """Mermaid output escapes newlines and hash characters."""
     stages = {"stage": _create_stage("stage", [], ["file#v2\nwith\nnewlines.txt"])}
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=False)
+    result = dag.render_mermaid(view, stages=False)
 
     # Newlines should be replaced with spaces
     assert "\n" not in result.split('"')[1] if '"' in result else True
@@ -567,7 +590,7 @@ def test_render_ascii_subgraph() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    g = engine_graph.build_graph(stages)
 
     # Get subgraph of just extract and transform
     subgraph = g.subgraph(
@@ -578,8 +601,9 @@ def test_render_ascii_subgraph() -> None:
             engine_graph.artifact_node(pathlib.Path("clean.csv")),
         ]
     )
+    view = engine_graph.extract_graph_view(subgraph)
 
-    result = dag.render_ascii(subgraph, stages=True)
+    result = dag.render_ascii(view, stages=True)
 
     assert "extract" in result
     assert "transform" in result
@@ -594,7 +618,7 @@ def test_render_mermaid_subgraph() -> None:
         "transform": _create_stage("transform", ["raw.csv"], ["clean.csv"]),
         "load": _create_stage("load", ["clean.csv"], ["output.csv"]),
     }
-    g = _build_graph(stages)
+    g = engine_graph.build_graph(stages)
 
     # Get subgraph of just extract and transform
     subgraph = g.subgraph(
@@ -605,8 +629,9 @@ def test_render_mermaid_subgraph() -> None:
             engine_graph.artifact_node(pathlib.Path("clean.csv")),
         ]
     )
+    view = engine_graph.extract_graph_view(subgraph)
 
-    result = dag.render_mermaid(subgraph, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     assert "extract" in result
     assert "transform" in result
@@ -624,9 +649,10 @@ def test_render_mermaid_format_is_valid() -> None:
         "a": _create_stage("a", [], ["out.txt"]),
         "b": _create_stage("b", ["out.txt"], ["final.txt"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_mermaid(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
     lines = result.split("\n")
     # First line should be flowchart directive
@@ -645,9 +671,10 @@ def test_render_dot_format_is_valid() -> None:
         "a": _create_stage("a", [], ["out.txt"]),
         "b": _create_stage("b", ["out.txt"], ["final.txt"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_dot(g, stages=True)
+    result = dag.render_dot(view, stages=True)
 
     lines = result.split("\n")
     # First line should open digraph
@@ -659,18 +686,98 @@ def test_render_dot_format_is_valid() -> None:
     assert len(edge_lines) >= 1
 
 
-def test_render_ascii_wide_characters() -> None:
-    """ASCII rendering handles wide characters (CJK, emoji) correctly."""
-    # Use a CJK character which has display width 2
+# =============================================================================
+# Edge directionality verification tests
+# =============================================================================
+
+
+def test_render_mermaid_linear_chain_edge_direction() -> None:
+    """Mermaid linear chain has correct edge direction (producer -> consumer)."""
     stages = {
-        "日本語": _create_stage("日本語", [], ["output.txt"]),
+        "stage_a": _create_stage("stage_a", [], ["intermediate.csv"]),
+        "stage_b": _create_stage("stage_b", ["intermediate.csv"], ["final.csv"]),
     }
-    g = _build_graph(stages)
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
 
-    result = dag.render_ascii(g, stages=True)
+    result = dag.render_mermaid(view, stages=True)
 
-    # Should contain the label
-    assert "日本語" in result
-    # Box should be properly formed (has borders)
-    assert "+" in result
-    assert "|" in result
+    # Parse node IDs from result
+    lines = result.split("\n")
+    node_map = dict[str, str]()
+    for line in lines:
+        if "[" in line and "]" in line and "node" in line:
+            # Extract: node1["stage_a"] -> node_map["stage_a"] = "node1"
+            node_id = line.split("[")[0].strip()
+            label_start = line.index('["') + 2
+            label_end = line.index('"]')
+            label = line[label_start:label_end]
+            node_map[label] = node_id
+
+    # Verify edge direction: stage_a --> stage_b (not reversed)
+    edge_line = f"    {node_map['stage_a']}-->{node_map['stage_b']}"
+    assert edge_line in result, f"Expected edge {edge_line} in output"
+
+    # Verify NO reverse edge
+    reverse_edge = f"    {node_map['stage_b']}-->{node_map['stage_a']}"
+    assert reverse_edge not in result, f"Unexpected reverse edge {reverse_edge}"
+
+
+def test_render_dot_diamond_edge_completeness() -> None:
+    """DOT diamond has all expected edges and no extras."""
+    stages = {
+        "source": _create_stage("source", [], ["data.csv"]),
+        "branch_a": _create_stage("branch_a", ["data.csv"], ["a.csv"]),
+        "branch_b": _create_stage("branch_b", ["data.csv"], ["b.csv"]),
+        "merge": _create_stage("merge", ["a.csv", "b.csv"], ["merged.csv"]),
+    }
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
+
+    result = dag.render_dot(view, stages=True)
+
+    # Expected edges in stage view
+    expected_edges = [
+        ('"source"', '"branch_a"'),
+        ('"source"', '"branch_b"'),
+        ('"branch_a"', '"merge"'),
+        ('"branch_b"', '"merge"'),
+    ]
+
+    for src, dst in expected_edges:
+        edge_line = f"{src} -> {dst}"
+        assert edge_line in result, f"Missing edge: {edge_line}"
+
+    # Count total edges
+    edge_count = result.count(" -> ")
+    assert edge_count == 4, f"Expected 4 edges in diamond, got {edge_count}"
+
+
+def test_render_mermaid_artifact_edges_match_data_flow() -> None:
+    """Mermaid artifact view edges follow data flow (input -> output)."""
+    stages = {
+        "stage_a": _create_stage("stage_a", ["input.csv"], ["output.csv"]),
+    }
+    bipartite = engine_graph.build_graph(stages)
+    view = engine_graph.extract_graph_view(bipartite)
+
+    result = dag.render_mermaid(view, stages=False)
+
+    # Parse to find which node is input vs output
+    lines = result.split("\n")
+    node_map = dict[str, str]()
+    for line in lines:
+        if "[" in line and "]" in line and "node" in line:
+            node_id = line.split("[")[0].strip()
+            label_start = line.index('["') + 2
+            label_end = line.index('"]')
+            label = line[label_start:label_end]
+            node_map[label] = node_id
+
+    # Edge should go input.csv -> output.csv (data flow direction)
+    edge_line = f"    {node_map['input.csv']}-->{node_map['output.csv']}"
+    assert edge_line in result, f"Expected data flow edge {edge_line}"
+
+    # NOT reversed
+    reverse_edge = f"    {node_map['output.csv']}-->{node_map['input.csv']}"
+    assert reverse_edge not in result, f"Unexpected reverse edge {reverse_edge}"

--- a/tests/core/test_stage_definition.py
+++ b/tests/core/test_stage_definition.py
@@ -1,0 +1,330 @@
+# pyright: reportUnusedFunction=false, reportUnusedParameter=false
+"""Tests for StageDefinition dataclass and extract_stage_definition().
+
+Tests the single-pass extraction that replaced individual get_dep_specs_from_signature /
+get_output_specs_from_return / get_single_output_spec_from_return calls.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Annotated, TypedDict
+
+import pytest
+
+from pivot import exceptions, loaders, outputs, stage_def
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+# ==============================================================================
+# Module-level stage fixtures (required for get_type_hints resolution)
+# ==============================================================================
+
+
+class _SimpleOutput(TypedDict):
+    result: Annotated[pathlib.Path, outputs.Out("result.txt", loaders.PathOnly())]
+
+
+class _MultiOutput(TypedDict):
+    model: Annotated[pathlib.Path, outputs.Out("model.bin", loaders.PathOnly())]
+    metrics: Annotated[
+        dict[str, float], outputs.Out("metrics.json", loaders.JSON[dict[str, float]]())
+    ]
+
+
+class _IncrementalOutput(TypedDict):
+    cache: Annotated[
+        dict[str, int], outputs.IncrementalOut("cache.json", loaders.JSON[dict[str, int]]())
+    ]
+
+
+class _TestParams(stage_def.StageParams):
+    lr: float = 0.01
+
+
+def _stage_with_dep(
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_no_annotations() -> None:
+    pass
+
+
+def _stage_outputs_only() -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_with_params(
+    params: _TestParams,
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_with_placeholder(
+    data: Annotated[pathlib.Path, outputs.PlaceholderDep(loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _single_output_stage(
+    data: Annotated[pathlib.Path, outputs.Dep("input.csv", loaders.PathOnly())],
+) -> Annotated[pathlib.Path, outputs.Out("output.txt", loaders.PathOnly())]:
+    return pathlib.Path("output.txt")
+
+
+def _stage_with_incremental_input(
+    cache: Annotated[
+        dict[str, int], outputs.IncrementalOut("cache.json", loaders.JSON[dict[str, int]]())
+    ],
+) -> _IncrementalOutput:
+    return _IncrementalOutput(cache=cache or {})
+
+
+def _stage_multi_dep(
+    left: Annotated[pathlib.Path, outputs.Dep("left.csv", loaders.PathOnly())],
+    right: Annotated[pathlib.Path, outputs.Dep("right.csv", loaders.PathOnly())],
+) -> _SimpleOutput:
+    return _SimpleOutput(result=pathlib.Path("result.txt"))
+
+
+def _stage_with_multi_output() -> _MultiOutput:
+    return _MultiOutput(model=pathlib.Path("model.bin"), metrics={"acc": 0.9})
+
+
+# ==============================================================================
+# Basic extraction
+# ==============================================================================
+
+
+def test_basic_extraction_all_fields() -> None:
+    """All StageDefinition fields are populated correctly for a dep+output stage."""
+    defn = stage_def.extract_stage_definition(_stage_with_dep, "test_stage")
+    assert defn.hints_resolved is True
+    assert "data" in defn.dep_specs
+    assert defn.dep_specs["data"].path == "input.csv"
+    assert defn.dep_specs["data"].creates_dep_edge is True
+    assert "result" in defn.out_specs
+    assert defn.out_specs["result"].path == "result.txt"
+    assert defn.single_out_spec is None
+    assert defn.params_arg_name is None
+    assert defn.params_type is None
+    assert defn.placeholder_dep_names == frozenset()
+
+
+def test_no_annotations() -> None:
+    """Empty function yields empty definition with hints_resolved=True."""
+    defn = stage_def.extract_stage_definition(_stage_no_annotations, "bare")
+    assert defn.hints_resolved is True
+    assert defn.dep_specs == {}
+    assert defn.out_specs == {}
+    assert defn.single_out_spec is None
+    assert defn.placeholder_dep_names == frozenset()
+
+
+def test_outputs_only_no_deps() -> None:
+    """Stage with only return outputs and no input deps."""
+    defn = stage_def.extract_stage_definition(_stage_outputs_only, "out_only")
+    assert defn.dep_specs == {}
+    assert "result" in defn.out_specs
+    assert defn.out_specs["result"].path == "result.txt"
+
+
+def test_multi_output_extraction() -> None:
+    """Multiple TypedDict output fields are all extracted."""
+    defn = stage_def.extract_stage_definition(_stage_with_multi_output, "multi_out")
+    assert len(defn.out_specs) == 2
+    assert defn.out_specs["model"].path == "model.bin"
+    assert defn.out_specs["metrics"].path == "metrics.json"
+
+
+def test_multi_dep_extraction() -> None:
+    """Multiple input deps are all extracted."""
+    defn = stage_def.extract_stage_definition(_stage_multi_dep, "multi_dep")
+    assert len(defn.dep_specs) == 2
+    assert defn.dep_specs["left"].path == "left.csv"
+    assert defn.dep_specs["right"].path == "right.csv"
+
+
+# ==============================================================================
+# Params extraction
+# ==============================================================================
+
+
+def test_params_extraction() -> None:
+    """StageParams subclass is detected with name and type."""
+    defn = stage_def.extract_stage_definition(_stage_with_params, "with_params")
+    assert defn.params_arg_name == "params"
+    assert defn.params_type is _TestParams
+
+
+def test_params_not_detected_without_stage_params() -> None:
+    """Regular (non-StageParams) parameters are not detected as params."""
+    defn = stage_def.extract_stage_definition(_stage_with_dep, "no_params")
+    assert defn.params_arg_name is None
+    assert defn.params_type is None
+
+
+# ==============================================================================
+# Single output (non-TypedDict)
+# ==============================================================================
+
+
+def test_single_output_extraction() -> None:
+    """Annotated return type with Out produces single_out_spec, not out_specs."""
+    defn = stage_def.extract_stage_definition(_single_output_stage, "single")
+    assert defn.out_specs == {}
+    assert defn.single_out_spec is not None
+    assert defn.single_out_spec.path == "output.txt"
+
+
+# ==============================================================================
+# PlaceholderDep
+# ==============================================================================
+
+
+def test_placeholder_with_override_resolves() -> None:
+    """PlaceholderDep with override is included in dep_specs and placeholder_dep_names."""
+    defn = stage_def.extract_stage_definition(
+        _stage_with_placeholder,
+        "placeholder",
+        dep_path_overrides={"data": "override.csv"},
+    )
+    assert "data" in defn.placeholder_dep_names
+    assert defn.dep_specs["data"].path == "override.csv"
+
+
+def test_placeholder_without_override_records_name() -> None:
+    """PlaceholderDep without override records name but does not add to dep_specs."""
+    defn = stage_def.extract_stage_definition(_stage_with_placeholder, "placeholder")
+    assert "data" in defn.placeholder_dep_names
+    assert "data" not in defn.dep_specs
+
+
+def test_placeholder_empty_string_override_raises() -> None:
+    """PlaceholderDep with empty string override raises ValueError."""
+    with pytest.raises(ValueError, match="override cannot be empty"):
+        stage_def.extract_stage_definition(
+            _stage_with_placeholder,
+            "placeholder",
+            dep_path_overrides={"data": ""},
+        )
+
+
+def test_placeholder_empty_list_override_raises() -> None:
+    """PlaceholderDep with empty list override raises ValueError."""
+    with pytest.raises(ValueError, match="override contains empty path"):
+        stage_def.extract_stage_definition(
+            _stage_with_placeholder,
+            "placeholder",
+            dep_path_overrides={"data": []},
+        )
+
+
+# ==============================================================================
+# Dep path overrides (regular Dep)
+# ==============================================================================
+
+
+def test_regular_dep_override() -> None:
+    """Regular Dep uses overridden path when dep_path_overrides provides one."""
+    defn = stage_def.extract_stage_definition(
+        _stage_with_dep,
+        "overridden",
+        dep_path_overrides={"data": "custom/path.csv"},
+    )
+    assert defn.dep_specs["data"].path == "custom/path.csv"
+
+
+# ==============================================================================
+# IncrementalOut as input
+# ==============================================================================
+
+
+def test_incremental_out_input_creates_dep_edge_false() -> None:
+    """IncrementalOut used as input parameter has creates_dep_edge=False."""
+    defn = stage_def.extract_stage_definition(_stage_with_incremental_input, "inc_stage")
+    assert "cache" in defn.dep_specs
+    assert defn.dep_specs["cache"].creates_dep_edge is False
+    assert defn.dep_specs["cache"].path == "cache.json"
+
+
+def test_incremental_out_output_is_in_out_specs() -> None:
+    """IncrementalOut is extracted from TypedDict return as out_spec."""
+    defn = stage_def.extract_stage_definition(_stage_with_incremental_input, "inc_stage")
+    assert "cache" in defn.out_specs
+    assert isinstance(defn.out_specs["cache"], outputs.IncrementalOut)
+
+
+# ==============================================================================
+# Strict / lenient hint resolution
+# ==============================================================================
+
+
+def _make_unresolvable_func() -> object:
+    """Create a function with unresolvable type hints via exec."""
+    ns: dict[str, object] = {}
+    exec(  # noqa: S102
+        "def bad_func(x: 'UnresolvableType') -> None: pass\n",
+        ns,
+    )
+    return ns["bad_func"]
+
+
+def test_strict_raises_on_unresolvable_hints() -> None:
+    """strict=True (default) raises StageDefinitionError for bad hints."""
+    bad_func = _make_unresolvable_func()
+    with pytest.raises(exceptions.StageDefinitionError, match="resolve type hints"):
+        stage_def.extract_stage_definition(bad_func, "bad_stage")  # pyright: ignore[reportArgumentType]
+
+
+def test_lenient_returns_hints_resolved_false() -> None:
+    """strict=False returns definition with hints_resolved=False and empty specs."""
+    bad_func = _make_unresolvable_func()
+    defn = stage_def.extract_stage_definition(bad_func, "bad_stage", strict=False)  # pyright: ignore[reportArgumentType]
+    assert defn.hints_resolved is False
+    assert defn.dep_specs == {}
+    assert defn.out_specs == {}
+    assert defn.single_out_spec is None
+    assert defn.placeholder_dep_names == frozenset()
+    assert defn.params_arg_name is None
+    assert defn.params_type is None
+
+
+# ==============================================================================
+# Pipeline integration
+# ==============================================================================
+
+
+def test_pipeline_register_calls_extract_once(
+    set_project_root: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Pipeline.register should call extract_stage_definition exactly once."""
+    from pivot.pipeline.pipeline import Pipeline
+
+    spy = mocker.spy(stage_def, "extract_stage_definition")
+    p = Pipeline("test", root=set_project_root)
+    p.register(_stage_with_dep, name="stage-with-dep")
+    spy.assert_called_once()
+
+
+def test_pipeline_definition_passed_to_registry(
+    set_project_root: pathlib.Path, mocker: MockerFixture
+) -> None:
+    """Pipeline passes its pre-extracted definition to registry.register."""
+    from pivot import registry
+    from pivot.pipeline.pipeline import Pipeline
+
+    spy = mocker.spy(registry.StageRegistry, "register")
+    p = Pipeline("test", root=set_project_root)
+    p.register(_stage_with_dep, name="stage-with-dep")
+
+    # Registry.register was called with a definition kwarg
+    _, kwargs = spy.call_args
+    assert "definition" in kwargs, "Pipeline should pass definition to registry"
+    assert isinstance(kwargs["definition"], stage_def.StageDefinition)
+    assert kwargs["definition"].hints_resolved is True

--- a/tests/execution/test_executor_worker.py
+++ b/tests/execution/test_executor_worker.py
@@ -1586,9 +1586,10 @@ def test_single_annotated_return_saves_output(
     Regression test for GitHub issue #233.
     """
     # Get the output spec from the single annotated return type
-    single_out_spec = stage_def.get_single_output_spec_from_return(
-        _stage_with_single_annotated_return
-    )
+    single_out_spec = stage_def.extract_stage_definition(
+        _stage_with_single_annotated_return,
+        _stage_with_single_annotated_return.__name__,
+    ).single_out_spec
     assert single_out_spec is not None, "Should have single output spec"
 
     stage_info = _make_stage_info(
@@ -1888,7 +1889,7 @@ def test_directory_out_first_run_writes_files(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """DirectoryOut stage writes all files on first run."""
-    out_specs = stage_def.get_output_specs_from_return(_directory_out_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(_directory_out_stage, "test_stage").out_specs
     # Create outs list with absolute path (preserving trailing slash)
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
@@ -1922,7 +1923,7 @@ def test_directory_out_skipped_on_second_run(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """DirectoryOut stage is skipped on second run when unchanged."""
-    out_specs = stage_def.get_output_specs_from_return(_directory_out_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(_directory_out_stage, "test_stage").out_specs
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
     )
@@ -1949,7 +1950,7 @@ def test_directory_out_reruns_on_fingerprint_change(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """DirectoryOut stage re-runs when code fingerprint changes."""
-    out_specs = stage_def.get_output_specs_from_return(_directory_out_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(_directory_out_stage, "test_stage").out_specs
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
     )
@@ -1985,7 +1986,7 @@ def test_directory_out_restored_from_cache(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """DirectoryOut files are restored from cache when missing."""
-    out_specs = stage_def.get_output_specs_from_return(_directory_out_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(_directory_out_stage, "test_stage").out_specs
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
     )
@@ -2436,7 +2437,9 @@ def test_run_cache_skip_with_directory_out(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """Run cache correctly handles DirectoryOut restoration."""
-    out_specs = stage_def.get_output_specs_from_return(_run_cache_directory_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(
+        _run_cache_directory_stage, "test_stage"
+    ).out_specs
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
     )
@@ -2491,7 +2494,9 @@ def test_run_cache_skip_restores_corrupted_directory(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
     """Run cache restores DirectoryOut when files are corrupted."""
-    out_specs = stage_def.get_output_specs_from_return(_run_cache_directory_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(
+        _run_cache_directory_stage, "test_stage"
+    ).out_specs
     dir_out: outputs.BaseOut = outputs.DirectoryOut(
         str(tmp_path / "results") + "/", loaders.JSON[dict[str, int]]()
     )
@@ -3082,7 +3087,9 @@ def test_run_cache_skip_with_mixed_cached_and_noncached_outputs(
     the cached output should be restored from cache and the non-cached output
     should get a real hash computed (not None) for the lockfile.
     """
-    out_specs = stage_def.get_output_specs_from_return(_run_cache_mixed_output_stage, "test_stage")
+    out_specs = stage_def.extract_stage_definition(
+        _run_cache_mixed_output_stage, "test_stage"
+    ).out_specs
     out = outputs.Out(str(tmp_path / "output.txt"), loaders.PathOnly())
     metric = outputs.Metric(str(tmp_path / "metrics.json"))
 

--- a/tests/integration/test_lazy_resolution.py
+++ b/tests/integration/test_lazy_resolution.py
@@ -109,7 +109,7 @@ pipeline.register({stage_name})
 def test_lazy_resolution_builds_complete_dag(set_project_root: pathlib.Path) -> None:
     """Child pipeline should build complete DAG including parent stages.
 
-    End-to-end test verifying that resolve_from_parents() enables build_dag()
+    End-to-end test verifying that resolve_external_dependencies() enables build_dag()
     to succeed by including necessary producers from parent pipeline.
     """
     # Parent pipeline at root
@@ -128,7 +128,7 @@ def test_lazy_resolution_builds_complete_dag(set_project_root: pathlib.Path) -> 
     child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
     assert child is not None, "Failed to load child pipeline"
 
-    child.resolve_from_parents()
+    child.resolve_external_dependencies()
     dag = child.build_dag(validate=True)
 
     assert "producer" in dag.nodes, "Expected producer from parent in DAG"
@@ -159,7 +159,7 @@ def test_lazy_resolution_preserves_parent_state_dir(set_project_root: pathlib.Pa
     child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
     assert child is not None, "Failed to load child pipeline"
 
-    child.resolve_from_parents()
+    child.resolve_external_dependencies()
 
     # Producer's state_dir should be parent's .pivot, not child's
     producer_info = child.get("producer")
@@ -204,7 +204,7 @@ def test_lazy_resolution_multilevel_hierarchy(set_project_root: pathlib.Path) ->
     child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
     assert child is not None, "Failed to load child pipeline"
 
-    child.resolve_from_parents()
+    child.resolve_external_dependencies()
 
     # Should have all three stages
     stages = set(child.list_stages())
@@ -268,7 +268,7 @@ stages:
         child = discovery.load_pipeline_from_path(child_dir / "pipeline.py")
         assert child is not None, "Failed to load child pipeline"
 
-        child.resolve_from_parents()
+        child.resolve_external_dependencies()
 
     # Should include producer from YAML parent
     assert "producer" in child.list_stages(), "Expected to include producer from pivot.yaml parent"

--- a/tests/storage/test_incremental_out.py
+++ b/tests/storage/test_incremental_out.py
@@ -788,7 +788,9 @@ def test_incremental_out_recognized_as_input_annotation() -> None:
     """IncrementalOut should be recognized as a valid input annotation."""
     from pivot import stage_def
 
-    dep_specs = stage_def.get_dep_specs_from_signature(_test_stage_with_incremental_input)
+    dep_specs = stage_def.extract_stage_definition(
+        _test_stage_with_incremental_input, _test_stage_with_incremental_input.__name__
+    ).dep_specs
     assert "existing" in dep_specs
     assert dep_specs["existing"].path == "cache.json"
     assert dep_specs["existing"].creates_dep_edge is False
@@ -798,7 +800,9 @@ def test_incremental_input_first_run_returns_empty(tmp_path: pathlib.Path) -> No
     """IncrementalOut as input should return empty value if file doesn't exist."""
     from pivot import stage_def
 
-    dep_specs = stage_def.get_dep_specs_from_signature(_test_stage_with_incremental_input)
+    dep_specs = stage_def.extract_stage_definition(
+        _test_stage_with_incremental_input, _test_stage_with_incremental_input.__name__
+    ).dep_specs
     loaded = stage_def.load_deps_from_specs(dep_specs, tmp_path)
 
     # JSON loader returns empty dict for first run
@@ -813,7 +817,9 @@ def test_incremental_input_subsequent_run_loads_value(tmp_path: pathlib.Path) ->
     cache_file = tmp_path / "cache.json"
     cache_file.write_text('{"key": "value"}')
 
-    dep_specs = stage_def.get_dep_specs_from_signature(_test_stage_with_incremental_input)
+    dep_specs = stage_def.extract_stage_definition(
+        _test_stage_with_incremental_input, _test_stage_with_incremental_input.__name__
+    ).dep_specs
     loaded = stage_def.load_deps_from_specs(dep_specs, tmp_path)
 
     assert loaded["existing"] == {"key": "value"}
@@ -839,11 +845,13 @@ def test_incremental_input_type_alias_pattern() -> None:
     from pivot import stage_def
 
     # Verify both input and output recognized
-    dep_specs = stage_def.get_dep_specs_from_signature(_test_cache_stage)
+    dep_specs = stage_def.extract_stage_definition(
+        _test_cache_stage, _test_cache_stage.__name__
+    ).dep_specs
     assert "existing" in dep_specs
     assert dep_specs["existing"].creates_dep_edge is False
 
-    out_specs = stage_def.get_output_specs_from_return(_test_cache_stage, "_test_cache_stage")
+    out_specs = stage_def.extract_stage_definition(_test_cache_stage, "_test_cache_stage").out_specs
     assert "existing" in out_specs
     assert isinstance(out_specs["existing"], outputs.IncrementalOut)
 
@@ -852,7 +860,9 @@ def test_incremental_input_mixed_with_regular_deps() -> None:
     """IncrementalOut input can coexist with regular Dep annotations."""
     from pivot import stage_def
 
-    dep_specs = stage_def.get_dep_specs_from_signature(_test_stage_with_mixed_deps)
+    dep_specs = stage_def.extract_stage_definition(
+        _test_stage_with_mixed_deps, _test_stage_with_mixed_deps.__name__
+    ).dep_specs
 
     # Regular Dep creates edge
     assert "data" in dep_specs


### PR DESCRIPTION
## Summary
Closes #380, closes #381, closes #382

### #380 Single StageDefinition extraction seam
- Add `extract_stage_definition()` as single parsing entry point
- Remove legacy wrappers (`get_dep_specs_from_signature`, `get_output_specs_from_return`, etc.)
- `strict=True` everywhere — hint resolution failures are explicit `StageDefinitionError`

### #381 Graph model adapter
- Add `GraphView` TypedDict + `extract_graph_view()` to `engine/graph.py`
- Update `dag/render.py` to consume `GraphView`, remove engine imports
- Remove `parse_node` from public API

### #382 TUI decoupling
- Add `StageDataProvider` Protocol in `tui/types.py`
- Wire provider through `PivotApp` to diff panels
- Remove all `cli_helpers` imports from TUI modules
- Remove backward-compat aliases and dead code

## Test plan
- [x] Single extraction point for stage definitions
- [x] Graph rendering works with new GraphView interface
- [x] TUI has zero imports from cli_helpers
- [x] 3499 tests pass, ruff + basedpyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)