### PR TITLE
fix(engine): logging transport + worker output capture (#383, #384)

### DIFF
--- a/docs/plans/2026-02-07-logging-transport-replace-manager-queue.md
+++ b/docs/plans/2026-02-07-logging-transport-replace-manager-queue.md
@@ -1,0 +1,290 @@
+# Logging Transport: Replace Manager Queue + Polling Drain
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `multiprocessing.Manager().Queue()` with a plain spawn-context `multiprocessing.Queue` and replace the polling drain loop with a dedicated blocking drain thread that forwards messages into anyio.
+
+**Architecture:** The engine currently uses `Manager().Queue()` (which spawns a separate manager process) and polls it with 20ms timeouts. We replace the Manager queue with `mp.get_context("spawn").Queue()` (no manager process needed), replace the polling drain task with a blocking drain thread that calls `queue.get()` with no timeout, and use a sentinel value to signal clean shutdown. The drain thread forwards messages into the async event loop via `anyio.from_thread.run`.
+
+**Tech Stack:** Python multiprocessing, anyio, threading (via `anyio.to_thread`)
+
+---
+
+## Summary of Changes
+
+**Engine side** (`src/pivot/engine/engine.py`):
+1. Replace `Manager().Queue()` with `spawn_ctx.Queue()`
+2. Replace `_drain_output_queue` (polling loop) with a blocking drain thread
+3. Use a sentinel (`None`) to signal the drain thread to stop
+4. Remove manager shutdown cleanup
+5. Remove `_get_from_queue` helper and `_OUTPUT_QUEUE_DRAIN_TIMEOUT` constant
+
+**Worker side** (`src/pivot/executor/worker.py`):
+- No changes needed. Workers already use `queue.put()` with `block=False`. The `Queue` type annotation is the same `multiprocessing.Queue[OutputMessage]`.
+
+**Test fixtures** (`tests/conftest.py`):
+- Replace `Manager().Queue()` with `spawn_ctx.Queue()` to match production
+
+**Test files** (`tests/test_dep_injection.py`):
+- Uses plain `Queue()` for `_run_stage_function_with_injection` calls — no change needed (it's same-process, not cross-process)
+
+---
+
+### Task 1: Replace Manager Queue with spawn-context Queue in engine
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py:547-549` (queue creation)
+- Modify: `src/pivot/engine/engine.py:723-728` (manager shutdown cleanup)
+- Modify: `src/pivot/engine/engine.py:9` (remove `import multiprocessing as mp` if possible, or keep for `mp.Queue` type)
+
+**Step 1: Modify queue creation in `_orchestrate_execution`**
+
+Replace lines 547-549:
+```python
+        spawn_ctx = mp.get_context("spawn")
+        local_manager = spawn_ctx.Manager()
+        output_queue: mp.Queue[OutputMessage] = local_manager.Queue()  # pyright: ignore[reportAssignmentType]
+```
+With:
+```python
+        spawn_ctx = mp.get_context("spawn")
+        output_queue: mp.Queue[OutputMessage] = spawn_ctx.Queue()  # pyright: ignore[reportAssignmentType]
+```
+
+**Step 2: Remove manager shutdown in finally block**
+
+Replace lines 723-728:
+```python
+        finally:
+            self._executor = None
+            # Manager shutdown can fail if the manager process died unexpectedly
+            with contextlib.suppress(OSError, BrokenPipeError):
+                local_manager.shutdown()
+```
+With:
+```python
+        finally:
+            self._executor = None
+```
+
+**Step 3: Remove unused `queue` import**
+
+Remove from imports at line 11:
+```python
+import queue
+```
+
+(The `queue` module was only used in `_get_from_queue` for `queue.Empty`. After Task 2 removes that method, this import is unused.)
+
+**Step 4: Run tests to verify queue creation still works**
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py -x -q`
+Expected: PASS (workers don't care what Queue implementation they get)
+
+---
+
+### Task 2: Replace polling drain with blocking drain thread
+
+**Files:**
+- Modify: `src/pivot/engine/engine.py:60-62` (remove `_OUTPUT_QUEUE_DRAIN_TIMEOUT` constant)
+- Modify: `src/pivot/engine/engine.py:764-805` (replace `_drain_output_queue` and `_get_from_queue`)
+- Modify: `src/pivot/engine/engine.py:560-564` (drain task startup)
+- Modify: `src/pivot/engine/engine.py:720-722` (drain shutdown signal)
+- Add import: `from anyio import from_thread` at top or use `anyio.from_thread.run`
+
+**Step 1: Remove `_OUTPUT_QUEUE_DRAIN_TIMEOUT` constant**
+
+Delete line 62:
+```python
+_OUTPUT_QUEUE_DRAIN_TIMEOUT = 0.02
+```
+
+**Step 2: Replace `_drain_output_queue` method**
+
+Replace the current polling implementation (lines 764-805):
+```python
+    async def _drain_output_queue(
+        self,
+        output_queue: mp.Queue[OutputMessage],
+        stop_event: anyio.Event,
+    ) -> None:
+        """Drain output messages from worker processes and emit LogLine events."""
+        while not stop_event.is_set():
+            try:
+                # Poll the queue in a thread to not block the event loop
+                msg = await anyio.to_thread.run_sync(
+                    lambda: self._get_from_queue(output_queue, timeout=_OUTPUT_QUEUE_DRAIN_TIMEOUT)
+                )
+                if msg is None:
+                    continue
+                ...
+            except Exception:
+                ...
+
+    def _get_from_queue(self, q: mp.Queue[OutputMessage], timeout: float) -> OutputMessage | None:
+        ...
+```
+
+With a blocking drain thread approach:
+```python
+    async def _drain_output_queue(
+        self,
+        output_queue: mp.Queue[OutputMessage],
+    ) -> None:
+        """Drain output messages from worker processes and emit LogLine events.
+
+        Runs a blocking thread that calls queue.get() without polling.
+        The thread exits when it receives a sentinel (None).
+        Messages are forwarded into the async event loop via anyio.from_thread.run.
+        """
+        await anyio.to_thread.run_sync(
+            lambda: self._blocking_drain(output_queue),
+            abandon_on_cancel=True,
+        )
+
+    def _blocking_drain(self, output_queue: mp.Queue[OutputMessage]) -> None:
+        """Block on queue.get() and forward messages to the async event loop.
+
+        Runs in a dedicated thread. Exits when sentinel (None) is received.
+        """
+        while True:
+            try:
+                msg = output_queue.get()
+            except (EOFError, OSError):
+                break
+
+            # Sentinel signals shutdown
+            if msg is None:
+                break
+
+            try:
+                stage_name, line, is_stderr = msg
+            except (TypeError, ValueError):
+                continue
+
+            try:
+                anyio.from_thread.run(
+                    self._emit_log_line, stage_name, line, is_stderr
+                )
+            except Exception:
+                # Event loop closed or cancelled — stop draining
+                break
+
+    async def _emit_log_line(self, stage_name: str, line: str, is_stderr: bool) -> None:
+        """Emit a single LogLine event. Called from drain thread via from_thread.run."""
+        await self.emit(
+            LogLine(
+                type="log_line",
+                stage=stage_name,
+                line=line,
+                is_stderr=is_stderr,
+            )
+        )
+```
+
+**Step 3: Update drain task startup (remove stop_event)**
+
+Replace lines 560-564:
+```python
+            # Start output drain task
+            output_stop_event = anyio.Event()
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(self._drain_output_queue, output_queue, output_stop_event)
+```
+With:
+```python
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(self._drain_output_queue, output_queue)
+```
+
+**Step 4: Replace stop event with sentinel on shutdown**
+
+Replace lines 720-722:
+```python
+                # Signal output drain task to stop
+                output_stop_event.set()
+```
+With:
+```python
+                # Send sentinel to stop blocking drain thread
+                output_queue.put(None)
+```
+
+**Step 5: Run full test suite**
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/ -n auto -q`
+Expected: PASS
+
+---
+
+### Task 3: Update test fixture to use spawn-context Queue directly
+
+**Files:**
+- Modify: `tests/conftest.py:380-392` (output_queue fixture)
+
+**Step 1: Replace Manager-based fixture**
+
+Replace:
+```python
+@pytest.fixture
+def output_queue() -> Generator[mp.Queue[OutputMessage]]:
+    """Create a multiprocessing queue for worker output using spawn context.
+
+    Uses spawn context to match production behavior and avoid Python 3.13+
+    deprecation warnings about fork() in multi-threaded contexts.
+    """
+    spawn_ctx = mp.get_context("spawn")
+    manager = spawn_ctx.Manager()
+    # Manager().Queue() returns Queue[Any] - cast through object for type safety
+    queue = cast("mp.Queue[OutputMessage]", cast("object", manager.Queue()))
+    yield queue
+    manager.shutdown()
+```
+With:
+```python
+@pytest.fixture
+def output_queue() -> Generator[mp.Queue[OutputMessage]]:
+    """Create a multiprocessing queue for worker output using spawn context.
+
+    Uses spawn context to match production behavior and avoid Python 3.13+
+    deprecation warnings about fork() in multi-threaded contexts.
+    """
+    spawn_ctx = mp.get_context("spawn")
+    q: mp.Queue[OutputMessage] = spawn_ctx.Queue()  # pyright: ignore[reportAssignmentType]
+    yield q
+```
+
+Also check if `cast` is still used elsewhere in conftest.py — if not, remove from imports.
+
+**Step 2: Run the worker tests to verify fixture works**
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py tests/execution/test_execution_modes.py tests/test_run_cache_lock_update.py -x -q`
+Expected: PASS
+
+---
+
+### Task 4: Run quality checks and final verification
+
+**Step 1: Run linting and type checking**
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run ruff format . && uv run ruff check . && uv run basedpyright`
+Expected: PASS (no new errors)
+
+**Step 2: Run full test suite**
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/ -n auto`
+Expected: All tests pass
+
+---
+
+## What Changed (Reviewer Checklist)
+
+- [ ] `multiprocessing.Manager()` removed from engine — no more manager process for log queue
+- [ ] Drain loop replaced: polling with 20ms timeout → blocking `queue.get()` + sentinel
+- [ ] Deterministic shutdown: sentinel `None` replaces `anyio.Event` stop signal
+- [ ] `_get_from_queue` helper removed (no longer needed)
+- [ ] `_OUTPUT_QUEUE_DRAIN_TIMEOUT` constant removed
+- [ ] Manager shutdown cleanup (`contextlib.suppress(OSError, BrokenPipeError)`) removed
+- [ ] Test fixture uses `spawn_ctx.Queue()` directly (matches production)
+- [ ] Worker code unchanged — `Queue[OutputMessage]` interface is identical

--- a/docs/plans/2026-02-07-worker-output-capture-bound-memory-fd.md
+++ b/docs/plans/2026-02-07-worker-output-capture-bound-memory-fd.md
@@ -1,0 +1,476 @@
+# Worker Output Capture — Bounded Memory + FD-Compatible stdout/stderr
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the unbounded `output_lines` list with a bounded ring buffer and give `_QueueWriter` a real file descriptor via `os.pipe()` so libraries that call `fileno()` work.
+
+**Architecture:** Two changes to `_QueueWriter` in `src/pivot/executor/worker.py`:
+1. Replace the `list[tuple[str, bool]]` accumulator with an `_OutputRingBuffer` that evicts oldest lines when capacity is reached, adding a truncation indicator.
+2. Back each `_QueueWriter` with an `os.pipe()` — the write-end FD is returned by `fileno()`, a reader thread drains the read-end into the existing line-splitting + queue-sending logic.
+
+**Tech Stack:** Python 3.13+, `os.pipe()`, `threading`, `collections.deque`
+
+---
+
+## Key Observations
+
+1. **`output_lines` in `StageResult` is dead data.** No consumer reads `result["output_lines"]` — the engine only uses `status`, `reason`, `metrics`, and `deferred_writes`. Real-time output flows through the multiprocessing `Queue`. The `output_lines` field exists purely as a "just in case" backup stored in the result dict.
+
+2. **The ring buffer replaces the list passed to `_QueueWriter`.** Instead of `list.append()`, we call `ring_buffer.append()`. The ring buffer is a thin wrapper around `collections.deque(maxlen=N)`.
+
+3. **The pipe-backed FD is transparent.** The stage function writes to what it thinks is stdout/stderr. `contextlib.redirect_stdout/stderr` points to `_QueueWriter`. When something calls `fileno()`, it gets the write-end of a pipe. A background thread reads the pipe read-end and feeds bytes into the same `_QueueWriter.write()` path.
+
+4. **Thread safety is already handled.** `_QueueWriter` has a `threading.Lock` protecting `_buffer`. The pipe reader thread just calls `write()` like any other thread.
+
+## Design Decisions
+
+**Ring buffer max lines default:** 1000 lines. Configurable per `_OutputRingBuffer(max_lines=N)`. This bounds memory to ~1000 * avg_line_len bytes (typically <1MB).
+
+**Truncation indicator:** When the buffer overflows, the oldest line is evicted. After all output is collected, if `dropped_count > 0`, we prepend a single indicator line: `"[{dropped_count} earlier lines truncated]"`. This goes into the ring buffer's snapshot, not into the real-time queue (which already sent those lines).
+
+**Pipe lifecycle:** The pipe is created in `__enter__`, the reader thread starts immediately, and both FDs are closed in `__exit__` (write-end first to signal EOF, then join reader thread, then close read-end).
+
+**`StageResult.output_lines` type change:** Change from `list[tuple[str, bool]]` to `list[tuple[str, bool]]` — same type, but now populated from ring buffer snapshot. No type change needed. We keep the field for backward compatibility of the TypedDict shape (tests and serialization).
+
+---
+
+## Task 1: Add `_OutputRingBuffer` class
+
+**Files:**
+- Modify: `src/pivot/executor/worker.py` (add class after `_QueueWriter`)
+- Test: `tests/execution/test_executor_worker.py` (new tests)
+
+### Step 1: Write failing tests for ring buffer
+
+Add to `tests/execution/test_executor_worker.py`, after the existing `_QueueWriter` tests section:
+
+```python
+# =============================================================================
+# _OutputRingBuffer Tests
+# =============================================================================
+
+
+def test_ring_buffer_stores_lines_within_capacity() -> None:
+    """Ring buffer stores lines when under max_lines."""
+    buf = worker._OutputRingBuffer(max_lines=5)
+    buf.append("line1", False)
+    buf.append("line2", True)
+    assert buf.snapshot() == [("line1", False), ("line2", True)]
+    assert buf.dropped_count == 0
+
+
+def test_ring_buffer_evicts_oldest_on_overflow() -> None:
+    """Ring buffer evicts oldest lines when exceeding max_lines."""
+    buf = worker._OutputRingBuffer(max_lines=3)
+    for i in range(5):
+        buf.append(f"line{i}", False)
+    snap = buf.snapshot()
+    assert len(snap) == 3
+    assert snap[0] == ("line2", False)
+    assert snap[2] == ("line4", False)
+    assert buf.dropped_count == 2
+
+
+def test_ring_buffer_truncation_indicator() -> None:
+    """Ring buffer includes truncation indicator when lines were dropped."""
+    buf = worker._OutputRingBuffer(max_lines=2)
+    for i in range(5):
+        buf.append(f"line{i}", False)
+    snap = buf.snapshot_with_truncation()
+    assert len(snap) == 3  # indicator + 2 kept lines
+    assert snap[0] == ("[3 earlier lines truncated]", False)
+    assert snap[1] == ("line3", False)
+    assert snap[2] == ("line4", False)
+
+
+def test_ring_buffer_no_truncation_indicator_when_no_overflow() -> None:
+    """Ring buffer snapshot_with_truncation returns plain snapshot when nothing dropped."""
+    buf = worker._OutputRingBuffer(max_lines=10)
+    buf.append("only line", False)
+    snap = buf.snapshot_with_truncation()
+    assert snap == [("only line", False)]
+
+
+def test_ring_buffer_thread_safe() -> None:
+    """Ring buffer is thread-safe under concurrent appends."""
+    import concurrent.futures
+    import threading
+
+    buf = worker._OutputRingBuffer(max_lines=500)
+    barrier = threading.Barrier(5)
+
+    def writer(tid: int) -> None:
+        barrier.wait()
+        for i in range(100):
+            buf.append(f"t{tid}-{i}", False)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+        futs = [pool.submit(writer, t) for t in range(5)]
+        for f in futs:
+            f.result()
+
+    snap = buf.snapshot()
+    assert len(snap) == 500
+    assert buf.dropped_count == 0
+```
+
+### Step 2: Run tests to verify they fail
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py -k "ring_buffer" -v`
+Expected: FAIL — `worker._OutputRingBuffer` does not exist
+
+### Step 3: Implement `_OutputRingBuffer`
+
+Add to `src/pivot/executor/worker.py`, just before the `_QueueWriter` class:
+
+```python
+class _OutputRingBuffer:
+    """Bounded ring buffer for captured output lines.
+
+    Uses collections.deque(maxlen=N) for O(1) append with automatic eviction.
+    Thread-safe: all mutations protected by lock.
+    """
+
+    _lines: collections.deque[tuple[str, bool]]
+    _dropped_count: int
+    _lock: threading.Lock
+
+    def __init__(self, max_lines: int = 1000) -> None:
+        self._lines = collections.deque(maxlen=max_lines)
+        self._dropped_count = 0
+        self._lock = threading.Lock()
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped_count
+
+    def append(self, line: str, is_stderr: bool) -> None:
+        with self._lock:
+            if len(self._lines) == self._lines.maxlen:
+                self._dropped_count += 1
+            self._lines.append((line, is_stderr))
+
+    def snapshot(self) -> list[tuple[str, bool]]:
+        with self._lock:
+            return list(self._lines)
+
+    def snapshot_with_truncation(self) -> list[tuple[str, bool]]:
+        with self._lock:
+            lines = list(self._lines)
+            if self._dropped_count > 0:
+                indicator = f"[{self._dropped_count} earlier lines truncated]"
+                lines.insert(0, (indicator, False))
+            return lines
+```
+
+Also add `import collections` to the imports at the top of `worker.py`.
+
+### Step 4: Run tests to verify they pass
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py -k "ring_buffer" -v`
+Expected: PASS
+
+---
+
+## Task 2: Wire ring buffer into `_QueueWriter` and `execute_stage`
+
+**Files:**
+- Modify: `src/pivot/executor/worker.py` — change `_QueueWriter`, `_run_stage_function_with_injection`, `execute_stage`, `_make_result`
+- Modify: `src/pivot/engine/engine.py:619-622` — remove `output_lines=[]` from error StageResult
+- Modify: `tests/execution/test_executor_worker.py` — update existing tests
+- Modify: `tests/test_dep_injection.py` — update callers
+
+### Step 1: Change `_QueueWriter` to use `_OutputRingBuffer`
+
+Replace the `_output_lines: list[tuple[str, bool]]` field and `output_lines` constructor parameter with `_ring_buffer: _OutputRingBuffer`:
+
+In `_QueueWriter.__init__`:
+- Remove `output_lines` parameter
+- Add `ring_buffer: _OutputRingBuffer` parameter
+- Store as `self._ring_buffer = ring_buffer`
+
+In `_QueueWriter._send_line`:
+- Change `self._output_lines.append(...)` to `self._ring_buffer.append(line, self._is_stderr)`
+
+### Step 2: Change `_run_stage_function_with_injection` signature
+
+Change parameter from `output_lines: list[tuple[str, bool]]` to `ring_buffer: _OutputRingBuffer`:
+
+```python
+def _run_stage_function_with_injection(
+    func: Callable[..., Any],
+    stage_name: str,
+    output_queue: Queue[OutputMessage],
+    ring_buffer: _OutputRingBuffer,
+    ...
+```
+
+Pass `ring_buffer` to both `_QueueWriter` constructors.
+
+### Step 3: Change `execute_stage` to use ring buffer
+
+Replace `output_lines: list[tuple[str, bool]] = []` with `ring_buffer = _OutputRingBuffer()` (uses default 1000 max_lines).
+
+In `_make_result`, change parameter from `output_lines: list[tuple[str, bool]]` to `ring_buffer: _OutputRingBuffer`, and use `ring_buffer.snapshot_with_truncation()`:
+
+```python
+def _make_result(
+    status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED],
+    reason: str,
+    ring_buffer: _OutputRingBuffer,
+) -> StageResult:
+    return StageResult(
+        status=status,
+        reason=reason,
+        output_lines=ring_buffer.snapshot_with_truncation(),
+        metrics=metrics.get_entries(),
+    )
+```
+
+Update all call sites in `execute_stage`:
+- Where `_make_result(status, reason, [])` is used for early returns (no output captured yet), pass a fresh `_OutputRingBuffer(max_lines=0)` or just use an empty ring buffer. **Simpler:** create the ring buffer at the top of `execute_stage` and pass it everywhere.
+- Where `_make_result(status, reason, output_lines)` is used, change to `ring_buffer`.
+- The two early-return `StageResult(...)` constructions that hardcode `output_lines=[]` should also use `ring_buffer.snapshot_with_truncation()`.
+
+### Step 4: Update `engine.py` error path
+
+In `src/pivot/engine/engine.py:619-622`, the error StageResult:
+```python
+failed_result = StageResult(
+    status=StageStatus.FAILED,
+    reason=str(e),
+    output_lines=[],
+)
+```
+This stays as `output_lines=[]` — it's an engine-side error, not worker output.
+
+### Step 5: Update tests
+
+**`tests/execution/test_executor_worker.py`:**
+
+All tests that create `output_lines: list[tuple[str, bool]] = []` and pass to `_QueueWriter` or `_run_stage_function_with_injection` need to:
+1. Create `ring_buffer = worker._OutputRingBuffer(max_lines=1000)` instead
+2. Pass `ring_buffer=ring_buffer` instead of `output_lines=output_lines`
+3. Assert against `ring_buffer.snapshot()` instead of `output_lines`
+
+This affects approximately 20+ test functions. The changes are mechanical:
+- `output_lines: list[tuple[str, bool]] = []` → `ring_buffer = worker._OutputRingBuffer()`
+- `output_lines=output_lines` → `ring_buffer=ring_buffer`
+- `assert output_lines == [...]` → `assert ring_buffer.snapshot() == [...]`
+- `assert len(output_lines) == N` → `assert len(ring_buffer.snapshot()) == N`
+- `output_lines[i]` → `ring_buffer.snapshot()[i]`
+
+**`tests/test_dep_injection.py`:** Same mechanical change at lines 480 and 531.
+
+### Step 6: Run full test suite
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py tests/test_dep_injection.py -v`
+Expected: PASS
+
+---
+
+## Task 3: Add pipe-backed `fileno()` support to `_QueueWriter`
+
+**Files:**
+- Modify: `src/pivot/executor/worker.py` — add pipe to `_QueueWriter`
+- Test: `tests/execution/test_executor_worker.py` — new + updated tests
+
+### Step 1: Write failing tests
+
+```python
+def test_queue_writer_fileno_returns_valid_fd(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """_QueueWriter.fileno() returns a writable file descriptor."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        fd = writer.fileno()
+        assert isinstance(fd, int)
+        # Write through the FD directly
+        os.write(fd, b"hello from fd\n")
+    # Reader thread drains pipe into ring buffer
+    assert ("hello from fd", False) in ring_buffer.snapshot()
+
+
+def test_queue_writer_fd_captures_subprocess_output(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """_QueueWriter captures output from subprocess using fileno()."""
+    import subprocess
+
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        subprocess.run(
+            [sys.executable, "-c", "print('subprocess hello')"],
+            stdout=writer.fileno(),
+            check=True,
+        )
+    assert ("subprocess hello", False) in ring_buffer.snapshot()
+
+
+def test_queue_writer_pipe_and_write_interleave(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """Output via write() and via FD both appear in ring buffer."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("from write\n")
+        os.write(writer.fileno(), b"from fd\n")
+    snap = ring_buffer.snapshot()
+    lines = [line for line, _ in snap]
+    assert "from write" in lines
+    assert "from fd" in lines
+```
+
+### Step 2: Run tests to verify they fail
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py -k "fileno" -v`
+Expected: FAIL
+
+### Step 3: Implement pipe-backed FD in `_QueueWriter`
+
+The design:
+- In `__init__`, call `os.pipe()` → `(read_fd, write_fd)`. Store both.
+- In `__enter__`, start a daemon thread that reads from `read_fd` in a loop, feeding bytes into `self.write()`.
+- `fileno()` returns `write_fd`.
+- In `__exit__`, close `write_fd` first (signals EOF to reader), join the reader thread, then close `read_fd`.
+
+```python
+class _QueueWriter:
+    _stage_name: str
+    _queue: Queue[OutputMessage]
+    _is_stderr: bool
+    _ring_buffer: _OutputRingBuffer
+    _buffer: str
+    _redirect: contextlib.AbstractContextManager[object]
+    _lock: threading.Lock
+    _read_fd: int
+    _write_fd: int
+    _reader_thread: threading.Thread | None
+
+    def __init__(
+        self,
+        stage_name: str,
+        output_queue: Queue[OutputMessage],
+        *,
+        is_stderr: bool,
+        ring_buffer: _OutputRingBuffer,
+    ) -> None:
+        self._stage_name = stage_name
+        self._queue = output_queue
+        self._is_stderr = is_stderr
+        self._ring_buffer = ring_buffer
+        self._buffer = ""
+        self._lock = threading.Lock()
+        self._read_fd, self._write_fd = os.pipe()
+        self._reader_thread = None
+        if is_stderr:
+            self._redirect = contextlib.redirect_stderr(self)
+        else:
+            self._redirect = contextlib.redirect_stdout(self)
+
+    def _pipe_reader(self) -> None:
+        """Read from pipe read-end and feed into write() for line splitting."""
+        try:
+            while True:
+                data = os.read(self._read_fd, 8192)
+                if not data:
+                    break
+                self.write(data.decode("utf-8", errors="replace"))
+        except OSError:
+            pass  # Pipe closed
+
+    def __enter__(self) -> _QueueWriter:
+        self._reader_thread = threading.Thread(
+            target=self._pipe_reader, daemon=True, name=f"pipe-reader-{self._stage_name}"
+        )
+        self._reader_thread.start()
+        self._redirect.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._redirect.__exit__(exc_type, exc_val, exc_tb)
+        # Close write-end to signal EOF to reader thread
+        with contextlib.suppress(OSError):
+            os.close(self._write_fd)
+        # Wait for reader thread to finish draining
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=5.0)
+        # Close read-end
+        with contextlib.suppress(OSError):
+            os.close(self._read_fd)
+        self.flush()
+
+    def fileno(self) -> int:
+        """Return write-end of pipe for FD-compatible operations."""
+        return self._write_fd
+
+    # write(), flush(), _send_line(), isatty() remain the same
+    # except _send_line uses ring_buffer instead of output_lines
+```
+
+### Step 4: Update the existing `fileno` test
+
+The old test `test_queue_writer_fileno_raises_unsupported_operation` should be **deleted** and replaced by the new `test_queue_writer_fileno_returns_valid_fd` test.
+
+### Step 5: Run tests
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/execution/test_executor_worker.py -k "fileno or pipe or subprocess" -v`
+Expected: PASS
+
+### Step 6: Run full test suite
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/ -n auto`
+Expected: PASS
+
+---
+
+## Task 4: Run quality checks and final validation
+
+**Files:** All modified files
+
+### Step 1: Format and lint
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run ruff format . && uv run ruff check .`
+Expected: Clean
+
+### Step 2: Type check
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run basedpyright`
+Expected: Clean
+
+### Step 3: Full test suite
+
+Run: `cd /home/sami/pivot/roadmap-383 && uv run pytest tests/ -n auto`
+Expected: All pass
+
+---
+
+## Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `src/pivot/executor/worker.py` | Add `_OutputRingBuffer`, refactor `_QueueWriter` (ring buffer + pipe FD), update `_make_result`, `execute_stage`, `_run_stage_function_with_injection` signatures |
+| `src/pivot/engine/engine.py` | No change needed (already uses `output_lines=[]` in error path) |
+| `src/pivot/types.py` | No change needed (`output_lines: list[tuple[str, bool]]` type stays same) |
+| `tests/execution/test_executor_worker.py` | Update ~20 tests from `output_lines` list to `ring_buffer`, add ring buffer tests, add pipe FD tests, delete old `fileno` raises test |
+| `tests/test_dep_injection.py` | Update 2 call sites from `output_lines` to `ring_buffer` |
+
+## Uncertainty / Open Questions
+
+1. **Pipe reader thread join timeout:** 5 seconds should be generous. If a stage writes massive data to the pipe, the reader should drain quickly since it's reading into memory. If this proves flaky, we can increase or add a warning.
+
+2. **Two `_QueueWriter` instances per stage (stdout + stderr):** Each creates its own pipe. That's 4 FDs per stage execution. Should be fine — Unix default limit is 1024 FDs and workers run one stage at a time.
+
+3. **`collections.deque` maxlen behavior:** When `len(deque) == maxlen`, the next `append()` silently drops the leftmost item. We manually track `_dropped_count` before the append to count truncated lines accurately.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import AsyncGenerator, Callable, Generator
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import click.testing
 import pytest
@@ -428,11 +428,13 @@ def output_queue() -> Generator[mp.Queue[OutputMessage]]:
     deprecation warnings about fork() in multi-threaded contexts.
     """
     spawn_ctx = mp.get_context("spawn")
-    manager = spawn_ctx.Manager()
-    # Manager().Queue() returns Queue[Any] - cast through object for type safety
-    queue = cast("mp.Queue[OutputMessage]", cast("object", manager.Queue()))
-    yield queue
-    manager.shutdown()
+    q: mp.Queue[OutputMessage] = spawn_ctx.Queue()
+    try:
+        yield q
+    finally:
+        q.close()
+        with contextlib.suppress(OSError, ValueError):
+            q.join_thread()
 
 
 @pytest.fixture

--- a/tests/execution/test_executor_worker.py
+++ b/tests/execution/test_executor_worker.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import inspect
-import io
 import json
 import os
 import pathlib
@@ -269,14 +268,14 @@ def test_run_stage_function_captures_stdout(output_queue: mp.Queue[OutputMessage
         print("line1")
         print("line2")
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
     worker._run_stage_function_with_injection(
-        stage_with_output, "test_stage", output_queue, output_lines
+        stage_with_output, "test_stage", output_queue, ring_buffer
     )
 
-    assert len(output_lines) == 2
-    assert output_lines[0] == ("line1", False)  # stdout
-    assert output_lines[1] == ("line2", False)
+    assert len(ring_buffer.snapshot()) == 2
+    assert ring_buffer.snapshot()[0] == ("line1", False)  # stdout
+    assert ring_buffer.snapshot()[1] == ("line2", False)
 
 
 def test_run_stage_function_captures_stderr(output_queue: mp.Queue[OutputMessage]) -> None:
@@ -286,14 +285,14 @@ def test_run_stage_function_captures_stderr(output_queue: mp.Queue[OutputMessage
         print("error1", file=sys.stderr)
         print("error2", file=sys.stderr)
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
     worker._run_stage_function_with_injection(
-        stage_with_errors, "test_stage", output_queue, output_lines
+        stage_with_errors, "test_stage", output_queue, ring_buffer
     )
 
-    assert len(output_lines) == 2
-    assert output_lines[0] == ("error1", True)  # stderr
-    assert output_lines[1] == ("error2", True)
+    assert len(ring_buffer.snapshot()) == 2
+    assert ring_buffer.snapshot()[0] == ("error1", True)  # stderr
+    assert ring_buffer.snapshot()[1] == ("error2", True)
 
 
 def test_run_stage_function_captures_mixed_output(output_queue: mp.Queue[OutputMessage]) -> None:
@@ -304,13 +303,13 @@ def test_run_stage_function_captures_mixed_output(output_queue: mp.Queue[OutputM
         print("stderr1", file=sys.stderr)
         print("stdout2")
 
-    output_lines: list[tuple[str, bool]] = []
-    worker._run_stage_function_with_injection(stage_mixed, "test_stage", output_queue, output_lines)
+    ring_buffer = worker._OutputRingBuffer()
+    worker._run_stage_function_with_injection(stage_mixed, "test_stage", output_queue, ring_buffer)
 
-    assert len(output_lines) == 3
-    assert output_lines[0] == ("stdout1", False)
-    assert output_lines[1] == ("stderr1", True)
-    assert output_lines[2] == ("stdout2", False)
+    assert len(ring_buffer.snapshot()) == 3
+    assert ring_buffer.snapshot()[0] == ("stdout1", False)
+    assert ring_buffer.snapshot()[1] == ("stderr1", True)
+    assert ring_buffer.snapshot()[2] == ("stdout2", False)
 
 
 def test_run_stage_function_restores_streams(output_queue: mp.Queue[OutputMessage]) -> None:
@@ -321,8 +320,8 @@ def test_run_stage_function_restores_streams(output_queue: mp.Queue[OutputMessag
     def noop_stage() -> None:
         pass
 
-    output_lines: list[tuple[str, bool]] = []
-    worker._run_stage_function_with_injection(noop_stage, "test", output_queue, output_lines)
+    ring_buffer = worker._OutputRingBuffer()
+    worker._run_stage_function_with_injection(noop_stage, "test", output_queue, ring_buffer)
 
     assert sys.stdout is original_stdout
     assert sys.stderr is original_stderr
@@ -338,9 +337,9 @@ def test_run_stage_function_restores_streams_on_exception(
     def failing_stage() -> None:
         raise RuntimeError("fail")
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
     with pytest.raises(RuntimeError):
-        worker._run_stage_function_with_injection(failing_stage, "test", output_queue, output_lines)
+        worker._run_stage_function_with_injection(failing_stage, "test", output_queue, ring_buffer)
 
     assert sys.stdout is original_stdout
     assert sys.stderr is original_stderr
@@ -353,13 +352,13 @@ def test_run_stage_function_captures_partial_lines(output_queue: mp.Queue[Output
         sys.stdout.write("no newline")
         sys.stdout.flush()
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
     worker._run_stage_function_with_injection(
-        stage_no_newline, "test_stage", output_queue, output_lines
+        stage_no_newline, "test_stage", output_queue, ring_buffer
     )
 
-    assert len(output_lines) == 1
-    assert output_lines[0] == ("no newline", False)
+    assert len(ring_buffer.snapshot()) == 1
+    assert ring_buffer.snapshot()[0] == ("no newline", False)
 
 
 # =============================================================================
@@ -369,133 +368,163 @@ def test_run_stage_function_captures_partial_lines(output_queue: mp.Queue[Output
 
 def test_queue_writer_splits_on_newlines(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter splits output on newlines."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        bytes_written = writer.write("line1\nline2\n")
 
-    bytes_written = writer.write("line1\nline2\n")
-
-    assert bytes_written == len("line1\nline2\n")
-    assert output_lines == [("line1", False), ("line2", False)]
+        assert bytes_written == len("line1\nline2\n")
+        assert ring_buffer.snapshot() == [("line1", False), ("line2", False)]
 
 
 def test_queue_writer_buffers_partial_lines(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter buffers incomplete lines."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("partial")
+        assert ring_buffer.snapshot() == []  # Not flushed yet
 
-    writer.write("partial")
-    assert output_lines == []  # Not flushed yet
-
-    writer.write(" line\n")
-    assert output_lines == [("partial line", False)]
+        writer.write(" line\n")
+        assert ring_buffer.snapshot() == [("partial line", False)]
 
 
 def test_queue_writer_flush_writes_buffer(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter.flush() writes buffered content."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("no newline")
+        assert ring_buffer.snapshot() == []
 
-    writer.write("no newline")
-    assert output_lines == []
-
-    writer.flush()
-    assert output_lines == [("no newline", False)]
+        writer.flush()
+        assert ring_buffer.snapshot() == [("no newline", False)]
 
 
 def test_queue_writer_distinguishes_stderr(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter marks stderr lines correctly."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=True, output_lines=output_lines
-    )
-
-    writer.write("error\n")
-    assert output_lines == [("error", True)]
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=True, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("error\n")
+        assert ring_buffer.snapshot() == [("error", True)]
 
 
 def test_queue_writer_handles_multiple_newlines(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter handles text with multiple consecutive newlines."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
-
-    writer.write("line1\n\nline2\n")
-    # Empty lines are skipped (code checks 'if line:')
-    assert output_lines == [("line1", False), ("line2", False)]
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("line1\n\nline2\n")
+        # Empty lines are skipped (code checks 'if line:')
+        assert ring_buffer.snapshot() == [("line1", False), ("line2", False)]
 
 
 def test_queue_writer_empty_flush_does_nothing(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter.flush() with empty buffer does nothing."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
-
-    writer.flush()
-    assert output_lines == []
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.flush()
+        assert ring_buffer.snapshot() == []
 
 
 def test_queue_writer_isatty_returns_false(output_queue: mp.Queue[OutputMessage]) -> None:
     """_QueueWriter.isatty() returns False."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        assert writer.isatty() is False
 
-    assert writer.isatty() is False
 
-
-def test_queue_writer_fileno_raises_unsupported_operation(
+def test_queue_writer_fileno_returns_valid_fd(
     output_queue: mp.Queue[OutputMessage],
 ) -> None:
-    """_QueueWriter.fileno() raises io.UnsupportedOperation."""
-    output_lines: list[tuple[str, bool]] = []
-    writer = worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
-    )
+    """_QueueWriter.fileno() returns a writable file descriptor."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        fd = writer.fileno()
+        assert isinstance(fd, int)
+        # Write through the FD directly
+        os.write(fd, b"hello from fd\n")
+    # Reader thread drains pipe into ring buffer
+    assert ("hello from fd", False) in ring_buffer.snapshot()
 
-    with pytest.raises(io.UnsupportedOperation, match="file descriptor"):
-        writer.fileno()
+
+def test_queue_writer_fd_captures_subprocess_output(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """_QueueWriter captures output from subprocess using fileno()."""
+    import subprocess
+
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        subprocess.run(
+            [sys.executable, "-c", "print('subprocess hello')"],
+            stdout=writer.fileno(),
+            check=True,
+        )
+    assert ("subprocess hello", False) in ring_buffer.snapshot()
+
+
+def test_queue_writer_pipe_and_write_interleave(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """Output via write() and via FD both appear in ring buffer."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        writer.write("from write\n")
+        os.write(writer.fileno(), b"from fd\n")
+    snap = ring_buffer.snapshot()
+    lines = [line for line, _ in snap]
+    assert "from write" in lines
+    assert "from fd" in lines
 
 
 def test_queue_writer_context_manager_flushes_on_exit(
     output_queue: mp.Queue[OutputMessage],
 ) -> None:
     """_QueueWriter context manager flushes buffer on exit."""
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
     with worker._QueueWriter(
-        "test_stage", output_queue, is_stderr=False, output_lines=output_lines
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
     ) as writer:
         writer.write("no newline")
-        assert output_lines == []  # Not flushed yet
+        assert ring_buffer.snapshot() == []  # Not flushed yet
 
     # Flushed on context exit
-    assert output_lines == [("no newline", False)]
+    assert ring_buffer.snapshot() == [("no newline", False)]
 
 
 def test_queue_writer_context_manager_flushes_on_exception(
     output_queue: mp.Queue[OutputMessage],
 ) -> None:
     """_QueueWriter context manager flushes buffer even when exception raised."""
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
     with (
         pytest.raises(RuntimeError),
-        worker._QueueWriter("test_stage", output_queue, is_stderr=False, output_lines=output_lines),
+        worker._QueueWriter("test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer),
     ):
         print("before error")
         raise RuntimeError("test error")
 
     # Output captured despite exception
-    assert output_lines == [("before error", False)]
+    assert ring_buffer.snapshot() == [("before error", False)]
 
 
 def test_run_stage_function_preserves_output_on_exception(
@@ -507,15 +536,163 @@ def test_run_stage_function_preserves_output_on_exception(
         print("line before error")
         raise RuntimeError("stage failed")
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
     with pytest.raises(RuntimeError):
         worker._run_stage_function_with_injection(
-            failing_stage, "test_stage", output_queue, output_lines
+            failing_stage, "test_stage", output_queue, ring_buffer
         )
 
     # Output captured despite exception
-    assert len(output_lines) == 1
-    assert output_lines[0] == ("line before error", False)
+    assert len(ring_buffer.snapshot()) == 1
+    assert ring_buffer.snapshot()[0] == ("line before error", False)
+
+
+# =============================================================================
+# _OutputRingBuffer Tests
+# =============================================================================
+
+
+def test_ring_buffer_stores_lines_within_capacity() -> None:
+    """Ring buffer stores lines when under max_lines."""
+    buf = worker._OutputRingBuffer(max_lines=5)
+    buf.append("line1", False)
+    buf.append("line2", True)
+    assert buf.snapshot() == [("line1", False), ("line2", True)]
+
+
+def test_ring_buffer_evicts_oldest_on_overflow() -> None:
+    """Ring buffer evicts oldest lines when exceeding max_lines."""
+    buf = worker._OutputRingBuffer(max_lines=3)
+    for i in range(5):
+        buf.append(f"line{i}", False)
+    snap = buf.snapshot()
+    # 2 lines dropped: indicator + 3 kept lines
+    assert len(snap) == 4
+    assert snap[0] == ("[2 earlier lines truncated]", False)
+    assert snap[1] == ("line2", False)
+    assert snap[3] == ("line4", False)
+
+
+def test_ring_buffer_truncation_indicator() -> None:
+    """Ring buffer includes truncation indicator when lines were dropped."""
+    buf = worker._OutputRingBuffer(max_lines=2)
+    for i in range(5):
+        buf.append(f"line{i}", False)
+    snap = buf.snapshot()
+    assert len(snap) == 3  # indicator + 2 kept lines
+    assert snap[0] == ("[3 earlier lines truncated]", False)
+    assert snap[1] == ("line3", False)
+    assert snap[2] == ("line4", False)
+
+
+def test_ring_buffer_no_truncation_indicator_when_no_overflow() -> None:
+    """Ring buffer snapshot returns plain lines when nothing was dropped."""
+    buf = worker._OutputRingBuffer(max_lines=10)
+    buf.append("only line", False)
+    snap = buf.snapshot()
+    assert snap == [("only line", False)]
+
+
+def test_ring_buffer_thread_safe() -> None:
+    """Ring buffer is thread-safe under concurrent appends."""
+    import concurrent.futures
+    import threading
+
+    buf = worker._OutputRingBuffer(max_lines=500)
+    barrier = threading.Barrier(5)
+
+    def writer(tid: int) -> None:
+        barrier.wait()
+        for i in range(100):
+            buf.append(f"t{tid}-{i}", False)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+        futs = [pool.submit(writer, t) for t in range(5)]
+        for f in futs:
+            f.result()
+
+    snap = buf.snapshot()
+    assert len(snap) == 500
+
+
+def test_ring_buffer_empty_snapshot() -> None:
+    """Ring buffer snapshot returns empty list when no lines appended."""
+    buf = worker._OutputRingBuffer(max_lines=10)
+    assert buf.snapshot() == []
+
+
+def test_ring_buffer_max_lines_one() -> None:
+    """Ring buffer with max_lines=1 keeps only the most recent line."""
+    buf = worker._OutputRingBuffer(max_lines=1)
+    buf.append("first", False)
+    buf.append("second", True)
+    snap = buf.snapshot()
+    # 1 dropped line => indicator + 1 kept line
+    assert len(snap) == 2
+    assert snap[0] == ("[1 earlier lines truncated]", False)
+    assert snap[1] == ("second", True)
+
+
+def test_ring_buffer_truncation_indicator_is_not_stderr() -> None:
+    """Truncation indicator is always marked as stdout even when all dropped lines were stderr."""
+    buf = worker._OutputRingBuffer(max_lines=2)
+    # Append 4 stderr lines; 2 will be dropped
+    for i in range(4):
+        buf.append(f"err{i}", True)
+    snap = buf.snapshot()
+    assert len(snap) == 3  # indicator + 2 kept
+    indicator_line, indicator_is_stderr = snap[0]
+    assert "2 earlier lines truncated" in indicator_line
+    assert indicator_is_stderr is False, "Truncation indicator should not be marked as stderr"
+    # Kept lines are still stderr
+    assert snap[1] == ("err2", True)
+    assert snap[2] == ("err3", True)
+
+
+def test_ring_buffer_snapshot_returns_copy() -> None:
+    """Ring buffer snapshot returns a new list each call (not a reference to internal state)."""
+    buf = worker._OutputRingBuffer(max_lines=10)
+    buf.append("line1", False)
+    snap1 = buf.snapshot()
+    buf.append("line2", False)
+    snap2 = buf.snapshot()
+    assert len(snap1) == 1, "First snapshot should not be affected by later appends"
+    assert len(snap2) == 2
+
+
+def test_queue_writer_fd_is_closed_after_context_exit(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """_QueueWriter pipe FDs are closed after context manager exit."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        write_fd = writer.fileno()
+        read_fd = writer._read_fd
+        assert read_fd is not None
+    # Both FDs should be closed after __exit__
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
+def test_queue_writer_reader_thread_joins_on_exit(
+    output_queue: mp.Queue[OutputMessage],
+) -> None:
+    """_QueueWriter reader thread is joined (not left running) after context exit."""
+    ring_buffer = worker._OutputRingBuffer()
+    with worker._QueueWriter(
+        "test_stage", output_queue, is_stderr=False, ring_buffer=ring_buffer
+    ) as writer:
+        assert writer._reader_thread is None
+        writer.fileno()
+        thread = writer._reader_thread
+        assert thread is not None
+        assert thread.is_alive()
+    # Thread should be joined after __exit__
+    assert not thread.is_alive(), "Reader thread should be stopped after context exit"
 
 
 # =============================================================================
@@ -1543,36 +1720,35 @@ def test_queue_writer_thread_safety_concurrent_writes(
     import concurrent.futures
     import threading
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
-    writer = worker._QueueWriter(
+    with worker._QueueWriter(
         "test_stage",
         output_queue,
         is_stderr=False,
-        output_lines=output_lines,
-    )
+        ring_buffer=ring_buffer,
+    ) as writer:
+        num_threads = 10
+        lines_per_thread = 100
+        barrier = threading.Barrier(num_threads)
 
-    num_threads = 10
-    lines_per_thread = 100
-    barrier = threading.Barrier(num_threads)
+        def write_lines(thread_id: int) -> None:
+            # Wait for all threads to be ready before starting
+            barrier.wait()
+            for i in range(lines_per_thread):
+                writer.write(f"thread-{thread_id}-line-{i}\n")
 
-    def write_lines(thread_id: int) -> None:
-        # Wait for all threads to be ready before starting
-        barrier.wait()
-        for i in range(lines_per_thread):
-            writer.write(f"thread-{thread_id}-line-{i}\n")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
+            futures = [pool.submit(write_lines, tid) for tid in range(num_threads)]
+            for f in futures:
+                f.result()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
-        futures = [pool.submit(write_lines, tid) for tid in range(num_threads)]
-        for f in futures:
-            f.result()
-
-    writer.flush()
+        writer.flush()
 
     # All lines should be captured (no data loss from race conditions)
     expected_line_count = num_threads * lines_per_thread
-    assert len(output_lines) == expected_line_count, (
-        f"Expected {expected_line_count} lines, got {len(output_lines)} - possible thread safety issue"
+    assert len(ring_buffer.snapshot()) == expected_line_count, (
+        f"Expected {expected_line_count} lines, got {len(ring_buffer.snapshot())} - possible thread safety issue"
     )
 
 
@@ -1590,40 +1766,39 @@ def test_queue_writer_thread_safety_atomic_writes(
     import concurrent.futures
     import threading
 
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
-    writer = worker._QueueWriter(
+    with worker._QueueWriter(
         "test_stage",
         output_queue,
         is_stderr=False,
-        output_lines=output_lines,
-    )
+        ring_buffer=ring_buffer,
+    ) as writer:
+        num_threads = 5
+        lines_per_thread = 10
+        barrier = threading.Barrier(num_threads)
 
-    num_threads = 5
-    lines_per_thread = 10
-    barrier = threading.Barrier(num_threads)
+        def write_complete_lines(thread_id: int) -> None:
+            barrier.wait()
+            # Write complete lines (full line in single write call) - these should NOT interleave
+            for i in range(lines_per_thread):
+                writer.write(f"t{thread_id}-i{i}\n")
 
-    def write_complete_lines(thread_id: int) -> None:
-        barrier.wait()
-        # Write complete lines (full line in single write call) - these should NOT interleave
-        for i in range(lines_per_thread):
-            writer.write(f"t{thread_id}-i{i}\n")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
+            futures = [pool.submit(write_complete_lines, tid) for tid in range(num_threads)]
+            for f in futures:
+                f.result()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
-        futures = [pool.submit(write_complete_lines, tid) for tid in range(num_threads)]
-        for f in futures:
-            f.result()
-
-    writer.flush()
+        writer.flush()
 
     # All lines should be captured
     expected_count = num_threads * lines_per_thread
-    assert len(output_lines) == expected_count, (
-        f"Expected {expected_count} lines, got {len(output_lines)}"
+    assert len(ring_buffer.snapshot()) == expected_count, (
+        f"Expected {expected_count} lines, got {len(ring_buffer.snapshot())}"
     )
 
     # Each line should be properly formatted (not corrupted by interleaving)
-    for line, is_stderr in output_lines:
+    for line, is_stderr in ring_buffer.snapshot():
         assert not is_stderr
         # Line format: t{thread_id}-i{iteration}
         assert line.startswith("t"), f"Corrupted line: {line}"

--- a/tests/test_dep_injection.py
+++ b/tests/test_dep_injection.py
@@ -477,7 +477,7 @@ def test_worker_injects_deps(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyP
 
     # Run the stage function through worker
     output_queue: Queue[OutputMessage] = Queue()
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
     # Get dep specs and out specs for the worker
     dep_specs = stage_def.get_dep_specs_from_signature(process)
@@ -487,7 +487,7 @@ def test_worker_injects_deps(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyP
         process,
         "test_stage",
         output_queue,
-        output_lines,
+        ring_buffer,
         params=None,
         dep_specs=dep_specs,
         project_root=tmp_path,
@@ -528,7 +528,7 @@ def test_worker_injects_params_and_deps(
 
     # Run the stage function through worker
     output_queue: Queue[OutputMessage] = Queue()
-    output_lines: list[tuple[str, bool]] = []
+    ring_buffer = worker._OutputRingBuffer()
 
     dep_specs = stage_def.get_dep_specs_from_signature(train)
     out_specs = stage_def.get_output_specs_from_return(train, "test_stage")
@@ -539,7 +539,7 @@ def test_worker_injects_params_and_deps(
         train,
         "test_stage",
         output_queue,
-        output_lines,
+        ring_buffer,
         params=params,
         dep_specs=dep_specs,
         project_root=tmp_path,


### PR DESCRIPTION
## Summary
Closes #383, closes #384

### #383 Logging transport
- Replace polling drain loop with blocking drain thread via `anyio.to_thread.run_sync(abandon_on_cancel=True)`
- `queue.get(timeout=5.0)` replaces infinite block for safety
- Sentinel `None` for deterministic shutdown with safety-net in `finally`
- Removed: `_OUTPUT_QUEUE_DRAIN_TIMEOUT`, `_get_from_queue`, `output_stop_event`
- Note: `Manager().Queue()` retained because loky needs picklable queue objects

### #384 Worker output capture
- Add `_OutputRingBuffer` with bounded `deque(maxlen=1000)` and truncation indicator
- Pipe-backed `fileno()` via `os.pipe()` + reader thread for real FD support
- Replace unbounded `output_lines` list with ring buffer across all call sites
- 14 new tests for ring buffer and pipe FD

## Test plan
- [x] Logs still appear for stdout/stderr and logging handlers
- [x] Engine shuts down cleanly without polling
- [x] Ring buffer bounds memory, truncation indicator visible
- [x] `fileno()` returns real FD for libraries that need it
- [x] 3475 tests pass, ruff + basedpyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)