### PR TITLE
fix: P0 cache/fingerprint correctness + safe fingerprinting defaults

### DIFF
--- a/.sisyphus/plans/p0-cache-fingerprint-correctness.md
+++ b/.sisyphus/plans/p0-cache-fingerprint-correctness.md
@@ -1,0 +1,666 @@
+# P0: Cache/State Correctness + Fingerprint Caching Completion
+
+## TL;DR
+
+> **Quick Summary**: Fix the core cache/state soundness gaps and complete the fingerprint manifest caching system that's already partially implemented. This makes generation-based skip detection truly O(1), eliminates the dual-source-of-truth for dep_generations, completes #363 (manifest cache flush), enables #358 (selective re-fingerprinting), and adds safe-by-default fingerprinting that errors on unsound closure captures.
+>
+> **Deliverables**:
+> - Generation skip reordered to run before dep hashing (C0)
+> - `dep_generations` consolidated to StateDB-only (C1)
+> - Manifest cache flush boundaries added for watch mode (C2/#363)
+> - Selective re-fingerprinting via reverse index (#358)
+> - Safe fingerprinting defaults with mutable-closure error + unsafe mode escape hatch
+>
+> **Estimated Effort**: Large
+> **Parallel Execution**: YES - 2 waves
+> **Critical Path**: Task 1 → Task 2 → Task 3 → Task 5 → Task 6
+
+---
+
+## Context
+
+### Original Request
+Convert P0 items from deep architecture review into an executable work plan. P1/P2 work (Engine refactor, logging transport, concurrency design) is explicitly deferred.
+
+### Interview Summary
+**Key Decisions**:
+- Single-run correctness first; concurrency deferred
+- Aggressive remediation posture (breaking changes OK, pre-alpha)
+- Generation skip soundness boundary: Pivot-produced artifacts only
+- `dep_generations` single source of truth: StateDB-only (preferred)
+- Manifest cache: best-effort perf optimization, never correctness-critical
+- Mutable closure captures: ERROR by default, single boolean unsafe mode escape hatch
+- Frozen instances: allow via cheap static detection only (no recursion)
+- Error messages: name offending variables + suggest `StageParams`/`Dep(...)` fix
+
+### Metis Review
+**Identified Gaps** (addressed):
+- Mixed deps edge case (Pivot-produced + external) → explicitly gate generation skip
+- Legacy lockfiles missing `dep_generations` → handle gracefully in schema migration
+- Watch-mode rapid flush perf concern → limit flush to well-defined checkpoints
+- Nested mutable structures in closures (tuple containing list) → treat tuple-of-mutable as mutable
+
+---
+
+## Work Objectives
+
+### Core Objective
+Make Pivot's skip detection, fingerprinting, and caching systems correct-by-default and performant in all execution modes (one-shot, watch, TUI).
+
+### Concrete Deliverables
+- Modified `src/pivot/executor/worker.py`: generation skip before hashing
+- Modified `src/pivot/types.py`: `DeferredWrites` extended with file-hash cache entries
+- Modified `src/pivot/storage/state.py`: apply file-hash entries in deferred writes
+- Modified `src/pivot/storage/lock.py`: `dep_generations` removed from schema
+- Modified `src/pivot/fingerprint.py`: flush boundaries, safe-fingerprinting validation
+- Modified `src/pivot/discovery.py` and `src/pivot/pipeline/yaml.py`: manifest flush calls
+- Modified `src/pivot/engine/engine.py`: manifest flush in watch reload path
+- New/modified config: `core.unsafe_fingerprinting` in `src/pivot/config/models.py`
+- New/modified tests across `tests/`
+
+### Definition of Done
+- [x] `uv run pytest tests/ -n auto` passes
+- [x] `uv run ruff format . && uv run ruff check . && uv run basedpyright` clean
+- [x] Generation skip does not hash deps when generation matches
+- [x] `dep_generations` only lives in StateDB; lockfiles no longer store or read it
+- [x] Watch-mode manifest cache persists across reloads
+- [x] Mutable closure capture raises error by default; `PIVOT_UNSAFE_FINGERPRINTING=1` downgrades to warning
+
+### Must Have
+- All existing tests continue to pass
+- Each behavioral change covered by new tests
+- Backward compatibility for lockfiles missing `dep_generations` field
+
+### Must NOT Have (Guardrails)
+- No Engine refactoring (P1)
+- No logging transport changes (P1)
+- No concurrency/locking design work (P2)
+- No new abstractions or module splits unless required for the fix
+- No recursive immutability proofs for closure captures
+- No parallel fingerprinting (#364) — explicitly deferred
+- Follow existing code patterns in each module
+
+---
+
+## Verification Strategy (MANDATORY)
+
+> **UNIVERSAL RULE: ZERO HUMAN INTERVENTION**
+>
+> ALL tasks in this plan MUST be verifiable WITHOUT any human action.
+
+### Test Decision
+- **Infrastructure exists**: YES
+- **Automated tests**: YES (tests-after — add tests for each behavioral change)
+- **Framework**: pytest (`uv run pytest tests/ -n auto`)
+
+### Quality Gates
+```bash
+uv run pytest tests/ -n auto                                        # All tests pass
+uv run ruff format . && uv run ruff check . && uv run basedpyright  # Clean quality
+```
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Start Immediately — independent fixes):
+├── Task 1: Reorder generation skip before dep hashing (C0)
+├── Task 4: Complete manifest cache flush boundaries (C2/#363)
+└── Task 7: Safe fingerprinting defaults + unsafe mode
+
+Wave 2 (After Wave 1):
+├── Task 2: Extend DeferredWrites with file-hash cache entries (C0 cont.)
+├── Task 3: Consolidate dep_generations to StateDB-only (C1)
+├── Task 5: Selective re-fingerprinting via reverse index (#358)
+└── Task 6: Add skip-invariant documentation + tests
+
+Critical Path: Task 1 → Task 2 → Task 3 → Task 5 → Task 6
+Parallel Speedup: ~35% faster than sequential
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Can Parallelize With |
+|------|------------|--------|---------------------|
+| 1 | None | 2, 6 | 4, 7 |
+| 2 | 1 | 3, 6 | 4, 5, 7 |
+| 3 | 2 | 6 | 5 |
+| 4 | None | 5 | 1, 7 |
+| 5 | 4 | 6 | 2, 3 |
+| 6 | 2, 3, 5 | None | None (final integration) |
+| 7 | None | None | 1, 4 |
+
+---
+
+## TODOs
+
+- [x] 1. Reorder worker skip detection: generation check before dep hashing (C0)
+
+  **What to do**:
+  - In `_check_skip_or_run()` (`src/pivot/executor/worker.py:417`), move the generation-based skip check (`can_skip_via_generation()`) to run BEFORE `hash_dependencies()` is called.
+  - Currently the worker calls `hash_dependencies()` unconditionally at the top of `execute_stage()`, then passes `dep_hashes` into `_check_skip_or_run()`. Restructure so that:
+    1. Read lock data first (cheap)
+    2. Attempt `can_skip_via_generation()` with lock data + fingerprint + params (no hashing)
+    3. Only if generation check fails → hash dependencies → proceed to lock comparison + run cache
+  - Gate generation skip to only attempt when deps are Pivot-produced artifacts (have generation counters in StateDB). If any dep lacks a generation counter, fall through to hashing immediately.
+  - Add tests proving that when generation skip succeeds, `hash_dependencies()` is never called (use mock/spy).
+
+  **Must NOT do**:
+  - Do not change the `can_skip_via_generation()` algorithm itself (just when it's called)
+  - Do not modify the lock file format
+  - Do not change the `WorkerStageInfo` contract
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Requires careful understanding of the worker execution flow and skip detection tiers; must preserve correctness invariants while reordering.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 4, 7)
+  - **Blocks**: Task 2, Task 6
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/executor/worker.py:417-462` — `_check_skip_or_run()`: current skip detection flow that takes `dep_hashes` as input. This must be restructured to optionally skip hashing.
+  - `src/pivot/executor/worker.py:972-1041` — `can_skip_via_generation()`: the generation check logic. Note lines 1002-1005 where it falls back to `lock_data["dep_generations"]` (this fallback will be removed in Task 3, but for now keep it).
+  - `src/pivot/executor/worker.py:200-300` — `execute_stage()`: the top-level worker entry point where `hash_dependencies()` is called. This is where the reordering must happen.
+
+  **API/Type References**:
+  - `src/pivot/types.py:121-131` — `DeferredWrites` TypedDict (will be extended in Task 2)
+  - `src/pivot/types.py:134-142` — `StageResult` TypedDict
+  - `src/pivot/executor/worker.py` — `WorkerStageInfo` TypedDict
+
+  **Test References**:
+  - `tests/storage/test_state.py` — StateDB test patterns
+  - `tests/fingerprint/test_fingerprint.py` — fingerprint test patterns
+
+  **Acceptance Criteria**:
+
+  - [x] New test: when all deps have matching generations in StateDB, `hash_dependencies()` is NOT called
+  - [x] New test: when any dep lacks a generation counter, `hash_dependencies()` IS called and skip falls through to lock comparison
+  - [x] New test: mixed deps (Pivot-produced + external) correctly fall through to hashing
+  - [x] `uv run pytest tests/ -n auto` → PASS
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Generation skip avoids dep hashing
+    Tool: Bash
+    Preconditions: Test environment set up with pytest
+    Steps:
+      1. uv run pytest tests/ -k "generation_skip" -v
+      2. Assert: exit code 0
+      3. Assert: output contains "PASSED" for all generation skip tests
+    Expected Result: All generation skip tests pass
+    Evidence: pytest output captured
+
+  Scenario: Full test suite still passes after reordering
+    Tool: Bash
+    Preconditions: All changes applied
+    Steps:
+      1. uv run pytest tests/ -n auto
+      2. Assert: exit code 0
+    Expected Result: No regressions
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `fix(executor): reorder skip detection to try generation check before dep hashing`
+  - Files: `src/pivot/executor/worker.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 2. Extend DeferredWrites with file-hash cache write-back (C0 cont.)
+
+  **What to do**:
+  - Add a new optional field `file_hash_entries` to `DeferredWrites` in `src/pivot/types.py`:
+    ```python
+    file_hash_entries: list[tuple[str, int, int, int, str]]  # (path, mtime_ns, size, inode, hash)
+    ```
+  - In `hash_dependencies()` (`src/pivot/executor/worker.py`), collect file hash results as the worker computes them. Return these in `DeferredWrites` alongside existing fields.
+  - In `StateDB.apply_deferred_writes()` (`src/pivot/storage/state.py:674`), add handling for `file_hash_entries`: batch-write them in the same atomic transaction.
+  - This allows the worker (readonly StateDB) to contribute hash cache entries that the coordinator persists, making future runs' hash lookups hit cache.
+
+  **Must NOT do**:
+  - Do not make workers open StateDB in write mode
+  - Do not change the LMDB transaction model (single-writer via coordinator)
+  - Do not modify existing `DeferredWrites` fields
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Touches the coordinator-worker contract boundary; must preserve atomicity guarantees.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (sequential after Task 1)
+  - **Blocks**: Task 3, Task 6
+  - **Blocked By**: Task 1
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/storage/state.py:674-743` — `apply_deferred_writes()`: the single-txn atomic write. Add file-hash entries here following the same pattern as dep_generations.
+  - `src/pivot/storage/state.py:213-227` — `save()` and `save_many()`: the file-hash write pattern to replicate inside deferred writes.
+  - `src/pivot/storage/cache.py:84-113` — `hash_file()`: where file hashes are computed and (when writable) saved. The worker path skips the save; instead collect entries for deferred write-back.
+
+  **API/Type References**:
+  - `src/pivot/types.py:121-131` — `DeferredWrites` TypedDict to extend
+  - `src/pivot/storage/state.py:56-63` — `_make_key_file_hash()` key format
+  - `src/pivot/storage/state.py:125-134` — `_pack_value()` / `_unpack_value()` binary format
+
+  **Acceptance Criteria**:
+
+  - [x] `DeferredWrites` has new optional `file_hash_entries` field
+  - [x] `apply_deferred_writes()` persists file-hash entries in same atomic txn
+  - [x] Worker collects file-hash entries during dep hashing and includes them in result
+  - [x] New test: after worker run, coordinator applies deferred writes, subsequent `state_db.get()` returns cached hash
+  - [x] `uv run pytest tests/ -n auto` → PASS
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Deferred file-hash write-back works
+    Tool: Bash
+    Steps:
+      1. uv run pytest tests/ -k "deferred_write" -v
+      2. Assert: exit code 0
+    Expected Result: File-hash entries are persisted via deferred writes
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `feat(storage): add file-hash cache write-back via DeferredWrites`
+  - Files: `src/pivot/types.py`, `src/pivot/executor/worker.py`, `src/pivot/storage/state.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 3. Consolidate dep_generations to StateDB-only (C1)
+
+  **What to do**:
+  - Remove `dep_generations` from `_REQUIRED_LOCK_KEYS` in `src/pivot/storage/lock.py:47`.
+  - Remove `dep_generations` from `StorageLockData` and `LockData` TypedDicts in `src/pivot/types.py`.
+  - Remove `dep_generations` from `_convert_to_storage_format()` and `_convert_from_storage_format()` in `src/pivot/storage/lock.py`.
+  - In `is_lock_data()` validator (`src/pivot/storage/lock.py:61`), stop requiring `dep_generations` — but handle old lockfiles gracefully (ignore the field if present).
+  - In `can_skip_via_generation()` (`src/pivot/executor/worker.py:972`), remove the fallback to `lock_data["dep_generations"]` (lines 1002-1005). Only use `state_db.get_dep_generations()`.
+  - Update all call sites that construct `LockData(... dep_generations={})` to remove the field.
+  - Update `src/pivot/explain.py` if it references `dep_generations` from lock data.
+
+  **Must NOT do**:
+  - Do not break reading of old lockfiles that have `dep_generations` (just ignore the field)
+  - Do not change the StateDB dep-generation write path (it already works correctly)
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Touches a cross-cutting schema change across lock/types/worker/explain; must handle backward compatibility.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (after Task 2)
+  - **Blocks**: Task 6
+  - **Blocked By**: Task 2
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/storage/lock.py:47` — `_REQUIRED_LOCK_KEYS` frozenset to modify
+  - `src/pivot/storage/lock.py:96-162` — Storage format converters to update
+  - `src/pivot/executor/worker.py:1002-1005` — Lock data fallback to remove
+  - `src/pivot/executor/worker.py` — All `LockData(... dep_generations={})` constructors (search for `dep_generations`)
+
+  **API/Type References**:
+  - `src/pivot/types.py` — `LockData` and `StorageLockData` TypedDicts to modify
+  - `src/pivot/storage/state.py:412-454` — StateDB `get_dep_generations()` / `record_dep_generations()` (these stay unchanged)
+
+  **Test References**:
+  - `tests/storage/test_lock.py` — Lock file tests to update
+
+  **Acceptance Criteria**:
+
+  - [x] `dep_generations` removed from `LockData`, `StorageLockData`, `_REQUIRED_LOCK_KEYS`
+  - [x] Old lockfiles with `dep_generations` field still parse correctly (field ignored)
+  - [x] `can_skip_via_generation()` no longer references `lock_data["dep_generations"]`
+  - [x] New lockfiles written without `dep_generations` field
+  - [x] New test: lockfile without `dep_generations` is valid
+  - [x] New test: old lockfile with `dep_generations` still loads without error
+  - [x] `uv run pytest tests/ -n auto` → PASS
+  - [x] `uv run ruff format . && uv run ruff check . && uv run basedpyright` → clean
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Lock schema migration is backward-compatible
+    Tool: Bash
+    Steps:
+      1. uv run pytest tests/storage/test_lock.py -v
+      2. Assert: exit code 0
+    Expected Result: Old and new lockfile formats both work
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `fix(storage): consolidate dep_generations to StateDB-only, remove from lockfiles`
+  - Files: `src/pivot/types.py`, `src/pivot/storage/lock.py`, `src/pivot/executor/worker.py`, `src/pivot/explain.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 4. Complete manifest cache flush boundaries (C2 / #363)
+
+  **What to do**:
+  - Add `fingerprint.flush_manifest_cache()` calls at these lifecycle points:
+    1. `src/pivot/discovery.py` — after pipeline discovery completes (alongside existing `flush_ast_hash_cache()` calls at lines 130, 388)
+    2. `src/pivot/pipeline/yaml.py` — after YAML pipeline loading (alongside existing `flush_ast_hash_cache()` call at line 215)
+    3. `src/pivot/engine/engine.py:_handle_code_or_config_changed()` (line 1175) — after registry reload in watch mode, before next run cycle
+  - Verify that `flush_manifest_cache()` is safe to call multiple times (it is — it's a drain-and-write pattern).
+  - Add a test that verifies manifest cache entries are persisted to StateDB after discovery (not just at atexit).
+
+  **Must NOT do**:
+  - Do not change the manifest cache data format
+  - Do not change the atexit flush (keep it as a safety net)
+  - Do not add flush calls in hot loops (only at lifecycle checkpoints)
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Small, targeted change — adding function calls at 3 known locations.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 7)
+  - **Blocks**: Task 5
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/discovery.py:130` and `src/pivot/discovery.py:388` — Existing `flush_ast_hash_cache()` calls. Add `flush_manifest_cache()` alongside each.
+  - `src/pivot/pipeline/yaml.py:215` — Existing `flush_ast_hash_cache()` call. Add `flush_manifest_cache()` alongside.
+  - `src/pivot/engine/engine.py:1175-1200` — `_handle_code_or_config_changed()` watch reload handler. Add manifest flush after registry reload.
+
+  **API/Type References**:
+  - `src/pivot/fingerprint.py:274-292` — `flush_manifest_cache()` function
+
+  **Acceptance Criteria**:
+
+  - [x] `flush_manifest_cache()` called in discovery.py (2 locations), yaml.py (1 location), engine.py watch reload (1 location)
+  - [x] New test: after discovery, `sm:` entries exist in StateDB (not just pending in memory)
+  - [x] `uv run pytest tests/ -n auto` → PASS
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Manifest cache persists after discovery
+    Tool: Bash
+    Steps:
+      1. uv run pytest tests/ -k "manifest_cache" -v
+      2. Assert: exit code 0
+    Expected Result: Manifest cache flush tests pass
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `perf(fingerprint): add manifest cache flush boundaries for watch mode (#363)`
+  - Files: `src/pivot/discovery.py`, `src/pivot/pipeline/yaml.py`, `src/pivot/engine/engine.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 5. Selective re-fingerprinting via reverse index (#358)
+
+  **What to do**:
+  - In the watch-mode reload path (`src/pivot/engine/engine.py:_handle_code_or_config_changed()`), after receiving changed file paths from the watcher:
+    1. Load cached manifests from StateDB for all registered stages
+    2. For each cached manifest, check if any of its recorded source files (`"s"` key) match the changed paths
+    3. Only invalidate + re-fingerprint stages whose source files overlap with changes
+    4. Stages with no overlap keep their cached manifest (skip fingerprinting entirely)
+  - Add a helper function in `src/pivot/fingerprint.py` like `invalidate_manifests_for_paths(changed_paths: list[str])` that scans `sm:` entries and deletes those referencing changed files.
+  - If no cached manifests exist (cold start), fall back to fingerprinting all stages (existing behavior).
+
+  **Must NOT do**:
+  - Do not change the manifest cache format
+  - Do not attempt parallel fingerprinting (#364)
+  - Do not change one-shot (non-watch) behavior
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Requires understanding of the manifest cache data structure and the watch-mode reload flow.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (after Task 4)
+  - **Blocks**: Task 6
+  - **Blocked By**: Task 4
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/fingerprint.py:319-352` — `get_stage_fingerprint_cached()`: shows how manifest is stored with source map `"s": {rel_path: [mtime_ns, size, inode]}`. This is the reverse index.
+  - `src/pivot/fingerprint.py:146-148` — `_make_manifest_cache_key()`: key format for `sm:` entries
+  - `src/pivot/engine/engine.py:1175-1200` — Watch reload handler that currently re-fingerprints all stages
+
+  **API/Type References**:
+  - `src/pivot/engine/types.py:79-81` — `CodeOrConfigChanged` event with `paths` field (the changed file paths from watcher)
+  - `src/pivot/storage/state.py:329-347` — `get_raw()` / `put_raw()` for reading/writing `sm:` entries
+
+  **Acceptance Criteria**:
+
+  - [x] New function `invalidate_manifests_for_paths()` or similar in `src/pivot/fingerprint.py`
+  - [x] Watch reload only re-fingerprints stages whose source files changed
+  - [x] Stages unaffected by file changes retain cached manifests
+  - [x] Cold start (no cached manifests) falls back to fingerprinting all stages
+  - [x] New test: with 5 stages, changing 1 source file only invalidates affected stage(s)
+  - [x] `uv run pytest tests/ -n auto` → PASS
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Selective re-fingerprinting works
+    Tool: Bash
+    Steps:
+      1. uv run pytest tests/ -k "selective_fingerprint" -v
+      2. Assert: exit code 0
+    Expected Result: Only affected stages re-fingerprinted
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `perf(fingerprint): selective re-fingerprinting in watch mode via reverse index (#358)`
+  - Files: `src/pivot/fingerprint.py`, `src/pivot/engine/engine.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 6. Add skip-invariant documentation + integration tests
+
+  **What to do**:
+  - Add a `docs/solutions/` document explaining the skip detection invariants:
+    - What is keyed by logical path vs physical identity (resolve vs normpath)
+    - What data must exist for generation skipping to be sound
+    - The tiering: generation → lock compare → run cache (now actually tiered)
+    - The Pivot-produced-artifact soundness boundary
+  - Add integration tests that exercise the full skip detection pipeline end-to-end:
+    - Stage with all Pivot deps → generation skip works (no hashing)
+    - Stage with external dep → falls through to hash-based check
+    - StateDB cleared → graceful degradation to lock comparison
+    - Lock file missing → full run
+  - Update `src/pivot/storage/AGENTS.md` to reflect the changes (dep_generations removed from lockfiles, file-hash write-back added).
+
+  **Must NOT do**:
+  - Do not change any runtime behavior (documentation + tests only)
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+    - Reason: Mix of documentation writing and integration test authoring; needs thorough understanding of all prior tasks.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (final, after Tasks 2, 3, 5)
+  - **Blocks**: None (final task)
+  - **Blocked By**: Tasks 2, 3, 5
+
+  **References**:
+
+  **Documentation References**:
+  - `src/pivot/storage/AGENTS.md` — Storage guidelines to update
+  - `docs/solutions/` — Existing solution docs for pattern reference
+  - This plan file (`p0-cache-fingerprint-correctness.md`) — Context and design decisions sections
+
+  **Test References**:
+  - `tests/storage/test_state.py` — StateDB test patterns
+  - `tests/storage/test_lock.py` — Lock test patterns
+
+  **Acceptance Criteria**:
+
+  - [x] New doc in `docs/solutions/` covering skip detection invariants
+  - [x] `src/pivot/storage/AGENTS.md` updated (dep_generations removed, file-hash write-back documented)
+  - [x] Integration tests covering all 4 skip scenarios (generation, external dep, cleared StateDB, missing lock)
+  - [x] `uv run pytest tests/ -n auto` → PASS
+
+  **Commit**: YES
+  - Message: `docs(storage): document skip detection invariants and add integration tests`
+  - Files: `docs/solutions/`, `src/pivot/storage/AGENTS.md`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+- [x] 7. Safe fingerprinting defaults + unsafe mode escape hatch
+
+  **What to do**:
+  - In `_process_closure_values()` (`src/pivot/fingerprint.py:451`), add validation when processing closure variables:
+    - For each value that is a user-class instance (currently handled by `_process_instance_dependency()`):
+      - Check if it's a frozen dataclass (`dataclasses.is_dataclass(value) and value.__dataclass_params__.frozen`)
+      - Check if it's a frozen Pydantic model (`hasattr(type(value), 'model_config') and type(value).model_config.get('frozen', False)`)
+      - If frozen → allow (existing behavior: fingerprint by class)
+      - If NOT frozen → raise `StageDefinitionError` with message naming the variable, its type, and suggesting `StageParams` or `Dep(...)`
+    - For mutable collections (dict, list, set) captured as closure variables that contain non-callable, non-primitive content:
+      - Raise `StageDefinitionError` with same guidance
+  - Add project config `core.unsafe_fingerprinting` (boolean, default false) in `src/pivot/config/models.py`:
+    - When true, downgrade the above errors to warnings (log.warning)
+  - Add env var `PIVOT_UNSAFE_FINGERPRINTING` that overrides config (either one enables unsafe mode)
+  - Read the config/env in `get_stage_fingerprint()` or `_process_closure_values()` and branch accordingly.
+  - Error message format:
+    ```
+    Stage '{stage_name}': closure captures mutable variable '{var_name}' (type: {type_name}).
+    Pivot cannot track changes to mutable runtime state, which may cause silent wrong outputs.
+    Fix: pass this data via StageParams or declare it as a Dep(...) input.
+    To suppress: set core.unsafe_fingerprinting=true or PIVOT_UNSAFE_FINGERPRINTING=1
+    ```
+
+  **Must NOT do**:
+  - Do not recurse into objects to prove immutability (static checks only)
+  - Do not change fingerprinting behavior for primitives, tuples, frozensets, or callables
+  - Do not add per-stage or per-variable granularity (single boolean only)
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Needs careful logic for detecting mutability + integration with config system + error message design.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 4)
+  - **Blocks**: None
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `src/pivot/fingerprint.py:451-489` — `_process_closure_values()`: where closure variables are categorized and processed. Add validation here.
+  - `src/pivot/fingerprint.py:519-533` — `_process_instance_dependency()`: current instance handling (class-only fingerprint)
+  - `src/pivot/fingerprint.py:487-488` — `_is_user_class_instance()`: detection function
+  - `src/pivot/registry.py:309-316` — Existing lambda warning pattern (follow this style for error messages)
+
+  **API/Type References**:
+  - `src/pivot/config/models.py:59-73` — `CoreConfig` model (add `unsafe_fingerprinting: bool = False`)
+  - `src/pivot/config/io.py` — Config reader functions (add `get_unsafe_fingerprinting()`)
+  - `src/pivot/exceptions.py` — `StageDefinitionError` for the error to raise
+
+  **Test References**:
+  - `tests/fingerprint/test_fingerprint.py` — Existing fingerprint tests
+
+  **Acceptance Criteria**:
+
+  - [x] Stage closing over mutable dict/list/set raises `StageDefinitionError` by default
+  - [x] Stage closing over non-frozen user-class instance raises `StageDefinitionError` by default
+  - [x] Stage closing over frozen dataclass → allowed (no error)
+  - [x] Stage closing over frozen Pydantic model → allowed (no error)
+  - [x] Error message names the variable, its type, and suggests `StageParams`/`Dep(...)`
+  - [x] `PIVOT_UNSAFE_FINGERPRINTING=1` downgrades error to warning
+  - [x] `core.unsafe_fingerprinting=true` in config downgrades error to warning
+  - [x] Primitives, tuples, frozensets, callables → no change in behavior
+  - [x] `uv run pytest tests/ -n auto` → PASS
+  - [x] `uv run ruff format . && uv run ruff check . && uv run basedpyright` → clean
+
+  **Agent-Executed QA Scenarios**:
+
+  ```
+  Scenario: Mutable closure capture raises error
+    Tool: Bash
+    Steps:
+      1. uv run pytest tests/ -k "safe_fingerprint" -v
+      2. Assert: exit code 0
+      3. Assert: output contains "PASSED" for mutable capture test
+    Expected Result: Error raised for mutable captures, allowed for frozen instances
+    Evidence: pytest output captured
+
+  Scenario: Unsafe mode suppresses error
+    Tool: Bash
+    Steps:
+      1. PIVOT_UNSAFE_FINGERPRINTING=1 uv run pytest tests/ -k "unsafe_fingerprint" -v
+      2. Assert: exit code 0
+    Expected Result: Warning instead of error when env var set
+    Evidence: pytest output captured
+  ```
+
+  **Commit**: YES
+  - Message: `feat(fingerprint): safe-by-default closure validation with unsafe mode escape hatch`
+  - Files: `src/pivot/fingerprint.py`, `src/pivot/config/models.py`, `src/pivot/config/io.py`, `tests/`
+  - Pre-commit: `uv run pytest tests/ -n auto`
+
+---
+
+## Commit Strategy
+
+| After Task | Message | Key Files | Verification |
+|------------|---------|-----------|--------------|
+| 1 | `fix(executor): reorder skip detection to try generation check before dep hashing` | worker.py | `uv run pytest tests/ -n auto` |
+| 2 | `feat(storage): add file-hash cache write-back via DeferredWrites` | types.py, worker.py, state.py | `uv run pytest tests/ -n auto` |
+| 3 | `fix(storage): consolidate dep_generations to StateDB-only, remove from lockfiles` | types.py, lock.py, worker.py | `uv run pytest tests/ -n auto` |
+| 4 | `perf(fingerprint): add manifest cache flush boundaries for watch mode (#363)` | discovery.py, yaml.py, engine.py | `uv run pytest tests/ -n auto` |
+| 5 | `perf(fingerprint): selective re-fingerprinting in watch mode (#358)` | fingerprint.py, engine.py | `uv run pytest tests/ -n auto` |
+| 6 | `docs(storage): document skip detection invariants and add integration tests` | docs/, AGENTS.md, tests/ | `uv run pytest tests/ -n auto` |
+| 7 | `feat(fingerprint): safe-by-default closure validation with unsafe mode escape hatch` | fingerprint.py, config/ | `uv run pytest tests/ -n auto` |
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+uv run pytest tests/ -n auto                                        # All tests pass
+uv run ruff format . && uv run ruff check . && uv run basedpyright  # Quality clean
+```
+
+### Final Checklist
+- [x] Generation skip runs before dep hashing (C0 fixed)
+- [x] File-hash cache entries written back via DeferredWrites (C0 perf)
+- [x] `dep_generations` only in StateDB; lockfiles no longer store it (C1 fixed)
+- [x] Old lockfiles with `dep_generations` still load correctly (backward compat)
+- [x] Manifest cache flushed at discovery/registration/watch reload (C2/#363 complete)
+- [x] Watch mode only re-fingerprints affected stages (#358 complete)
+- [x] Mutable closure captures error by default (safe fingerprinting)
+- [x] Unsafe mode escape hatch works (config + env var)
+- [x] Skip detection invariants documented in `docs/solutions/`
+- [x] All tests pass, quality checks clean

--- a/docs/solutions/2026-02-08-skip-detection-invariants.md
+++ b/docs/solutions/2026-02-08-skip-detection-invariants.md
@@ -1,0 +1,107 @@
+---
+tags: [python, caching, skip-detection, statedb, fingerprinting]
+category: architecture
+module: executor, storage
+symptoms: ["stage re-runs unexpectedly", "stage skips when it shouldn't", "generation check falls through to hashing"]
+---
+
+# Skip Detection Invariants
+
+## Overview
+
+Skip detection decides whether a stage needs to re-execute. It uses a three-tier algorithm with increasing cost, short-circuiting at the first conclusive tier.
+
+## Three-Tier Algorithm
+
+### Tier 1: O(1) Generation Check
+
+`worker.can_skip_via_generation()` runs **before** any dependency hashing. It compares monotonic generation counters stored in StateDB.
+
+Every time a stage's outputs are committed, the coordinator increments a generation counter for each output path. When a downstream stage checks whether to skip, it compares the current generation of each dependency against the generations recorded when the stage last ran.
+
+**Preconditions for generation skip:**
+- Lock file exists with matching code manifest (`fingerprint`) and params
+- Output paths in lock file match current output paths
+- All dependency paths have generation counters in StateDB
+- All dependency generations match the recorded values from last run
+- File metadata in StateDB matches on-disk stat (catches external modifications)
+
+If **any** of these fail, the generation check returns `False` and execution falls through to Tier 2.
+
+### Tier 2: O(n) Lock File Comparison
+
+`StageLock.is_changed_with_lock_data()` compares the full lock file state:
+- Code manifest (fingerprint of stage function + helper functions)
+- Parameters (effective params after overrides)
+- Dependency hashes (content hashes of all input files/directories)
+- Output path list (detect added/removed outputs)
+
+This requires hashing all dependency files, hence O(n) in the number/size of dependencies.
+
+### Tier 3: Run Cache Lookup
+
+If Tier 2 determines the stage must run (e.g., a dependency changed), the run cache is checked before actual execution. The run cache maps `(fingerprint + params + dep_hashes + out_specs) → output_hashes`, so if the same configuration was previously executed (even in a different pipeline run), outputs can be restored from cache without re-executing.
+
+The run cache key (`input_hash`) includes output cache flags, so toggling `cache=True/False` on an output produces a different key.
+
+## Pivot-Produced Artifact Boundary
+
+Generation skip only works when **all** dependencies have generation counters in StateDB. Counters are created by the coordinator when a stage's outputs are committed — meaning only **Pivot-produced artifacts** have them.
+
+External files (user-created data, config files, files not produced by any Pivot stage) lack generation counters. When a stage depends on external files:
+
+1. `can_skip_via_generation()` finds `current_gen is None` for the external dep
+2. Returns `False`, falling through to hash-based comparison (Tier 2)
+3. Tier 2 hashes the file and compares against the lock file
+
+This is by design: external files can change at any time without Pivot's knowledge, so the only reliable check is content hashing.
+
+## dep_generations: StateDB Only
+
+Dependency generations (`{dep_path: generation}`) are stored **only in StateDB**, not in lock files. The `LockData` TypedDict contains `code_manifest`, `params`, `dep_hashes`, and `output_hashes` — no `dep_generations` field.
+
+Workers compute dependency generations via `compute_dep_generation_map()` and return them in `DeferredWrites`. The coordinator applies these to StateDB via `apply_deferred_writes()`. Old lock files that may have contained `dep_generations` are handled gracefully — the field is simply ignored during lock file reading since `LockData` doesn't declare it.
+
+## File-Hash Write-Back
+
+Workers open StateDB in **readonly mode** during execution to avoid write contention. However, dependency hashing produces file hash entries (path, mtime_ns, size, inode, hash) that should be cached in StateDB for future O(1) lookups.
+
+The solution: workers collect these entries in `file_hash_entries` (returned from `hash_dependencies()`) and include them in `DeferredWrites`. The coordinator writes them back to StateDB after stage completion via `apply_deferred_writes()`. This gives the performance benefit of hash caching without requiring workers to hold write locks on StateDB.
+
+`DeferredWrites.file_hash_entries` is a list of `(path, mtime_ns, size, inode, hash)` tuples. The coordinator writes these entries back to StateDB as provided. If a file changed between the worker's read and the coordinator's write, the entry may contain stale metadata — the next run will detect the mismatch and re-hash (self-healing).
+
+## Logical Path vs Physical Identity
+
+Lock files and StateDB use different path semantics:
+
+- **Lock files** store project-relative paths. In memory, paths are first normalized to absolute form via `project.normalize_path()`, and `storage/lock.py` converts between those absolute paths and the project-relative paths written to (and read from) the lock file. Symlinks are preserved. Using project-relative paths ensures portability across machines and stable lock file content.
+
+- **StateDB file hash cache** uses `path.resolve()` (follows symlinks) for the key. This means multiple symlinks to the same physical file share one cached hash entry, avoiding redundant hashing.
+
+- **StateDB generation counters** use `os.path.normpath(path.absolute())` (preserves symlinks). This tracks the *logical* path the user declared, not where symlinks point. This is important because Pivot outputs become symlinks to cache after execution — `resolve()` would follow them to cache paths that change per-run.
+
+## Manifest Cache
+
+Fingerprint manifests (the code_manifest dict mapping `"self:func_name"` → hash) are cached in StateDB under the `sm:` prefix, along with source maps that record which source files contributed to the manifest.
+
+**Flush boundaries** (where pending manifest cache writes are committed to StateDB):
+- After discovery (`discovery.py` — when stages are found via `pivot.yaml`/`pipeline.py`)
+- After YAML config load
+- After module load
+- In watch mode, before reload
+
+**Selective invalidation in watch mode:** When a source file changes, the engine uses a reverse index to find which manifest cache entries depend on that file, and invalidates only those entries. This avoids re-fingerprinting all stages when only one source file changed. The reverse index is built by scanning all `sm:` entries' source maps.
+
+## Safe Fingerprinting
+
+Pivot fingerprints stage functions by hashing their AST and the ASTs of any helper functions they call. Closures that capture **mutable** variables (lists, dicts, instances) are problematic because their runtime state isn't tracked by the AST hash — a change to a captured list won't trigger re-execution.
+
+By default, mutable closure captures raise `StageDefinitionError` with a message explaining the issue and suggesting alternatives (StageParams or Dep inputs).
+
+**Escape hatches:**
+- Config: `core.unsafe_fingerprinting: true` in `pivot.yaml`
+- Environment: `PIVOT_UNSAFE_FINGERPRINTING=1`
+
+When enabled, mutable captures produce a warning instead of an error. This is unsafe because it can lead to silent wrong outputs — the captured value may change without triggering re-execution.
+
+Immutable captures (strings, numbers, tuples, frozen dataclasses, frozensets) are always allowed since they can't change after creation.

--- a/packages/pivot-tui/src/pivot_tui/diff_panels.py
+++ b/packages/pivot-tui/src/pivot_tui/diff_panels.py
@@ -171,7 +171,7 @@ def compute_output_changes(
                 if path_obj.is_dir():
                     new_hash, _ = cache.hash_directory(path_obj)
                 else:
-                    new_hash = cache.hash_file(path_obj)
+                    new_hash, _ = cache.hash_file(path_obj)
         except OSError as e:
             logger.debug("Failed to read %s for hashing: %s", path, e)
             new_hash = None

--- a/packages/pivot-tui/tests/conftest.py
+++ b/packages/pivot-tui/tests/conftest.py
@@ -297,7 +297,7 @@ def cleanup_worker_pool() -> Generator[None]:
 
 
 # Type alias for make_valid_lock_content fixture
-# Returns dict matching StorageLockData structure (code_manifest, params, deps, outs, dep_generations)
+# Returns dict matching StorageLockData structure (code_manifest, params, deps, outs)
 ValidLockContentFactory = Callable[..., dict[str, object]]
 
 
@@ -316,7 +316,6 @@ def make_valid_lock_content() -> ValidLockContentFactory:
             "params": params or {},
             "deps": deps or [],
             "outs": outs or [],
-            "dep_generations": {},
         }
 
     return _factory

--- a/packages/pivot-tui/tests/test_diff_panels.py
+++ b/packages/pivot-tui/tests/test_diff_panels.py
@@ -220,7 +220,6 @@ def test_compute_output_changes_missing_file_shows_removed(tmp_path: pathlib.Pat
         "params": {},
         "dep_hashes": {},
         "output_hashes": {str(output_file): {"hash": "oldhash123"}},
-        "dep_generations": {},
     }
 
     result = diff_panels.compute_output_changes(lock_data, registry_info)
@@ -236,7 +235,7 @@ def test_compute_output_changes_unchanged(tmp_path: pathlib.Path) -> None:
     output_file = tmp_path / "output.csv"
     output_file.write_text("data")
 
-    actual_hash = cache.hash_file(output_file)
+    actual_hash, _ = cache.hash_file(output_file)
 
     registry_info: RegistryStageInfo = {
         "func": lambda: None,
@@ -261,7 +260,6 @@ def test_compute_output_changes_unchanged(tmp_path: pathlib.Path) -> None:
         "params": {},
         "dep_hashes": {},
         "output_hashes": {str(output_file): {"hash": actual_hash}},
-        "dep_generations": {},
     }
 
     result = diff_panels.compute_output_changes(lock_data, registry_info)

--- a/packages/pivot/src/pivot/cli/track.py
+++ b/packages/pivot/src/pivot/cli/track.py
@@ -159,7 +159,7 @@ def _track_single_path(
             "manifest": manifest,
         }
     else:
-        file_hash = cache.hash_file(path)
+        file_hash, _ = cache.hash_file(path)
         file_size = path.stat().st_size
         file_cache_path = cache.get_cache_path(cache_dir, file_hash)
         if not file_cache_path.exists():

--- a/packages/pivot/src/pivot/config/models.py
+++ b/packages/pivot/src/pivot/config/models.py
@@ -61,6 +61,7 @@ class CoreConfig(pydantic.BaseModel):
     max_workers: int = -2
     state_dir: str = ".pivot"
     run_history_retention: Annotated[int, pydantic.Field(gt=0)] = 100
+    unsafe_fingerprinting: bool = False
 
     @pydantic.field_validator("max_workers")
     @classmethod
@@ -144,6 +145,7 @@ CONFIG_KEY_DESCRIPTIONS: dict[str, str] = {
     "core.max_workers": "Parallel execution workers",
     "core.state_dir": "State directory path",
     "core.run_history_retention": "Keep last N runs",
+    "core.unsafe_fingerprinting": "Allow mutable closure captures (unsafe)",
     "remote.jobs": "Concurrent transfer jobs",
     "remote.retries": "Retry attempts",
     "remote.connect_timeout": "Connection timeout (seconds)",

--- a/packages/pivot/src/pivot/discovery.py
+++ b/packages/pivot/src/pivot/discovery.py
@@ -128,6 +128,7 @@ def discover_pipeline(
         finally:
             metrics.end("discovery.load_module", _t_module)
             fingerprint.flush_ast_hash_cache()
+            fingerprint.flush_manifest_cache()
     finally:
         metrics.end("discovery.total", _t)
 
@@ -391,6 +392,7 @@ def load_pipeline_from_path(path: pathlib.Path) -> Pipeline | None:
             return None
         finally:
             fingerprint.flush_ast_hash_cache()
+            fingerprint.flush_manifest_cache()
     else:
         logger.debug(f"Unknown pipeline file type: {path}")
         return None

--- a/packages/pivot/src/pivot/engine/engine.py
+++ b/packages/pivot/src/pivot/engine/engine.py
@@ -18,7 +18,7 @@ import anyio
 import anyio.from_thread
 import anyio.to_thread
 
-from pivot import config, exceptions, parameters, project, registry
+from pivot import config, exceptions, fingerprint, parameters, project, registry
 from pivot.engine import agent_rpc
 from pivot.engine import graph as engine_graph
 from pivot.engine.types import (
@@ -1203,12 +1203,15 @@ class Engine:
         # Execute affected stages
         await self._execute_affected_stages(affected)
 
-    async def _handle_code_or_config_changed(self, _event: CodeOrConfigChanged) -> None:
+    async def _handle_code_or_config_changed(self, event: CodeOrConfigChanged) -> None:
         """Handle code/config changes by reloading registry and re-running."""
         _logger.info("Code/config changed - reloading pipeline")
 
         # Invalidate caches
         self._invalidate_caches()
+
+        # Invalidate manifest cache entries for changed source files
+        fingerprint.invalidate_manifests_for_paths(event["paths"])
 
         # Reload registry - returns old_stages on success, None on failure
         reload_result = self._reload_registry()
@@ -1220,6 +1223,9 @@ class Engine:
         # Emit reload event
         old_stages, old_registry = reload_result
         await self._emit_reload_event(old_stages, old_registry)
+
+        # Flush manifest cache so cached manifests survive the reload
+        fingerprint.flush_manifest_cache()
 
         # Resolve external deps (e.g. sibling pipelines) before reading stages.
         # Reload bypasses Pipeline.build_dag() so we must resolve explicitly.

--- a/packages/pivot/src/pivot/executor/commit.py
+++ b/packages/pivot/src/pivot/executor/commit.py
@@ -92,7 +92,7 @@ def commit_stages(
             )
 
             # 3. Hash deps (pass state_db for hash caching)
-            dep_hashes, missing, unreadable = worker.hash_dependencies(
+            dep_hashes, missing, unreadable, _ = worker.hash_dependencies(
                 stage_info["deps_paths"], stage_db
             )
             if missing:
@@ -169,7 +169,6 @@ def commit_stages(
                 params=current_params,
                 dep_hashes=dict(sorted(dep_hashes.items())),
                 output_hashes=dict(sorted(output_hashes.items())),
-                dep_generations={},
             )
             production_lock.write(new_lock_data)
 

--- a/packages/pivot/src/pivot/executor/core.py
+++ b/packages/pivot/src/pivot/executor/core.py
@@ -405,7 +405,7 @@ def verify_tracked_files(project_root: pathlib.Path, checkout_missing: bool = Fa
             # Try to hash the file - handles race conditions where file disappears
             try:
                 if path.is_file():
-                    current_hash = cache.hash_file(path, state_db)
+                    current_hash, _ = cache.hash_file(path, state_db)
                 elif path.is_dir():
                     current_hash, _ = cache.hash_directory(path, state_db)
                 else:

--- a/packages/pivot/src/pivot/executor/worker.py
+++ b/packages/pivot/src/pivot/executor/worker.py
@@ -214,7 +214,40 @@ def execute_stage(
                 lock_data = production_lock.read()
 
                 with state.StateDB(state_db_path, readonly=True) as state_db:
-                    dep_hashes, missing, unreadable = hash_dependencies(
+                    outputs_missing_from_cache = False
+                    if lock_data is not None and not stage_info["force"]:
+                        out_paths = _get_normalized_out_paths(stage_info)
+                        if can_skip_via_generation(
+                            stage_name=stage_name,
+                            fingerprint=stage_info["fingerprint"],
+                            deps=stage_info["deps"],
+                            outs_paths=out_paths,
+                            current_params=current_params,
+                            lock_data=lock_data,
+                            state_db=state_db,
+                            verify_files=True,
+                        ):
+                            out_specs = _get_output_specs(stage_info)
+                            input_hash = _compute_input_hash_from_lock(
+                                lock_data, current_fingerprint, current_params, out_specs
+                            )
+                            restored = _restore_outputs_from_cache(
+                                stage_outs,
+                                lock_data,
+                                files_cache_dir,
+                                checkout_modes,
+                                state_db=state_db,
+                            )
+                            if restored:
+                                return _make_result(
+                                    StageStatus.SKIPPED,
+                                    "unchanged (generation)",
+                                    ring_buffer,
+                                    input_hash=input_hash,
+                                )
+                            outputs_missing_from_cache = True
+
+                    dep_hashes, missing, unreadable, file_hash_entries = hash_dependencies(
                         stage_info["deps"], state_db
                     )
 
@@ -231,15 +264,17 @@ def execute_stage(
                         )
 
                     skip_reason, run_reason, input_hash = _check_skip_or_run(
-                        stage_name,
                         stage_info,
                         production_lock,
                         lock_data,
-                        state_db,
                         current_fingerprint,
                         current_params,
                         dep_hashes,
                     )
+
+                    if outputs_missing_from_cache and skip_reason is not None:
+                        skip_reason = None
+                        run_reason = "outputs missing from cache"
 
                     # Override skip decision if force flag is set
                     if stage_info["force"] and skip_reason is not None:
@@ -286,7 +321,6 @@ def execute_stage(
                                 params=current_params,
                                 dep_hashes=dict(sorted(dep_hashes.items())),
                                 output_hashes=dict(sorted(run_cache_skip["output_hashes"].items())),
-                                dep_generations={},
                             )
                             deferred = _commit_lock_and_build_deferred(
                                 stage_info,
@@ -295,6 +329,7 @@ def execute_stage(
                                 run_cache_skip["output_hashes"],
                                 production_lock,
                                 state_db,
+                                file_hash_entries=file_hash_entries,
                                 increment_outputs=False,
                             )
                             return StageResult(
@@ -350,7 +385,6 @@ def execute_stage(
                     params=current_params,
                     dep_hashes=dict(sorted(dep_hashes.items())),
                     output_hashes=dict(sorted(output_hashes.items())),
-                    dep_generations={},
                 )
 
                 # Single StateDB open for post-execution work
@@ -362,6 +396,7 @@ def execute_stage(
                         output_hashes,
                         production_lock,
                         state_db,
+                        file_hash_entries=file_hash_entries,
                     )
                     return StageResult(
                         status=StageStatus.RAN,
@@ -414,12 +449,23 @@ def _get_output_specs(stage_info: WorkerStageInfo) -> list[tuple[str, bool]]:
     return [(_canonicalize_out(str(out.path)), out.cache) for out in stage_info["outs"]]
 
 
+def _compute_input_hash_from_lock(
+    lock_data: LockData,
+    current_fingerprint: dict[str, str],
+    current_params: dict[str, Any],
+    out_specs: list[tuple[str, bool]],
+) -> str:
+    """Compute input hash using lock file dependency hashes."""
+    deps_list = [
+        DepEntry(path=path, hash=info["hash"]) for path, info in lock_data["dep_hashes"].items()
+    ]
+    return run_history.compute_input_hash(current_fingerprint, current_params, deps_list, out_specs)
+
+
 def _check_skip_or_run(
-    stage_name: str,
     stage_info: WorkerStageInfo,
     stage_lock: lock.StageLock,
     lock_data: LockData | None,
-    state_db: state.StateDB,
     current_fingerprint: dict[str, str],
     current_params: dict[str, Any],
     dep_hashes: dict[str, HashInfo],
@@ -440,18 +486,6 @@ def _check_skip_or_run(
 
     if lock_data is None:
         return None, "No previous run", input_hash
-
-    if can_skip_via_generation(
-        stage_name=stage_name,
-        fingerprint=stage_info["fingerprint"],
-        deps=stage_info["deps"],
-        outs_paths=out_paths,
-        current_params=current_params,
-        lock_data=lock_data,
-        state_db=state_db,
-        verify_files=True,
-    ):
-        return "unchanged (generation)", "", input_hash
 
     changed, run_reason = stage_lock.is_changed_with_lock_data(
         lock_data, current_fingerprint, current_params, dep_hashes, out_paths
@@ -594,7 +628,7 @@ def _file_needs_restore(
         return True
 
     try:
-        current_hash = cache.hash_file(path, state_db)
+        current_hash, _ = cache.hash_file(path, state_db)
         return current_hash != cached_hash["hash"]
     except OSError:
         return True
@@ -670,7 +704,7 @@ def hash_output(path: pathlib.Path, state_db: state.StateDB | None = None) -> Ha
     if path.is_dir():
         tree_hash, manifest = cache.hash_directory(path, state_db)
         return DirHash(hash=tree_hash, manifest=manifest)
-    file_hash = cache.hash_file(path, state_db)
+    file_hash, _ = cache.hash_file(path, state_db)
     return FileHash(hash=file_hash)
 
 
@@ -936,7 +970,7 @@ class _QueueWriter:
 
 def hash_dependencies(
     deps: list[str], state_db: state.StateDB | None = None
-) -> tuple[dict[str, HashInfo], list[str], list[str]]:
+) -> tuple[dict[str, HashInfo], list[str], list[str], list[tuple[str, int, int, int, str]]]:
     """Hash all dependency files and directories.
 
     Returns (hashes, missing_files, unreadable_files).
@@ -947,6 +981,7 @@ def hash_dependencies(
     hashes = dict[str, HashInfo]()
     missing = list[str]()
     unreadable = list[str]()
+    file_hash_entries = list[tuple[str, int, int, int, str]]()
     for dep in deps:
         normalized = str(project.normalize_path(dep))
         path = pathlib.Path(dep)
@@ -955,13 +990,23 @@ def hash_dependencies(
                 tree_hash, manifest = cache.hash_directory(path, state_db)
                 hashes[normalized] = DirHash(hash=tree_hash, manifest=manifest)
             else:
-                hashes[normalized] = FileHash(hash=cache.hash_file(path, state_db))
+                file_hash, file_stat = cache.hash_file(path, state_db)
+                hashes[normalized] = FileHash(hash=file_hash)
+                file_hash_entries.append(
+                    (
+                        normalized,
+                        file_stat.st_mtime_ns,
+                        file_stat.st_size,
+                        file_stat.st_ino,
+                        file_hash,
+                    )
+                )
         except FileNotFoundError:
             missing.append(dep)
         except OSError:
             unreadable.append(dep)
     metrics.end("worker.hash_dependencies", _t)
-    return hashes, missing, unreadable
+    return hashes, missing, unreadable, file_hash_entries
 
 
 # -----------------------------------------------------------------------------
@@ -982,7 +1027,7 @@ def can_skip_via_generation(
     """Check if stage can skip using O(1) generation tracking.
 
     Generation tracking avoids hashing files by tracking monotonic generation counters.
-    Set verify_files=False for status prediction. Falls back to lock_data for --no-commit mode.
+    Set verify_files=False for status prediction.
     """
     if lock_data["code_manifest"] != fingerprint:
         return False
@@ -999,10 +1044,8 @@ def can_skip_via_generation(
     if not deps:
         return True
 
-    # Try StateDB first, fall back to lock_data (for --no-commit mode)
+    # Try StateDB for recorded dependency generations
     recorded_gens = state_db.get_dep_generations(stage_name)
-    if recorded_gens is None:
-        recorded_gens = lock_data["dep_generations"]
     if not recorded_gens:
         return False
 
@@ -1068,6 +1111,7 @@ def _commit_lock_and_build_deferred(
     production_lock: lock.StageLock,
     state_db: state.StateDB,
     *,
+    file_hash_entries: list[tuple[str, int, int, int, str]] | None = None,
     increment_outputs: bool = True,
 ) -> DeferredWrites:
     """Commit lock file and build deferred writes for StateDB.
@@ -1077,7 +1121,12 @@ def _commit_lock_and_build_deferred(
     """
     production_lock.write(lock_data)
     return _build_deferred_writes(
-        stage_info, input_hash, output_hashes, state_db, increment_outputs=increment_outputs
+        stage_info,
+        input_hash,
+        output_hashes,
+        state_db,
+        file_hash_entries=file_hash_entries,
+        increment_outputs=increment_outputs,
     )
 
 
@@ -1087,6 +1136,7 @@ def _build_deferred_writes(
     output_hashes: dict[str, HashInfo],
     state_db: state.StateDB,
     *,
+    file_hash_entries: list[tuple[str, int, int, int, str]] | None = None,
     increment_outputs: bool = True,
 ) -> DeferredWrites:
     """Build deferred writes for coordinator to apply."""
@@ -1113,6 +1163,9 @@ def _build_deferred_writes(
             run_id=stage_info["run_id"],
             output_hashes=output_entries,
         )
+
+    if file_hash_entries:
+        result["file_hash_entries"] = file_hash_entries
 
     return result
 

--- a/packages/pivot/src/pivot/explain.py
+++ b/packages/pivot/src/pivot/explain.py
@@ -256,11 +256,11 @@ def get_stage_explanation(
                 else:
                     missing_deps.append(dep)
 
-        file_hashes, more_missing, unreadable_deps = worker.hash_dependencies(deps_to_hash)
+        file_hashes, more_missing, unreadable_deps, _ = worker.hash_dependencies(deps_to_hash)
         dep_hashes = {**file_hashes, **fallback_hashes}
         missing_deps.extend(more_missing)
     else:
-        dep_hashes, missing_deps, unreadable_deps = worker.hash_dependencies(deps)
+        dep_hashes, missing_deps, unreadable_deps, _ = worker.hash_dependencies(deps)
 
     if missing_deps:
         # Convert to relative paths for user-facing message

--- a/packages/pivot/src/pivot/fingerprint.py
+++ b/packages/pivot/src/pivot/fingerprint.py
@@ -1,24 +1,26 @@
 import ast
 import atexit
 import contextlib
+import contextvars
 import dataclasses
 import functools
 import inspect
 import json
 import logging
 import marshal
+import os
 import pathlib
 import sys
 import textwrap
 import types
 import typing
 import weakref
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import xxhash
 
-from pivot import ast_utils, metrics
+from pivot import ast_utils, exceptions, metrics
 
 if TYPE_CHECKING:
     from pivot import loaders
@@ -96,6 +98,11 @@ _pending_manifest_writes: list[tuple[bytes, bytes]] = []
 # Source files visited during a single stage's fingerprinting.
 # Maps rel_path -> (mtime_ns, size, ino). Set by _collecting_sources().
 _active_source_map: dict[str, tuple[int, int, int]] | None = None
+
+# Stage name used for error reporting during fingerprinting.
+_current_stage_name: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_current_stage_name", default=None
+)
 
 
 def _close_state_db() -> None:
@@ -292,6 +299,93 @@ def flush_manifest_cache() -> None:
         _logger.debug("Failed to flush manifest cache (%d entries)", len(pending), exc_info=True)
 
 
+def _normalize_changed_paths(
+    paths: Sequence[str | os.PathLike[str] | pathlib.Path],
+) -> set[str]:
+    """Normalize changed paths to project-relative strings."""
+    from pivot import project
+
+    project_root = project.get_project_root()
+    normalized = set[str]()
+    for path in paths:
+        candidate = pathlib.Path(path)
+        if not candidate.is_absolute():
+            candidate = project_root / candidate
+        with contextlib.suppress(OSError):
+            candidate = candidate.resolve()
+        try:
+            rel_path = candidate.relative_to(project_root)
+        except ValueError:
+            continue
+        normalized.add(str(rel_path))
+    return normalized
+
+
+def _manifest_references_paths(raw: bytes, changed_paths: set[str]) -> bool:
+    """Check if a cached manifest references any changed path."""
+    try:
+        data: object = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    typed_data = cast("dict[str, Any]", data)
+    sources_raw: object = typed_data.get("s")
+    if not isinstance(sources_raw, dict):
+        return False
+    sources = cast("dict[str, list[int]]", sources_raw)
+    return any(source_path in changed_paths for source_path in sources)
+
+
+def invalidate_manifests_for_paths(
+    paths: Sequence[str | os.PathLike[str] | pathlib.Path],
+) -> None:
+    """Invalidate cached manifests that reference changed source files."""
+    global _pending_manifest_writes
+
+    if not paths:
+        return
+    changed_paths = _normalize_changed_paths(paths)
+    if not changed_paths:
+        return
+
+    from pivot.config import io
+    from pivot.storage import state
+
+    keys_to_delete = set[bytes]()
+    try:
+        with state.StateDB(io.get_state_db_path(), readonly=True) as db:
+            for key, raw in db.iter_prefix(b"sm:"):
+                if _manifest_references_paths(raw, changed_paths):
+                    keys_to_delete.add(key)
+    except Exception:
+        _logger.debug("Failed to scan manifest cache for invalidation", exc_info=True)
+
+    if _pending_manifest_writes:
+        pending_keys = set[bytes]()
+        for key, raw in _pending_manifest_writes:
+            if _manifest_references_paths(raw, changed_paths):
+                pending_keys.add(key)
+        if pending_keys:
+            keys_to_delete.update(pending_keys)
+            _pending_manifest_writes = [
+                (key, value) for key, value in _pending_manifest_writes if key not in pending_keys
+            ]
+
+    if not keys_to_delete:
+        return
+
+    try:
+        with state.StateDB(io.get_state_db_path(), readonly=False) as db:
+            db.delete_raw_many(list(keys_to_delete))
+    except Exception:
+        _logger.debug(
+            "Failed to invalidate manifest cache entries (%d)",
+            len(keys_to_delete),
+            exc_info=True,
+        )
+
+
 def get_stage_fingerprint(
     func: Callable[..., Any], visited: set[int] | None = None
 ) -> dict[str, str]:
@@ -334,8 +428,12 @@ def get_stage_fingerprint_cached(stage_name: str, func: Callable[..., Any]) -> d
     metrics.count("fingerprint.manifest_cache.miss")
 
     # Compute with source tracking
-    with _collecting_sources() as source_map:
-        manifest = get_stage_fingerprint(func)
+    token = _current_stage_name.set(stage_name)
+    try:
+        with _collecting_sources() as source_map:
+            manifest = get_stage_fingerprint(func)
+    finally:
+        _current_stage_name.reset(token)
 
     # Queue for flush
     key = _make_manifest_cache_key(stage_name)
@@ -448,6 +546,55 @@ def get_loader_fingerprint(loader: "loaders.Writer[Any] | loaders.Reader[Any]") 
     return manifest
 
 
+def _is_unsafe_fingerprinting_enabled() -> bool:
+    if os.environ.get("PIVOT_UNSAFE_FINGERPRINTING") == "1":
+        return True
+    try:
+        from pivot.config import io
+
+        config = io.get_merged_config()
+        return config.core.unsafe_fingerprinting
+    except (ImportError, FileNotFoundError, AttributeError):
+        # Config not available yet (early in pipeline lifecycle)
+        return False
+    except Exception:
+        _logger.debug("Failed to read unsafe_fingerprinting config", exc_info=True)
+        return False
+
+
+def _check_mutable_capture(var_name: str, value: Any, stage_name: str) -> None:
+    message = (
+        f"Stage '{stage_name}': closure captures mutable variable '{var_name}' "
+        f"(type: {type(value).__name__}).\n"
+        "Pivot cannot track changes to mutable runtime state, which may cause silent wrong outputs.\n"
+        "Fix: pass this data via StageParams or declare it as a Dep(...) input.\n"
+        "To suppress: set core.unsafe_fingerprinting=true or PIVOT_UNSAFE_FINGERPRINTING=1"
+    )
+    if _is_unsafe_fingerprinting_enabled():
+        _logger.warning(message)
+        return
+    raise exceptions.StageDefinitionError(message)
+
+
+def _is_frozen_dataclass(value: Any) -> bool:
+    if not dataclasses.is_dataclass(value):
+        return False
+    cls = cast("type[Any]", type(value))
+    params = getattr(cls, "__dataclass_params__", None)
+    return bool(params and getattr(params, "frozen", False))
+
+
+def _is_frozen_pydantic(value: Any) -> bool:
+    cls = cast("type[Any]", type(value))
+    model_config = getattr(cls, "model_config", None)
+    if model_config is None:
+        return False
+    try:
+        return bool(model_config.get("frozen", False))
+    except AttributeError:
+        return False
+
+
 def _process_closure_values(
     values: Mapping[str, Any],
     func: Callable[..., Any],
@@ -458,6 +605,7 @@ def _process_closure_values(
     include_modules: bool,
 ) -> None:
     """Process closure variable values (globals or nonlocals) and add to manifest."""
+    stage_name = _current_stage_name.get() or getattr(func, "__name__", "<unknown>")
     for name, value in values.items():
         if skip_dunders and name.startswith("__"):
             continue
@@ -475,6 +623,8 @@ def _process_closure_values(
         elif isinstance(value, (bool, int, float, str, bytes, type(None))):
             manifest[f"const:{name}"] = repr(value)
         elif isinstance(value, (dict, list, tuple, set, frozenset)):
+            if isinstance(value, (dict, list, set)):
+                _check_mutable_capture(name, value, stage_name)
             _process_collection_dependency(
                 name,
                 cast(
@@ -485,7 +635,11 @@ def _process_closure_values(
                 visited,
             )
         elif _is_user_class_instance(value):
-            _process_instance_dependency(name, value, manifest, visited)
+            if _is_frozen_dataclass(value) or _is_frozen_pydantic(value):
+                _process_instance_dependency(name, value, manifest, visited)
+            else:
+                _check_mutable_capture(name, value, stage_name)
+                _process_instance_dependency(name, value, manifest, visited)
 
 
 def _process_callable_dependency(

--- a/packages/pivot/src/pivot/pipeline/yaml.py
+++ b/packages/pivot/src/pivot/pipeline/yaml.py
@@ -213,6 +213,7 @@ def load_pipeline_from_yaml(pipeline_file: Path) -> Pipeline:
 
     # Flush pending AST hash writes to persistent cache
     fingerprint.flush_ast_hash_cache()
+    fingerprint.flush_manifest_cache()
 
     return p
 

--- a/packages/pivot/src/pivot/show/data.py
+++ b/packages/pivot/src/pivot/show/data.py
@@ -587,7 +587,8 @@ def get_data_hashes_from_workspace(paths: Sequence[str]) -> dict[str, str | None
     for rel_path in paths:
         abs_path = proj_root / rel_path
         if abs_path.exists():
-            result[rel_path] = cache.hash_file(abs_path)
+            file_hash, _ = cache.hash_file(abs_path)
+            result[rel_path] = file_hash
         else:
             result[rel_path] = None
 

--- a/packages/pivot/src/pivot/show/plots.py
+++ b/packages/pivot/src/pivot/show/plots.py
@@ -170,7 +170,8 @@ def get_plot_hashes_from_workspace(
     for path_str in paths:
         path = proj_root / path_str
         if path.exists() and path.is_file():
-            result[path_str] = cache.hash_file(path)
+            file_hash, _ = cache.hash_file(path)
+            result[path_str] = file_hash
     return result
 
 

--- a/packages/pivot/src/pivot/status.py
+++ b/packages/pivot/src/pivot/status.py
@@ -349,7 +349,7 @@ def get_tracked_files_status(
                 if path.is_dir():
                     current_hash, _ = cache.hash_directory(path, state_db)
                 else:
-                    current_hash = cache.hash_file(path, state_db)
+                    current_hash, _ = cache.hash_file(path, state_db)
             except FileNotFoundError:
                 results.append(
                     TrackedFileInfo(

--- a/packages/pivot/src/pivot/storage/AGENTS.md
+++ b/packages/pivot/src/pivot/storage/AGENTS.md
@@ -10,15 +10,28 @@ Three-tier algorithm for deciding whether to skip stage execution:
 2. **O(n) lock file comparison** - Compare fingerprint + params + dependency hashes
 3. **Run cache lookup** - Check if input hash matches a cached run
 
+## dep_generations: StateDB Only
+
+Dependency generations (`{dep_path: generation}`) live **only in StateDB**, not in lock files. Workers compute them via `compute_dep_generation_map()` and return them in `DeferredWrites`. The coordinator applies them via `apply_deferred_writes()`. Old lock files that may have contained `dep_generations` are handled gracefully (field ignored on read).
+
+## File-Hash Write-Back (DeferredWrites)
+
+Workers open StateDB in readonly mode. Dependency hashing produces file hash entries that should be cached for future O(1) lookups. These are collected in `DeferredWrites.file_hash_entries` (a list of `(path, mtime_ns, size, inode, hash)` tuples) and written back to StateDB by the coordinator after stage completion.
+
 ## StateDB Key Prefixes
 
-StateDB uses key prefixes for namespacing. Current prefixes in `state_db.py`:
+StateDB uses key prefixes for namespacing. Current prefixes in `pivot/storage/state.py`:
 
 | Prefix | Purpose |
 |--------|---------|
-| `hash:` | Content hashes |
-| `gen:` | Generation counters |
-| `dep:` | Dependency tracking |
+| `hash:` | File content hashes (keyed by resolved/physical path) |
+| `gen:` | Output generation counters (keyed by logical/normpath) |
+| `dep:` | Stage dependency generations (`stage:dep_path` → generation) |
+| `runcache:` | Run cache entries (`stage:input_hash` → output hashes) |
+| `sm:` | Fingerprint manifest cache (stage manifests + source maps) |
+| `run:` | Run history entries |
+| `remote:` | Remote index entries |
+| `fp:` | AST fingerprint/hash cache entries |
 
 **When adding new state types**, define a new prefix constant and document it here.
 
@@ -26,7 +39,7 @@ StateDB uses key prefixes for namespacing. Current prefixes in `state_db.py`:
 
 - Single writer, multiple readers
 - Transactions are mandatory—use context managers
-- Map size must be set upfront (we use 1GB default)
+- Map size must be set upfront (we use 10GB virtual default)
 - Keys and values are bytes—use consistent encoding
 
 ## Path Storage

--- a/packages/pivot/src/pivot/storage/cache.py
+++ b/packages/pivot/src/pivot/storage/cache.py
@@ -81,14 +81,21 @@ def atomic_write_file(
                 os.close(fd)
 
 
-def hash_file(path: pathlib.Path, state_db: state_mod.StateDB | None = None) -> str:
-    """Compute xxhash64 of file contents, using state cache if available."""
+def hash_file(
+    path: pathlib.Path, state_db: state_mod.StateDB | None = None
+) -> tuple[str, os.stat_result]:
+    """Compute xxhash64 of file contents, using state cache if available.
+
+    Returns:
+        Tuple of (file_hash, file_stat) where file_hash is the xxhash64 hex digest
+        and file_stat is the os.stat_result for the file.
+    """
     file_stat = path.stat()
 
     if state_db is not None:
         cached = state_db.get(path, file_stat)
         if cached is not None:
-            return cached
+            return cached, file_stat
 
     _t = metrics.start()
     hasher = xxhash.xxh64()
@@ -110,7 +117,7 @@ def hash_file(path: pathlib.Path, state_db: state_mod.StateDB | None = None) -> 
     if state_db is not None and not state_db.readonly:
         state_db.save(path, file_stat, file_hash)
 
-    return file_hash
+    return file_hash, file_stat
 
 
 # Hardcoded ignore patterns for hot path - O(1) lookups only.
@@ -195,9 +202,10 @@ def hash_directory(
         try:
             rel = file_path.relative_to(path)
             file_stat = entry.stat(follow_symlinks=True)
+            file_hash, _ = hash_file(file_path, state_db)
             manifest_entry: DirManifestEntry = {
                 "relpath": str(rel),
-                "hash": hash_file(file_path, state_db),
+                "hash": file_hash,
                 "size": file_stat.st_size,
                 "isexec": bool(file_stat.st_mode & stat.S_IXUSR),
             }
@@ -467,7 +475,7 @@ def _save_file_to_cache(
             if cache_path.exists():
                 return FileHash(hash=existing_hash)
 
-    file_hash = hash_file(path, state_db)
+    file_hash, _ = hash_file(path, state_db)
     cache_path = get_cache_path(cache_dir, file_hash)
 
     copy_to_cache(path, cache_path)

--- a/packages/pivot/src/pivot/storage/lock.py
+++ b/packages/pivot/src/pivot/storage/lock.py
@@ -44,7 +44,7 @@ _VALID_STAGE_NAME = re.compile(
 )  # Allow / for pipeline-prefixed names, . for DVC matrix keys
 _PATH_TRAVERSAL = re.compile(r"(^|/)\.\.(/|$)")  # Reject ../ path traversal
 _MAX_STAGE_NAME_LEN = 200  # Leave room for ".lock" suffix within filesystem NAME_MAX (255)
-_REQUIRED_LOCK_KEYS = frozenset({"code_manifest", "params", "deps", "outs", "dep_generations"})
+_REQUIRED_LOCK_KEYS = frozenset({"code_manifest", "params", "deps", "outs"})
 
 STAGES_REL_PATH = ".pivot/stages"
 
@@ -125,7 +125,6 @@ def _convert_to_storage_format(data: LockData) -> StorageLockData:
         params=data["params"],
         deps=deps_list,
         outs=outs_list,
-        dep_generations=data["dep_generations"],
     )
 
 
@@ -156,7 +155,6 @@ def _convert_from_storage_format(data: StorageLockData) -> LockData:
         params=data["params"],
         dep_hashes=dep_hashes,
         output_hashes=output_hashes,
-        dep_generations=data["dep_generations"],
     )
 
     return result

--- a/packages/pivot/src/pivot/storage/state.py
+++ b/packages/pivot/src/pivot/storage/state.py
@@ -361,6 +361,32 @@ class StateDB:
         except lmdb.MapFullError as e:
             raise DatabaseFullError(_DB_FULL_MSG) from e
 
+    def delete_raw_many(self, keys: list[bytes]) -> None:
+        """Batch delete raw key-value pairs atomically."""
+        self._check_closed()
+        self._check_write_allowed()
+        if not keys:
+            return
+        try:
+            with self._env.begin(write=True) as txn:
+                for key in keys:
+                    txn.delete(key)
+        except lmdb.MapFullError as e:
+            raise DatabaseFullError(_DB_FULL_MSG) from e
+
+    def iter_prefix(self, prefix: bytes) -> list[tuple[bytes, bytes]]:
+        """Return all raw key-value pairs matching a prefix."""
+        self._check_closed()
+        results = list[tuple[bytes, bytes]]()
+        with self._env.begin() as txn:
+            cursor = txn.cursor()
+            if cursor.set_range(prefix):
+                for key, value in cursor:
+                    if not key.startswith(prefix):
+                        break
+                    results.append((bytes(key), bytes(value)))
+        return results
+
     # -------------------------------------------------------------------------
     # Generation tracking for O(1) skip detection
     # -------------------------------------------------------------------------
@@ -704,6 +730,14 @@ class StateDB:
                         f"Output path too long ({len(key)} bytes, max {_MAX_KEY_SIZE}): {path_str}"
                     )
 
+        if "file_hash_entries" in deferred:
+            for path_str, _, _, _, _ in deferred["file_hash_entries"]:
+                key = _make_key_file_hash(pathlib.Path(path_str))
+                if len(key) > _MAX_KEY_SIZE:
+                    raise PathTooLongError(
+                        f"Path too long for state cache ({len(key)} bytes, max {_MAX_KEY_SIZE}): {path_str}"
+                    )
+
         try:
             with self._env.begin(write=True) as txn:
                 # Dependency generations (clear old entries first, like record_dep_generations)
@@ -738,6 +772,13 @@ class StateDB:
                         + f"{stage_name}:{deferred['run_cache_input_hash']}".encode()
                     )
                     txn.put(key, run_history.serialize_to_bytes(deferred["run_cache_entry"]))
+
+                # File hash entries
+                if "file_hash_entries" in deferred:
+                    for path_str, mtime_ns, size, inode, hash_hex in deferred["file_hash_entries"]:
+                        key = _make_key_file_hash(pathlib.Path(path_str))
+                        value = _pack_value(mtime_ns, size, inode, hash_hex)
+                        txn.put(key, value)
 
         except lmdb.MapFullError as e:
             raise DatabaseFullError(_DB_FULL_MSG) from e

--- a/packages/pivot/src/pivot/types.py
+++ b/packages/pivot/src/pivot/types.py
@@ -129,6 +129,7 @@ class DeferredWrites(TypedDict, total=False):
     run_cache_input_hash: str
     run_cache_entry: RunCacheEntry
     increment_outputs: bool  # True → increment output generations; False/absent → skip
+    file_hash_entries: list[tuple[str, int, int, int, str]]  # (path, mtime_ns, size, inode, hash)
 
 
 class StageResult(TypedDict):
@@ -249,8 +250,6 @@ class StorageLockData(TypedDict):
     params: dict[str, Any]
     deps: list[DepEntry]
     outs: list[OutEntry]
-    # Always empty in lock files; dep generations are tracked in StateDB
-    dep_generations: dict[str, int]
 
 
 class LockData(TypedDict):
@@ -260,8 +259,6 @@ class LockData(TypedDict):
     params: dict[str, Any]
     dep_hashes: dict[str, HashInfo]
     output_hashes: dict[str, HashInfo]
-    # Always empty in lock files; dep generations are tracked in StateDB
-    dep_generations: dict[str, int]
 
 
 OutputMessage = tuple[str, str, bool] | None

--- a/packages/pivot/tests/cli/test_cli_data.py
+++ b/packages/pivot/tests/cli/test_cli_data.py
@@ -153,7 +153,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     lock_path = repo_path / ".pivot" / "stages" / "make_csv.lock"
     lock_path.write_text(lock_content)
@@ -205,7 +204,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -257,7 +255,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -305,7 +302,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -352,7 +348,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -398,7 +393,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -443,7 +437,6 @@ deps: []
 outs:
   - path: result.txt
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     lock_path = repo_path / ".pivot" / "stages" / "make_output.lock"
     lock_path.write_text(lock_content)
@@ -634,7 +627,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial CSV")
@@ -683,7 +675,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Initial")
@@ -734,7 +725,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Large CSV")
@@ -783,7 +773,6 @@ deps: []
 outs:
   - path: output.csv
     hash: {output_hash["hash"]}
-dep_generations: {{}}
 """
     (repo_path / ".pivot" / "stages" / "make_csv.lock").write_text(lock_content)
     commit("Empty CSV")

--- a/packages/pivot/tests/cli/test_cli_params.py
+++ b/packages/pivot/tests/cli/test_cli_params.py
@@ -233,7 +233,6 @@ def test_params_diff_no_changes(
             "params": {"x": 1},
             "deps": [],
             "outs": [],
-            "dep_generations": {},
         }
     )
     mocker.patch.object(
@@ -267,7 +266,6 @@ def test_params_diff_with_changes(
             "params": {"x": 1},
             "deps": [],
             "outs": [],
-            "dep_generations": {},
         }
     )
     mocker.patch.object(
@@ -302,7 +300,6 @@ def test_params_diff_json_format(
             "params": {"x": 1},
             "deps": [],
             "outs": [],
-            "dep_generations": {},
         }
     )
     mocker.patch.object(
@@ -338,7 +335,6 @@ def test_params_diff_md_format(
             "params": {"x": 1},
             "deps": [],
             "outs": [],
-            "dep_generations": {},
         }
     )
     mocker.patch.object(

--- a/packages/pivot/tests/cli/test_cli_status.py
+++ b/packages/pivot/tests/cli/test_cli_status.py
@@ -250,7 +250,7 @@ pipeline = Pipeline('test')
 
         data_file = pathlib.Path("data.txt")
         data_file.write_text("content")
-        file_hash = cache.hash_file(data_file)
+        file_hash, _ = cache.hash_file(data_file)
 
         pvt_data = track.PvtData(path="data.txt", hash=file_hash, size=7)
         track.write_pvt_file(pathlib.Path("data.txt.pvt"), pvt_data)
@@ -278,7 +278,7 @@ pipeline = Pipeline('test')
 
         data_file = pathlib.Path("data.txt")
         data_file.write_text("original")
-        old_hash = cache.hash_file(data_file)
+        old_hash, _ = cache.hash_file(data_file)
 
         pvt_data = track.PvtData(path="data.txt", hash=old_hash, size=8)
         track.write_pvt_file(pathlib.Path("data.txt.pvt"), pvt_data)
@@ -303,7 +303,7 @@ def test_status_stages_only(runner: click.testing.CliRunner, tmp_path: pathlib.P
 
         data_file = pathlib.Path("data.txt")
         data_file.write_text("content")
-        file_hash = cache.hash_file(data_file)
+        file_hash, _ = cache.hash_file(data_file)
 
         pvt_data = track.PvtData(path="data.txt", hash=file_hash, size=7)
         track.write_pvt_file(pathlib.Path("data.txt.pvt"), pvt_data)
@@ -328,7 +328,7 @@ def test_status_tracked_only(runner: click.testing.CliRunner, tmp_path: pathlib.
 
         data_file = pathlib.Path("data.txt")
         data_file.write_text("content")
-        file_hash = cache.hash_file(data_file)
+        file_hash, _ = cache.hash_file(data_file)
 
         pvt_data = track.PvtData(path="data.txt", hash=file_hash, size=7)
         track.write_pvt_file(pathlib.Path("data.txt.pvt"), pvt_data)

--- a/packages/pivot/tests/cli/test_repro.py
+++ b/packages/pivot/tests/cli/test_repro.py
@@ -189,7 +189,7 @@ def test_repro_dry_run_allow_missing_uses_pvt_hash(
     executor.run()
 
     # Track input
-    input_hash = cache.hash_file(tmp_path / "input.txt")
+    input_hash, _ = cache.hash_file(tmp_path / "input.txt")
     pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
     track.write_pvt_file(tmp_path / "input.txt.pvt", pvt_data)
 
@@ -240,7 +240,7 @@ def test_repro_explain_allow_missing_uses_pvt_hash(
     executor.run()
 
     # Track input
-    input_hash = cache.hash_file(tmp_path / "input.txt")
+    input_hash, _ = cache.hash_file(tmp_path / "input.txt")
     pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
     track.write_pvt_file(tmp_path / "input.txt.pvt", pvt_data)
 

--- a/packages/pivot/tests/cli/test_verify.py
+++ b/packages/pivot/tests/cli/test_verify.py
@@ -634,7 +634,7 @@ def test_verify_allow_missing_uses_pvt_hash_for_deps(
     # Track the input file (create .pvt)
     from pivot.storage import track
 
-    input_hash = cache.hash_file(tmp_path / "input.txt")
+    input_hash, _ = cache.hash_file(tmp_path / "input.txt")
     pvt_data = track.PvtData(path="input.txt", hash=input_hash, size=4)
     track.write_pvt_file(tmp_path / "input.txt.pvt", pvt_data)
 

--- a/packages/pivot/tests/conftest.py
+++ b/packages/pivot/tests/conftest.py
@@ -346,7 +346,7 @@ def cleanup_worker_pool() -> Generator[None]:
 
 
 # Type alias for make_valid_lock_content fixture
-# Returns dict matching StorageLockData structure (code_manifest, params, deps, outs, dep_generations)
+# Returns dict matching StorageLockData structure (code_manifest, params, deps, outs)
 ValidLockContentFactory = Callable[..., dict[str, object]]
 
 
@@ -365,7 +365,6 @@ def make_valid_lock_content() -> ValidLockContentFactory:
             "params": params or {},
             "deps": deps or [],
             "outs": outs or [],
-            "dep_generations": {},
         }
 
     return _factory

--- a/packages/pivot/tests/core/test_explain.py
+++ b/packages/pivot/tests/core/test_explain.py
@@ -329,7 +329,6 @@ def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -359,7 +358,6 @@ def test_get_stage_explanation_code_changed(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -393,7 +391,6 @@ def test_get_stage_explanation_params_changed(tmp_path: Path) -> None:
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -431,7 +428,6 @@ def test_get_stage_explanation_deps_changed(tmp_path: Path) -> None:
             params={},
             dep_hashes={normalized_path: {"hash": "old_data_hash"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -470,7 +466,6 @@ def test_get_stage_explanation_multiple_changes(tmp_path: Path) -> None:
             params={"epochs": 5},
             dep_hashes={normalized_path: {"hash": "old_hash"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -499,7 +494,6 @@ def test_get_stage_explanation_missing_deps(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -539,7 +533,6 @@ def test_get_stage_explanation_invalid_params(
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -583,7 +576,6 @@ def test_get_stage_explanation_force_without_changes(
                 params={},
                 dep_hashes={},
                 output_hashes={},
-                dep_generations={},
             )
         )
 
@@ -619,7 +611,6 @@ def test_get_stage_explanation_force_with_code_changes(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -650,7 +641,6 @@ def test_get_stage_explanation_force_with_missing_deps(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -848,7 +838,6 @@ def test_get_stage_explanation_with_allow_missing_uses_pvt_hash(tmp_path: Path) 
             params={},
             dep_hashes={normalized_path: {"hash": "pvt_hash_123"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -897,7 +886,6 @@ def test_get_stage_explanation_with_allow_missing_stale_pvt(tmp_path: Path) -> N
             params={},
             dep_hashes={normalized_path: {"hash": "old_lock_hash"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -934,7 +922,6 @@ def test_get_stage_explanation_allow_missing_untracked_still_fails(tmp_path: Pat
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -977,7 +964,6 @@ def test_get_stage_explanation_allow_missing_uses_lock_file_hash(tmp_path: Path)
             params={},
             dep_hashes={normalized_path: {"hash": "lock_hash_123"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 

--- a/packages/pivot/tests/execution/test_executor.py
+++ b/packages/pivot/tests/execution/test_executor.py
@@ -1913,7 +1913,6 @@ def test_executor_lock_file_missing_outs_triggers_rerun(
                 "code_manifest": {},
                 "params": {},
                 "deps": [],
-                "dep_generations": {},
                 # No outs - incomplete lock
             }
         )

--- a/packages/pivot/tests/execution/test_executor_worker.py
+++ b/packages/pivot/tests/execution/test_executor_worker.py
@@ -168,6 +168,97 @@ def test_execute_stage_runs_unchanged_stage(
     assert result2["reason"] == "unchanged"
 
 
+def test_execute_stage_generation_skip_avoids_hashing(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """Generation skip avoids dependency hashing and reports reason."""
+    dep_path = tmp_path / "input.txt"
+    dep_path.write_text("data")
+    stage_name = "test_stage"
+    fingerprint = {"self:_helper_noop_stage": "fp123"}
+
+    stage_info = _make_stage_info(
+        _helper_noop_stage,
+        tmp_path,
+        fingerprint=fingerprint,
+        deps=["input.txt"],
+    )
+
+    state_dir = tmp_path / ".pivot"
+    with _chdir_and_reset_project_root(tmp_path):
+        with state.StateDB(state_dir / "state.db") as state_db:
+            dep_hash, _ = cache.hash_file(dep_path, state_db)
+            state_db.increment_generation(dep_path)
+            dep_gen = state_db.get_generation(dep_path)
+            assert dep_gen is not None
+            normalized_dep = str(project.normalize_path("input.txt"))
+            state_db.record_dep_generations(stage_name, {normalized_dep: dep_gen})
+
+        lock_data: LockData = {
+            "code_manifest": fingerprint,
+            "params": {},
+            "dep_hashes": {normalized_dep: FileHash(hash=dep_hash)},
+            "output_hashes": {},
+        }
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
+        stage_lock.write(lock_data)
+
+    hash_mock = mocker.patch("pivot.executor.worker.hash_dependencies", autospec=True)
+    result = executor.execute_stage(stage_name, stage_info, worker_env, output_queue)
+
+    hash_mock.assert_not_called()
+    assert result["status"] == "skipped"
+    assert result["reason"] == "unchanged (generation)"
+
+
+def test_execute_stage_hashes_when_generation_missing(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """Missing dependency generation falls back to hashing."""
+    dep_path = tmp_path / "input.txt"
+    dep_path.write_text("data")
+    stage_name = "test_stage"
+    fingerprint = {"self:_helper_noop_stage": "fp123"}
+
+    stage_info = _make_stage_info(
+        _helper_noop_stage,
+        tmp_path,
+        fingerprint=fingerprint,
+        deps=["input.txt"],
+    )
+
+    state_dir = tmp_path / ".pivot"
+    with _chdir_and_reset_project_root(tmp_path):
+        with state.StateDB(state_dir / "state.db") as state_db:
+            dep_hash, _ = cache.hash_file(dep_path, state_db)
+            normalized_dep = str(project.normalize_path("input.txt"))
+            state_db.record_dep_generations(stage_name, {normalized_dep: 1})
+
+        lock_data: LockData = {
+            "code_manifest": fingerprint,
+            "params": {},
+            "dep_hashes": {normalized_dep: FileHash(hash=dep_hash)},
+            "output_hashes": {},
+        }
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(state_dir))
+        stage_lock.write(lock_data)
+
+    hash_mock = mocker.patch(
+        "pivot.executor.worker.hash_dependencies",
+        autospec=True,
+        wraps=worker.hash_dependencies,
+    )
+    _ = executor.execute_stage(stage_name, stage_info, worker_env, output_queue)
+
+    assert hash_mock.called, "Expected dependency hashing when generation is missing"
+
+
 def test_execute_stage_reruns_when_fingerprint_changes(
     worker_env: pathlib.Path, output_queue: mp.Queue[OutputMessage], tmp_path: pathlib.Path
 ) -> None:
@@ -1114,7 +1205,9 @@ def test_hash_dependencies_with_existing_files(
 
     monkeypatch.chdir(tmp_path)
     project._project_root_cache = None
-    hashes, missing, unreadable = executor.hash_dependencies(["file1.txt", "file2.txt"])
+    hashes, missing, unreadable, file_hash_entries = executor.hash_dependencies(
+        ["file1.txt", "file2.txt"]
+    )
 
     assert len(hashes) == 2
     # Keys are now normalized paths (absolute)
@@ -1129,15 +1222,21 @@ def test_hash_dependencies_with_existing_files(
     assert "manifest" not in file_hash, "Files should not have manifest"
     assert len(missing) == 0
     assert len(unreadable) == 0
+    assert len(file_hash_entries) == 2
+    entry_paths = {entry[0] for entry in file_hash_entries}
+    assert entry_paths == {str(tmp_path / "file1.txt"), str(tmp_path / "file2.txt")}
 
 
 def test_hash_dependencies_with_missing_files() -> None:
     """hash_dependencies reports missing files."""
-    hashes, missing, unreadable = executor.hash_dependencies(["missing1.txt", "missing2.txt"])
+    hashes, missing, unreadable, file_hash_entries = executor.hash_dependencies(
+        ["missing1.txt", "missing2.txt"]
+    )
 
     assert len(hashes) == 0
     assert missing == ["missing1.txt", "missing2.txt"]
     assert len(unreadable) == 0
+    assert file_hash_entries == []
 
 
 def test_hash_dependencies_with_directory(
@@ -1151,7 +1250,7 @@ def test_hash_dependencies_with_directory(
 
     monkeypatch.chdir(tmp_path)
     project._project_root_cache = None
-    hashes, missing, unreadable = executor.hash_dependencies(["data_dir"])
+    hashes, missing, unreadable, file_hash_entries = executor.hash_dependencies(["data_dir"])
 
     assert len(hashes) == 1, "Directory should be hashed"
     # Keys are now normalized paths (absolute)
@@ -1167,6 +1266,7 @@ def test_hash_dependencies_with_directory(
     assert manifest[0]["relpath"] == "file.txt"
     assert len(missing) == 0, "No missing dependencies"
     assert len(unreadable) == 0, "No unreadable dependencies"
+    assert file_hash_entries == []
 
 
 def test_hash_file_produces_consistent_hash(tmp_path: pathlib.Path) -> None:
@@ -1174,8 +1274,8 @@ def test_hash_file_produces_consistent_hash(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "test.txt"
     file_path.write_text("test content")
 
-    hash1 = cache.hash_file(file_path)
-    hash2 = cache.hash_file(file_path)
+    hash1, _ = cache.hash_file(file_path)
+    hash2, _ = cache.hash_file(file_path)
 
     assert hash1 == hash2
     assert len(hash1) == 16  # xxhash64 hexdigest
@@ -1188,8 +1288,8 @@ def test_hash_file_different_for_different_content(tmp_path: pathlib.Path) -> No
     file1.write_text("content1")
     file2.write_text("content2")
 
-    hash1 = cache.hash_file(file1)
-    hash2 = cache.hash_file(file2)
+    hash1, _ = cache.hash_file(file1)
+    hash2, _ = cache.hash_file(file2)
 
     assert hash1 != hash2
 
@@ -2307,7 +2407,7 @@ def test_file_needs_restore_returns_false_when_matching(tmp_path: pathlib.Path) 
     file_path = tmp_path / "output.txt"
     file_path.write_text("content")
 
-    file_hash = cache.hash_file(file_path)
+    file_hash, _ = cache.hash_file(file_path)
     cached_hash: FileHash = {"hash": file_hash}
 
     assert not worker._file_needs_restore(file_path, cached_hash)
@@ -2327,7 +2427,7 @@ def test_file_needs_restore_returns_true_for_wrong_content(tmp_path: pathlib.Pat
     file_path.write_text("original")
 
     # Get hash of original content
-    original_hash = cache.hash_file(file_path)
+    original_hash, _ = cache.hash_file(file_path)
     cached_hash: FileHash = {"hash": original_hash}
 
     # Modify content
@@ -2344,7 +2444,7 @@ def test_file_needs_restore_returns_true_on_permission_error(
     file_path.write_text("content")
 
     # Get hash before breaking things
-    file_hash = cache.hash_file(file_path)
+    file_hash, _ = cache.hash_file(file_path)
     cached_hash: FileHash = {"hash": file_hash}
 
     # Make hash_file raise OSError
@@ -2361,7 +2461,7 @@ def test_file_needs_restore_handles_empty_file(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "empty.txt"
     file_path.write_text("")
 
-    empty_hash = cache.hash_file(file_path)
+    empty_hash, _ = cache.hash_file(file_path)
     cached_hash: FileHash = {"hash": empty_hash}
 
     # Empty file matches
@@ -2379,7 +2479,7 @@ def test_file_needs_restore_uses_state_db(tmp_path: pathlib.Path) -> None:
     db_path = tmp_path / "state.db"
 
     with state.StateDB(db_path) as db:
-        file_hash = cache.hash_file(file_path, db)
+        file_hash, _ = cache.hash_file(file_path, db)
         cached_hash: FileHash = {"hash": file_hash}
 
         # Should work with state_db
@@ -2604,7 +2704,7 @@ def test_restore_outputs_cleans_up_on_partial_failure(
     # Create a temp file and hash it to get a valid hash
     temp_file = tmp_path / "temp_for_hash.txt"
     temp_file.write_text("output1 content")
-    output1_hash = cache.hash_file(temp_file)
+    output1_hash, _ = cache.hash_file(temp_file)
 
     # Create cached file in the expected location
     cached_file = files_cache_dir / output1_hash[:2] / output1_hash[2:]
@@ -2903,7 +3003,6 @@ def test_restore_outputs_from_cache_skips_noncached_outputs(
                 norm_output: cached_hash,
                 norm_metric: FileHash(hash="somehash"),
             },
-            "dep_generations": {},
         }
 
         checkout_modes = [cache.CheckoutMode.COPY]
@@ -2950,7 +3049,6 @@ def test_restore_outputs_from_cache_fails_when_noncached_missing(
             "output_hashes": {
                 norm_metric: FileHash(hash="somehash"),
             },
-            "dep_generations": {},
         }
 
         checkout_modes = [cache.CheckoutMode.COPY]
@@ -2975,7 +3073,7 @@ def test_hash_output_computes_correct_hash_for_file(tmp_path: pathlib.Path) -> N
 
     result = worker.hash_output(test_file)
 
-    expected_hash = cache.hash_file(test_file)
+    expected_hash, _ = cache.hash_file(test_file)
     assert result == FileHash(hash=expected_hash), (
         "FileHash from hash_output should match cache.hash_file"
     )

--- a/packages/pivot/tests/fingerprint/README.md
+++ b/packages/pivot/tests/fingerprint/README.md
@@ -298,3 +298,7 @@ Tests in `test_callback_vulnerabilities.py` document edge cases where callback c
 19. **Module attribute primitive collections ARE tracked**: Module-level collections (dict, list, tuple, set, frozenset) containing only primitive values (bool, int, float, str, bytes, None) are fingerprinted via JSON serialization. Collections containing non-primitives (custom objects, class instances, numpy arrays) raise a `TypeError` to prevent non-deterministic `repr()` output. The primitive check is recursive, so nested structures like `{"key": [1, 2, {"inner": "value"}]}` are supported.
 
     Tests: `test_integration.py::test_primitive_collection_module_attr_fingerprinting`, `test_integration.py::test_unsupported_module_attr_type_raises_error`
+
+20. **Manifest cache invalidation is path-scoped**: Watch-mode reloads invalidate only the cached manifests whose source maps include changed paths, leaving unaffected stage manifests intact. Affected stages are recomputed on next fingerprint access and re-cached.
+
+    Tests: `test_fingerprint.py::test_invalidate_manifests_for_paths_selective`, `test_fingerprint.py::test_invalidate_manifests_for_paths_recomputes_affected_stage`, `test_fingerprint.py::test_invalidate_manifests_for_paths_cold_start`

--- a/packages/pivot/tests/fingerprint/test_callback_vulnerabilities.py
+++ b/packages/pivot/tests/fingerprint/test_callback_vulnerabilities.py
@@ -10,7 +10,7 @@ import functools
 
 import pytest
 
-from pivot import fingerprint
+from pivot import exceptions, fingerprint
 
 # =============================================================================
 # Module-level helpers for testing
@@ -270,19 +270,14 @@ def test_module_variable_callback_change_detected():
 
 
 def test_dict_callback_in_closure_detected():
-    """Callbacks in dict closures ARE detected correctly."""
+    """Callbacks in dict closures are rejected by default."""
     handlers = {"process": _callback_v1}
 
     def stage():
         return handlers["process"]()
 
-    fp1 = fingerprint.get_stage_fingerprint(stage)
-
-    handlers["process"] = _callback_v2
-    fp2 = fingerprint.get_stage_fingerprint(stage)
-
-    # This WORKS correctly
-    assert fp1 != fp2, "Dict callback in closure should be detected"
+    with pytest.raises(exceptions.StageDefinitionError):
+        fingerprint.get_stage_fingerprint(stage)
 
 
 # =============================================================================

--- a/packages/pivot/tests/fingerprint/test_change_detection.py
+++ b/packages/pivot/tests/fingerprint/test_change_detection.py
@@ -400,8 +400,11 @@ def test_class_instance_method_change_detected(module_dir: pathlib.Path) -> None
     assert "mod:processor.process" in fp, "Should capture instance method usage"
 
 
-def test_dynamic_dispatch_change_detected(module_dir: pathlib.Path) -> None:
+def test_dynamic_dispatch_change_detected(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Functions in dispatch dicts are tracked for change detection."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_limit_helpers_dyn.py"
     helpers_py.write_text(
         "def add(x):\n    return x + 1\n\n"
@@ -471,8 +474,11 @@ def test_multiple_runs_stable(module_dir: pathlib.Path) -> None:
         assert fp == fingerprints[0], "Fingerprints must be stable across runs"
 
 
-def test_dispatch_dict_function_change_causes_miss(module_dir: pathlib.Path) -> None:
+def test_dispatch_dict_function_change_causes_miss(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Changing function inside dispatch dict causes cache miss."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_dispatch_helpers.py"
     helpers_py.write_text(
         "def add(x):\n    return x + 1\n\n"
@@ -504,8 +510,9 @@ def test_dispatch_dict_function_change_causes_miss(module_dir: pathlib.Path) -> 
     assert hash1 != hash2, "Dispatch dict function change must cause cache miss"
 
 
-def test_list_callable_tracking(module_dir: pathlib.Path) -> None:
+def test_list_callable_tracking(module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Functions in lists are tracked for change detection."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_list_helpers.py"
     helpers_py.write_text(
         "def step1(x):\n    return x + 1\n\n"
@@ -529,8 +536,11 @@ def test_list_callable_tracking(module_dir: pathlib.Path) -> None:
     assert "func:PIPELINE[1]" in fp, "Should capture second function in list"
 
 
-def test_fingerprint_ordering_stability(module_dir: pathlib.Path) -> None:
+def test_fingerprint_ordering_stability(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Fingerprint is stable regardless of dict key ordering in source."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     # Test that different dict key ORDER in source produces same fingerprint
     # (because we sort keys during processing)
     helpers_py = module_dir / "test_order_helpers.py"
@@ -611,8 +621,9 @@ def test_class_definition_change_causes_miss(module_dir: pathlib.Path) -> None:
     assert fp1 != fp2, "Class method change must cause cache miss"
 
 
-def test_class_instance_tracked(module_dir: pathlib.Path) -> None:
+def test_class_instance_tracked(module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Module-level class instances have their class tracked."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_instance_helpers.py"
     helpers_py.write_text(
         "class Processor:\n"
@@ -633,8 +644,11 @@ def test_class_instance_tracked(module_dir: pathlib.Path) -> None:
     assert "class:processor.__class__" in fp, "Should capture instance's class"
 
 
-def test_class_instance_change_causes_miss(module_dir: pathlib.Path) -> None:
+def test_class_instance_change_causes_miss(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Changing class of a module-level instance causes cache miss."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_instchange_helpers.py"
     helpers_py.write_text(
         "class Processor:\n"
@@ -666,8 +680,11 @@ def test_class_instance_change_causes_miss(module_dir: pathlib.Path) -> None:
     assert fp1 != fp2, "Instance class change must cause cache miss"
 
 
-def test_nonlocal_class_instance_tracked(module_dir: pathlib.Path) -> None:
+def test_nonlocal_class_instance_tracked(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Class instances captured as nonlocals have their class tracked."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_nonlocal_helpers.py"
     helpers_py.write_text(
         "class Processor:\n"

--- a/packages/pivot/tests/fingerprint/test_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_fingerprint.py
@@ -2,6 +2,7 @@
 
 import ast
 import importlib.util
+import json
 import math
 import os
 import pathlib
@@ -12,6 +13,7 @@ import networkx as nx
 import pytest
 
 from pivot import ast_utils, fingerprint
+from pivot.storage import state as state_mod
 
 # --- Module-level helper functions for testing ---
 # These must be at module level to properly capture imports in their closures
@@ -737,8 +739,9 @@ def _collection_helper_b(x):
     return x + 1
 
 
-def test_fingerprint_nonlocal_list_with_callable():
+def test_fingerprint_nonlocal_list_with_callable(monkeypatch: pytest.MonkeyPatch):
     """Should capture callable functions within nonlocal list."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
 
     def outer():
         transforms = [_collection_helper_a, _collection_helper_b]
@@ -759,8 +762,9 @@ def test_fingerprint_nonlocal_list_with_callable():
     assert "func:transforms[1]" in fp
 
 
-def test_fingerprint_nonlocal_dict_with_callable():
+def test_fingerprint_nonlocal_dict_with_callable(monkeypatch: pytest.MonkeyPatch):
     """Should capture callable functions within nonlocal dict."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
 
     def outer():
         handlers = {
@@ -803,8 +807,11 @@ def test_fingerprint_nonlocal_tuple_with_callable():
     assert "func:pipeline[1]" in fp
 
 
-def test_fingerprint_nonlocal_collection_callable_change_detected():
+def test_fingerprint_nonlocal_collection_callable_change_detected(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """Changing callable in collection should change fingerprint."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
 
     def make_func(transform):
         transforms = [transform]
@@ -1316,7 +1323,6 @@ def test_code_manifest_sorted_in_lock_file():
         params={},
         dep_hashes={},
         output_hashes={},
-        dep_generations={},
     )
 
     storage_data = lock._convert_to_storage_format(lock_data)
@@ -2509,6 +2515,203 @@ def test_try_manifest_cache_hit_path_traversal_blocked(tmp_path, monkeypatch):
         result = fingerprint._try_manifest_cache_hit("traversal_dotdot")
         assert result is None, "Path traversal with .. should be rejected"
     finally:
+        if fingerprint._state_db is not None:
+            fingerprint._state_db.close()
+        fingerprint._state_db = None
+        fingerprint._state_db_init_attempted = False
+
+
+def test_manifest_cache_flush_persists_to_statedb(tmp_path, monkeypatch):
+    """Manifest cache flush writes pending manifests to StateDB.
+
+    Verifies that:
+    1. get_stage_fingerprint_cached() queues manifest writes
+    2. flush_manifest_cache() writes to StateDB
+    3. Manifest can be retrieved from StateDB after flush
+    """
+    from pivot.storage import state
+
+    # Set up isolated state directory
+    state_dir = tmp_path / ".pivot"
+    state_dir.mkdir()
+    db_path = state_dir / "state.db"
+
+    # Create initial StateDB
+    with state.StateDB(db_path):
+        pass
+
+    # Patch project root and state db path
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+
+    # Reset fingerprint module state
+    fingerprint._pending_manifest_writes.clear()
+    fingerprint._state_db = None
+    fingerprint._state_db_init_attempted = False
+
+    # Create test module file
+    test_module = tmp_path / "test_stage.py"
+    test_module.write_text("""
+def test_stage():
+    return 42
+""")
+
+    # Import the function
+    spec = importlib.util.spec_from_file_location("test_stage", test_module)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_stage"] = module
+    try:
+        spec.loader.exec_module(module)
+        func = module.test_stage
+
+        # Step 1: Call get_stage_fingerprint_cached() - should queue manifest
+        manifest = fingerprint.get_stage_fingerprint_cached("test_stage", func)
+        assert isinstance(manifest, dict)
+        assert "self:test_stage" in manifest
+        assert len(fingerprint._pending_manifest_writes) > 0, "Should queue manifest writes"
+
+        # Step 2: Flush to StateDB
+        fingerprint.flush_manifest_cache()
+        assert len(fingerprint._pending_manifest_writes) == 0, (
+            "Pending writes should be empty after flush"
+        )
+
+        # Step 3: Verify manifest is in StateDB
+        with state.StateDB(db_path, readonly=True) as db:
+            key = fingerprint._make_manifest_cache_key("test_stage")
+            raw = db.get_raw(key)
+            assert raw is not None, "Manifest should be persisted in StateDB"
+            data = json.loads(raw)
+            assert "m" in data, "Cached data should have manifest key"
+            assert "s" in data, "Cached data should have sources key"
+            cached_manifest = data["m"]
+            assert "self:test_stage" in cached_manifest
+    finally:
+        sys.modules.pop("test_stage", None)
+        # Clean up fingerprint module state
+        if fingerprint._state_db is not None:
+            fingerprint._state_db.close()
+        fingerprint._state_db = None
+        fingerprint._state_db_init_attempted = False
+
+
+def test_invalidate_manifests_for_paths_selective(tmp_path, monkeypatch):
+    """Invalidate only manifests referencing changed source files."""
+    state_dir = tmp_path / ".pivot"
+    state_dir.mkdir()
+    db_path = state_dir / "state.db"
+    with state_mod.StateDB(db_path):
+        pass
+
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+
+    key_a = fingerprint._make_manifest_cache_key("stage_a")
+    key_b = fingerprint._make_manifest_cache_key("stage_b")
+    key_c = fingerprint._make_manifest_cache_key("stage_c")
+
+    with state_mod.StateDB(db_path) as db:
+        db.put_raw(
+            key_a,
+            json.dumps(
+                {"m": {"self:stage_a": "hash"}, "s": {"a.py": [1, 2, 3]}},
+                separators=(",", ":"),
+            ).encode(),
+        )
+        db.put_raw(
+            key_b,
+            json.dumps(
+                {"m": {"self:stage_b": "hash"}, "s": {"b.py": [1, 2, 3]}},
+                separators=(",", ":"),
+            ).encode(),
+        )
+        db.put_raw(
+            key_c,
+            json.dumps(
+                {"m": {"self:stage_c": "hash"}, "s": {"c.py": [1, 2, 3]}},
+                separators=(",", ":"),
+            ).encode(),
+        )
+
+    fingerprint.invalidate_manifests_for_paths([tmp_path / "b.py"])
+
+    with state_mod.StateDB(db_path, readonly=True) as db:
+        assert db.get_raw(key_a) is not None, "Unchanged manifest should remain"
+        assert db.get_raw(key_b) is None, "Changed manifest should be removed"
+        assert db.get_raw(key_c) is not None, "Unchanged manifest should remain"
+
+
+def test_invalidate_manifests_for_paths_cold_start(tmp_path, monkeypatch):
+    """Invalidation is a no-op when no cached manifests exist."""
+    state_dir = tmp_path / ".pivot"
+    state_dir.mkdir()
+    db_path = state_dir / "state.db"
+    with state_mod.StateDB(db_path):
+        pass
+
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+
+    fingerprint.invalidate_manifests_for_paths([tmp_path / "missing.py"])
+
+    with state_mod.StateDB(db_path, readonly=True) as db:
+        assert list(db.iter_prefix(b"sm:")) == [], "No manifest entries should exist"
+
+
+def test_invalidate_manifests_for_paths_recomputes_affected_stage(tmp_path, monkeypatch):
+    """Invalidation forces a cache miss and re-cache for affected stages."""
+    state_dir = tmp_path / ".pivot"
+    state_dir.mkdir()
+    db_path = state_dir / "state.db"
+    with state_mod.StateDB(db_path):
+        pass
+
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+
+    fingerprint._pending_manifest_writes.clear()
+    fingerprint._hash_function_ast_cache.clear()
+    fingerprint._state_db = None
+    fingerprint._state_db_init_attempted = False
+
+    test_module = tmp_path / "invalidate_stage.py"
+    test_module.write_text("""
+def invalidate_stage():
+    return 42
+""")
+
+    spec = importlib.util.spec_from_file_location("invalidate_stage", test_module)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["invalidate_stage"] = module
+    try:
+        spec.loader.exec_module(module)
+
+        key = fingerprint._make_manifest_cache_key("invalidate_stage")
+        fingerprint.get_stage_fingerprint_cached("invalidate_stage", module.invalidate_stage)
+        fingerprint.flush_manifest_cache()
+
+        with state_mod.StateDB(db_path, readonly=True) as db:
+            assert db.get_raw(key) is not None, "Manifest should be cached before invalidation"
+
+        fingerprint.invalidate_manifests_for_paths([test_module])
+
+        with state_mod.StateDB(db_path, readonly=True) as db:
+            assert db.get_raw(key) is None, "Manifest should be removed after invalidation"
+
+        if fingerprint._state_db is not None:
+            fingerprint._state_db.close()
+        fingerprint._state_db = None
+        fingerprint._state_db_init_attempted = False
+
+        fingerprint.get_stage_fingerprint_cached("invalidate_stage", module.invalidate_stage)
+        fingerprint.flush_manifest_cache()
+
+        with state_mod.StateDB(db_path, readonly=True) as db:
+            assert db.get_raw(key) is not None, "Manifest should be re-cached after recompute"
+    finally:
+        sys.modules.pop("invalidate_stage", None)
         if fingerprint._state_db is not None:
             fingerprint._state_db.close()
         fingerprint._state_db = None

--- a/packages/pivot/tests/fingerprint/test_integration.py
+++ b/packages/pivot/tests/fingerprint/test_integration.py
@@ -279,8 +279,11 @@ def run_stage():
     assert len(fp["mod:helpers.func_b"]) == 16, "Module attr should be hashed"
 
 
-def test_unsupported_module_attr_type_raises_error(module_dir: pathlib.Path) -> None:
+def test_unsupported_module_attr_type_raises_error(
+    module_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Unsupported types (custom objects, non-primitive collections) in module attrs raise TypeError."""
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     helpers_py = module_dir / "test_mod_helpers_v8.py"
     helpers_py.write_text("""
 # This is an unsupported type - a list containing a custom object

--- a/packages/pivot/tests/fingerprint/test_pydantic_defaults.py
+++ b/packages/pivot/tests/fingerprint/test_pydantic_defaults.py
@@ -6,6 +6,7 @@ Changes to default values trigger cache invalidation.
 """
 
 import pydantic
+import pytest
 
 from pivot import fingerprint
 
@@ -65,12 +66,13 @@ def _stage_references_string() -> str:
 # --- Tests for Pydantic default tracking ---
 
 
-def test_list_constants_not_captured_as_const():
+def test_list_constants_not_captured_as_const(monkeypatch: pytest.MonkeyPatch):
     """Lists referenced in function body are NOT captured as 'const:' entries.
 
     Lists are scanned for callables only, not hashed as data. This is intentional
     to avoid sensitivity to mutable runtime state.
     """
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
     fp = fingerprint.get_stage_fingerprint(_stage_directly_references_list)
 
     # Lists referenced in function body are NOT captured as const:

--- a/packages/pivot/tests/fingerprint/test_safe_fingerprinting.py
+++ b/packages/pivot/tests/fingerprint/test_safe_fingerprinting.py
@@ -1,0 +1,203 @@
+import dataclasses
+import logging
+from collections.abc import Callable
+from typing import ClassVar
+from unittest import mock
+
+import pydantic
+import pytest
+
+from pivot import exceptions, fingerprint
+from pivot.config import models
+
+
+@dataclasses.dataclass
+class MutableConfig:
+    value: int
+
+
+@dataclasses.dataclass(frozen=True)
+class FrozenConfig:
+    value: int
+
+
+class MutableModel(pydantic.BaseModel):
+    value: int
+
+
+class FrozenModel(pydantic.BaseModel):
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)
+    value: int
+
+
+MUTABLE_DICT = {"a": 1}
+MUTABLE_LIST = [1, 2]
+MUTABLE_SET = {1, 2}
+MUTABLE_DATACLASS = MutableConfig(value=1)
+MUTABLE_PYDANTIC = MutableModel(value=1)
+FROZEN_DATACLASS = FrozenConfig(value=1)
+FROZEN_PYDANTIC = FrozenModel(value=1)
+IMMUTABLE_TUPLE = (1, 2)
+IMMUTABLE_FROZENSET = frozenset({1, 2})
+PRIMITIVE_INT = 42
+
+
+def _callable_helper() -> int:
+    return 7
+
+
+def _stage_uses_mutable_dict() -> int:
+    return MUTABLE_DICT["a"]
+
+
+def _stage_uses_mutable_list() -> int:
+    return len(MUTABLE_LIST)
+
+
+def _stage_uses_mutable_set() -> int:
+    return len(MUTABLE_SET)
+
+
+def _stage_uses_mutable_dataclass() -> int:
+    return MUTABLE_DATACLASS.value
+
+
+def _stage_uses_mutable_pydantic() -> int:
+    return MUTABLE_PYDANTIC.value
+
+
+def _stage_uses_frozen_dataclass() -> int:
+    return FROZEN_DATACLASS.value
+
+
+def _stage_uses_frozen_pydantic() -> int:
+    return FROZEN_PYDANTIC.value
+
+
+def _stage_uses_tuple() -> int:
+    return len(IMMUTABLE_TUPLE)
+
+
+def _stage_uses_frozenset() -> int:
+    return len(IMMUTABLE_FROZENSET)
+
+
+def _stage_uses_primitive() -> int:
+    return PRIMITIVE_INT
+
+
+def _stage_uses_callable() -> int:
+    return _callable_helper()
+
+
+@pytest.mark.parametrize(
+    ("func", "var_name", "type_name"),
+    [
+        pytest.param(
+            _stage_uses_mutable_dict,
+            "MUTABLE_DICT",
+            "dict",
+            id="mutable-dict",
+        ),
+        pytest.param(
+            _stage_uses_mutable_list,
+            "MUTABLE_LIST",
+            "list",
+            id="mutable-list",
+        ),
+        pytest.param(
+            _stage_uses_mutable_set,
+            "MUTABLE_SET",
+            "set",
+            id="mutable-set",
+        ),
+        pytest.param(
+            _stage_uses_mutable_dataclass,
+            "MUTABLE_DATACLASS",
+            "MutableConfig",
+            id="mutable-dataclass",
+        ),
+        pytest.param(
+            _stage_uses_mutable_pydantic,
+            "MUTABLE_PYDANTIC",
+            "MutableModel",
+            id="mutable-pydantic",
+        ),
+    ],
+)
+def test_mutable_closure_capture_raises(
+    func: Callable[[], int],
+    var_name: str,
+    type_name: str,
+) -> None:
+    with pytest.raises(exceptions.StageDefinitionError) as exc:
+        fingerprint.get_stage_fingerprint_cached("train", func)
+
+    message = str(exc.value)
+    assert "Stage 'train'" in message, "Should include stage name"
+    assert var_name in message, "Should include captured variable name"
+    assert f"type: {type_name}" in message, "Should include captured variable type"
+    assert "Fix: pass this data via StageParams" in message, "Should include suggestion"
+    assert "PIVOT_UNSAFE_FINGERPRINTING=1" in message, "Should include suppression hint"
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(_stage_uses_frozen_dataclass, id="frozen-dataclass"),
+        pytest.param(_stage_uses_frozen_pydantic, id="frozen-pydantic"),
+        pytest.param(_stage_uses_tuple, id="tuple"),
+        pytest.param(_stage_uses_frozenset, id="frozenset"),
+        pytest.param(_stage_uses_primitive, id="primitive"),
+        pytest.param(_stage_uses_callable, id="callable"),
+    ],
+)
+def test_immutable_closure_capture_allows_fingerprint(func: Callable[[], int]) -> None:
+    fingerprint.get_stage_fingerprint_cached("train", func)
+
+
+def test_unsafe_env_allows_mutable_capture(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PIVOT_UNSAFE_FINGERPRINTING", "1")
+    with caplog.at_level(logging.WARNING):
+        fingerprint.get_stage_fingerprint_cached("train", _stage_uses_mutable_dict)
+
+    assert any(
+        "closure captures mutable variable" in record.message for record in caplog.records
+    ), "Should warn when unsafe fingerprinting is enabled"
+
+
+NESTED_MUTABLE_TUPLE = (1, [2, 3])
+
+
+def _stage_uses_nested_mutable_tuple() -> int:
+    return len(NESTED_MUTABLE_TUPLE)
+
+
+def _stage_uses_mutable_dict_for_config_test() -> int:
+    return MUTABLE_DICT["a"]
+
+
+def test_unsafe_config_allows_mutable_capture(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Config-based unsafe_fingerprinting=true downgrades errors to warnings."""
+    unsafe_config = models.PivotConfig.get_default()
+    unsafe_config.core.unsafe_fingerprinting = True
+
+    with (
+        mock.patch("pivot.config.io.get_merged_config", autospec=True, return_value=unsafe_config),
+        caplog.at_level(logging.WARNING),
+    ):
+        fingerprint.get_stage_fingerprint_cached("train", _stage_uses_mutable_dict_for_config_test)
+
+    assert any(
+        "closure captures mutable variable" in record.message for record in caplog.records
+    ), "Should warn when unsafe fingerprinting via config is enabled"
+
+
+def test_nested_mutable_in_tuple_allows_fingerprint() -> None:
+    """Tuple containing mutable list is allowed — tuples are immutable at top level."""
+    fingerprint.get_stage_fingerprint_cached("train", _stage_uses_nested_mutable_tuple)

--- a/packages/pivot/tests/pipeline/test_pipeline.py
+++ b/packages/pivot/tests/pipeline/test_pipeline.py
@@ -1135,7 +1135,6 @@ def test_lockfile_contains_project_relative_paths(set_project_root: pathlib.Path
         params={"key": "value"},
         dep_hashes={abs_dep: {"hash": "dep_hash_123"}},
         output_hashes={abs_out: {"hash": "out_hash_456"}},
-        dep_generations={"producer": 1},
     )
 
     # Write the lock file

--- a/packages/pivot/tests/remote/test_sync.py
+++ b/packages/pivot/tests/remote/test_sync.py
@@ -69,7 +69,6 @@ def _write_lock_with_dir_output(
         params={},
         dep_hashes={},
         output_hashes={"output_dir": dir_hash},
-        dep_generations={},
     )
     stage_lock = lock.StageLock(stage_name, stages_dir)
     stage_lock.write(lock_data)
@@ -107,7 +106,6 @@ def test_get_stage_dep_hashes_excludes_tree_hash(set_project_root: pathlib.Path)
         params={},
         dep_hashes={str(set_project_root / "input_dir"): dep_hash},
         output_hashes={},
-        dep_generations={},
     )
     stage_lock = lock.StageLock("my_stage", stages_dir)
     stage_lock.write(lock_data)

--- a/packages/pivot/tests/show/test_data.py
+++ b/packages/pivot/tests/show/test_data.py
@@ -1331,7 +1331,6 @@ deps: []
 outs:
   - path: output.csv
     hash: deadbeef
-dep_generations: {}
 """
 
     def mock_read_files(paths: list[str]) -> dict[str, str | None]:

--- a/packages/pivot/tests/show/test_plots.py
+++ b/packages/pivot/tests/show/test_plots.py
@@ -184,7 +184,6 @@ def test_get_plot_hashes_from_lock_with_hash(mock_discovery: pipeline_mod.Pipeli
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "abc123def456"}},
-            dep_generations={},
         )
     )
 
@@ -212,7 +211,6 @@ def test_get_plot_hashes_from_lock_with_none_hash(mock_discovery: pipeline_mod.P
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 
@@ -266,7 +264,6 @@ def test_get_plot_hashes_from_head_returns_committed_hash(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "committed_hash_123"}},
-            dep_generations={},
         )
     )
 
@@ -302,7 +299,6 @@ def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "original_hash"}},
-            dep_generations={},
         )
     )
 
@@ -315,7 +311,6 @@ def test_get_plot_hashes_from_head_ignores_uncommitted_changes(
             params={},
             dep_hashes={},
             output_hashes={str(plot_file): {"hash": "modified_hash"}},
-            dep_generations={},
         )
     )
 
@@ -675,7 +670,6 @@ def test_get_output_hashes_from_revision_returns_hashes(set_project_root: Path) 
             params={},
             dep_hashes={},
             output_hashes={"output.csv": {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 
@@ -707,7 +701,6 @@ def test_get_output_hashes_from_revision_multiple_stages(set_project_root: Path)
             params={},
             dep_hashes={},
             output_hashes={"plots/chart1.png": {"hash": "hash1"}},
-            dep_generations={},
         )
     )
     lock.StageLock("stage2", stages_dir).write(
@@ -716,7 +709,6 @@ def test_get_output_hashes_from_revision_multiple_stages(set_project_root: Path)
             params={},
             dep_hashes={},
             output_hashes={"plots/chart2.png": {"hash": "hash2"}},
-            dep_generations={},
         )
     )
 
@@ -747,7 +739,6 @@ def test_get_output_hashes_from_revision_normalizes_paths(set_project_root: Path
             params={},
             dep_hashes={},
             output_hashes={"./output.csv": {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 

--- a/packages/pivot/tests/storage/test_cache.py
+++ b/packages/pivot/tests/storage/test_cache.py
@@ -60,11 +60,12 @@ def test_hash_file(tmp_path: pathlib.Path) -> None:
     test_file = tmp_path / "file.txt"
     test_file.write_text("hello world")
 
-    hash1 = cache.hash_file(test_file)
-    hash2 = cache.hash_file(test_file)
+    hash1, stat1 = cache.hash_file(test_file)
+    hash2, stat2 = cache.hash_file(test_file)
 
     assert hash1 == hash2
     assert len(hash1) == 16  # xxhash64 hex is 16 chars
+    assert stat1.st_size == stat2.st_size
 
 
 def test_hash_file_different_content(tmp_path: pathlib.Path) -> None:
@@ -74,7 +75,9 @@ def test_hash_file_different_content(tmp_path: pathlib.Path) -> None:
     file1.write_text("hello")
     file2.write_text("world")
 
-    assert cache.hash_file(file1) != cache.hash_file(file2)
+    hash1, _ = cache.hash_file(file1)
+    hash2, _ = cache.hash_file(file2)
+    assert hash1 != hash2
 
 
 def test_hash_file_uses_state_cache(tmp_path: pathlib.Path) -> None:
@@ -86,7 +89,7 @@ def test_hash_file_uses_state_cache(tmp_path: pathlib.Path) -> None:
     with state.StateDB(db_path) as db:
         cache.hash_file(test_file, state_db=db)  # First hash populates cache
         db.save(test_file, test_file.stat(), "cached_hash")
-        hash2 = cache.hash_file(test_file, state_db=db)
+        hash2, _ = cache.hash_file(test_file, state_db=db)
 
     assert hash2 == "cached_hash"
 
@@ -96,7 +99,7 @@ def test_hash_file_binary(tmp_path: pathlib.Path) -> None:
     test_file = tmp_path / "binary.bin"
     test_file.write_bytes(b"\x00\x01\x02\xff\xfe")
 
-    file_hash = cache.hash_file(test_file)
+    file_hash, _ = cache.hash_file(test_file)
 
     assert len(file_hash) == 16
 
@@ -113,8 +116,8 @@ def test_hash_file_large_uses_mmap(tmp_path: pathlib.Path, monkeypatch: pytest.M
     large_file.write_bytes(b"x" * 150)  # Above threshold
 
     # Both should produce valid hashes
-    small_hash = cache.hash_file(small_file)
-    large_hash = cache.hash_file(large_file)
+    small_hash, _ = cache.hash_file(small_file)
+    large_hash, _ = cache.hash_file(large_file)
 
     assert len(small_hash) == 16
     assert len(large_hash) == 16
@@ -131,11 +134,11 @@ def test_hash_file_mmap_consistent(tmp_path: pathlib.Path, monkeypatch: pytest.M
 
     # Set threshold below content size to force mmap path
     monkeypatch.setattr(cache, "MMAP_THRESHOLD", 10)
-    mmap_hash = cache.hash_file(test_file)
+    mmap_hash, _ = cache.hash_file(test_file)
 
     # Set threshold above content size to force buffered path
     monkeypatch.setattr(cache, "MMAP_THRESHOLD", len(content) + 100)
-    buffered_hash = cache.hash_file(test_file)
+    buffered_hash, _ = cache.hash_file(test_file)
 
     # Both methods must produce identical hash
     assert mmap_hash == buffered_hash
@@ -152,7 +155,7 @@ def test_hash_file_mmap_fallback(tmp_path: pathlib.Path, monkeypatch: pytest.Mon
     monkeypatch.setattr(cache, "MMAP_THRESHOLD", 10)
 
     # Get expected hash via normal path first (mmap succeeds)
-    expected_hash = cache.hash_file(test_file)
+    expected_hash, _ = cache.hash_file(test_file)
 
     # Now make mmap fail
     def failing_mmap(*args: object, **kwargs: object) -> mmap.mmap:
@@ -161,7 +164,7 @@ def test_hash_file_mmap_fallback(tmp_path: pathlib.Path, monkeypatch: pytest.Mon
     monkeypatch.setattr(mmap, "mmap", failing_mmap)
 
     # Should fall back to buffered read and produce same hash
-    fallback_hash = cache.hash_file(test_file)
+    fallback_hash, _ = cache.hash_file(test_file)
     assert fallback_hash == expected_hash
 
 
@@ -298,7 +301,9 @@ def test_hash_directory_handles_deleted_file(
     original_hash_file = cache.hash_file
     call_count = 0
 
-    def hash_file_with_delete(path: pathlib.Path, state_db: state.StateDB | None = None) -> str:
+    def hash_file_with_delete(
+        path: pathlib.Path, state_db: state.StateDB | None = None
+    ) -> tuple[str, os.stat_result]:
         nonlocal call_count
         call_count += 1
         if path.name == "delete.txt":
@@ -335,10 +340,10 @@ def test_hash_file_state_cache_invalidation(tmp_path: pathlib.Path) -> None:
 
     with state.StateDB(db_path) as db:
         # First hash - cache miss
-        hash1 = cache.hash_file(test_file, state_db=db)
+        hash1, _ = cache.hash_file(test_file, state_db=db)
 
         # Second hash - cache hit (should return cached value)
-        cached_hash = cache.hash_file(test_file, state_db=db)
+        cached_hash, _ = cache.hash_file(test_file, state_db=db)
         assert cached_hash == hash1
 
         # Modify file content (changes both mtime and size)
@@ -348,7 +353,7 @@ def test_hash_file_state_cache_invalidation(tmp_path: pathlib.Path) -> None:
         test_file.write_text("modified content")
 
         # Third hash - cache should be invalidated
-        hash2 = cache.hash_file(test_file, state_db=db)
+        hash2, _ = cache.hash_file(test_file, state_db=db)
         assert hash2 != hash1, "Hash should change when file content changes"
 
 
@@ -630,7 +635,7 @@ def test_restore_directory_validates_all_entries_before_writing(
     # Create a real cached file for the first entry
     first_file = tmp_path / "first.txt"
     first_file.write_text("first")
-    first_hash = cache.hash_file(first_file)
+    first_hash, _ = cache.hash_file(first_file)
     cache_path = cache.get_cache_path(cache_dir, first_hash)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     first_file.rename(cache_path)

--- a/packages/pivot/tests/storage/test_incremental_out.py
+++ b/packages/pivot/tests/storage/test_incremental_out.py
@@ -169,7 +169,6 @@ def test_prepare_outputs_incremental_restores_from_cache(
         params={},
         dep_hashes={},
         output_hashes={"database.txt": output_hash},
-        dep_generations={},
     )
 
     # Prepare for execution (uses relative path like production)
@@ -199,7 +198,6 @@ def test_prepare_outputs_incremental_restored_file_is_writable(
         params={},
         dep_hashes={},
         output_hashes={"database.txt": output_hash},
-        dep_generations={},
     )
 
     # Prepare for execution (uses relative path like production)
@@ -229,7 +227,6 @@ def test_prepare_outputs_incremental_missing_cache_error(
         params={},
         dep_hashes={},
         output_hashes={"database.txt": fake_hash},
-        dep_generations={},
     )
 
     stage_outs: list[outputs.BaseOut] = [
@@ -433,7 +430,6 @@ def test_incremental_out_restores_directory(
         params={},
         dep_hashes={},
         output_hashes={"data_dir": output_hash},
-        dep_generations={},
     )
 
     # Delete the output
@@ -471,7 +467,6 @@ def test_incremental_out_directory_is_writable(
         params={},
         dep_hashes={},
         output_hashes={"data_dir": output_hash},
-        dep_generations={},
     )
 
     # Delete and restore (uses relative path like production)
@@ -512,7 +507,6 @@ def test_incremental_out_directory_subdirs_writable(
         params={},
         dep_hashes={},
         output_hashes={"data_dir": output_hash},
-        dep_generations={},
     )
 
     # Delete and restore (uses relative path like production)

--- a/packages/pivot/tests/storage/test_lock.py
+++ b/packages/pivot/tests/storage/test_lock.py
@@ -7,7 +7,7 @@ import pytest
 
 from pivot import project
 from pivot.storage import lock
-from pivot.types import DirHash, LockData
+from pivot.types import DirHash, LockData, StorageLockData
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,7 +27,6 @@ def test_lock_file_creation(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -47,7 +46,6 @@ def test_lock_file_read(set_project_root: Path) -> None:
         params={"learning_rate": 0.01},
         dep_hashes=dep_hashes,
         output_hashes={},
-        dep_generations={},
     )
 
     stage_lock.write(data)
@@ -81,7 +79,6 @@ def test_manifest_preservation(tmp_path: Path) -> None:
         params={},
         dep_hashes={},
         output_hashes={},
-        dep_generations={},
     )
     stage_lock.write(data)
     result = stage_lock.read()
@@ -104,7 +101,6 @@ def test_parallel_lock_writes(tmp_path: Path) -> None:
                     params={},
                     dep_hashes={},
                     output_hashes={},
-                    dep_generations={},
                 )
             )
         except Exception as e:
@@ -126,7 +122,6 @@ def test_parallel_lock_writes(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
 
 
@@ -159,7 +154,6 @@ def test_stage_unchanged_when_identical(tmp_path: Path) -> None:
             params=params,
             dep_hashes=dep_hashes,
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -178,7 +172,6 @@ def test_stage_changed_code_modified(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -201,7 +194,6 @@ def test_stage_changed_new_dependency(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -224,7 +216,6 @@ def test_stage_changed_params_modified(tmp_path: Path) -> None:
             params={"learning_rate": 0.01},
             dep_hashes={},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -250,7 +241,6 @@ def test_stage_changed_dep_hash_modified(tmp_path: Path) -> None:
             params={},
             dep_hashes=old_dep_hashes,
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -275,7 +265,6 @@ def test_stage_changed_dep_added(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": old_dep_hashes,
             "output_hashes": {},
-            "dep_generations": {},
         }
     )
 
@@ -305,7 +294,6 @@ def test_stage_changed_dep_removed(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": old_dep_hashes,
             "output_hashes": {},
-            "dep_generations": {},
         }
     )
 
@@ -329,7 +317,6 @@ def test_atomic_write_no_partial_file(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": {},
             "output_hashes": {},
-            "dep_generations": {},
         }
     )
 
@@ -349,7 +336,6 @@ def test_lock_directory_created(tmp_path: Path) -> None:
             "params": {},
             "dep_hashes": {},
             "output_hashes": {},
-            "dep_generations": {},
         }
     )
 
@@ -407,7 +393,6 @@ def test_write_failure_no_orphaned_tmp(tmp_path: Path, mocker: MockerFixture) ->
                 "params": {},
                 "dep_hashes": {},
                 "output_hashes": {},
-                "dep_generations": {},
             }
         )
 
@@ -429,7 +414,6 @@ def test_concurrent_same_stage_writes(tmp_path: Path) -> None:
                     "params": {"thread_id": value},
                     "dep_hashes": {},
                     "output_hashes": {},
-                    "dep_generations": {},
                 }
             )
             results.append(value)
@@ -510,14 +494,39 @@ def test_read_empty_file_returns_none(tmp_path: Path) -> None:
     assert result is None
 
 
+def test_is_lock_data_accepts_missing_dep_generations() -> None:
+    """Lock data without dep_generations is valid."""
+    data: StorageLockData = {
+        "code_manifest": {},
+        "params": {},
+        "deps": [],
+        "outs": [],
+    }
+
+    assert lock.is_lock_data(data)
+
+
+def test_read_lock_with_dep_generations_ignored(tmp_path: Path) -> None:
+    """Legacy lock files with dep_generations are still readable."""
+    stage_lock = lock.StageLock("legacy", tmp_path)
+    stage_lock.path.parent.mkdir(parents=True, exist_ok=True)
+    stage_lock.path.write_text(
+        "code_manifest: {}\nparams: {}\ndeps: []\nouts: []\ndep_generations: {}\n"
+    )
+
+    result = stage_lock.read()
+
+    assert result is not None
+    assert "dep_generations" not in result
+
+
 @pytest.mark.parametrize(
     ("missing_key", "lock_content"),
     [
-        ("code_manifest", "params: {}\ndeps: []\nouts: []\ndep_generations: {}\n"),
-        ("params", "code_manifest: {}\ndeps: []\nouts: []\ndep_generations: {}\n"),
-        ("deps", "code_manifest: {}\nparams: {}\nouts: []\ndep_generations: {}\n"),
-        ("outs", "code_manifest: {}\nparams: {}\ndeps: []\ndep_generations: {}\n"),
-        ("dep_generations", "code_manifest: {}\nparams: {}\ndeps: []\nouts: []\n"),
+        ("code_manifest", "params: {}\ndeps: []\nouts: []\n"),
+        ("params", "code_manifest: {}\ndeps: []\nouts: []\n"),
+        ("deps", "code_manifest: {}\nparams: {}\nouts: []\n"),
+        ("outs", "code_manifest: {}\nparams: {}\ndeps: []\n"),
     ],
 )
 def test_is_changed_with_missing_required_key_triggers_rerun(
@@ -544,9 +553,7 @@ def test_is_changed_with_null_values_triggers_rerun(tmp_path: Path) -> None:
     stage_lock = lock.StageLock("nulls", tmp_path)
     stage_lock.path.parent.mkdir(parents=True, exist_ok=True)
     # All required keys present but with null values
-    stage_lock.path.write_text(
-        "code_manifest: null\nparams: null\ndeps: null\nouts: null\ndep_generations: null\n"
-    )
+    stage_lock.path.write_text("code_manifest: null\nparams: null\ndeps: null\nouts: null\n")
 
     changed, reason = stage_lock.is_changed(
         current_fingerprint={},
@@ -565,7 +572,7 @@ def test_read_lock_with_extra_keys_accepted(tmp_path: Path) -> None:
     stage_lock.path.parent.mkdir(parents=True, exist_ok=True)
     stage_lock.path.write_text(
         "code_manifest: {}\nparams: {}\ndeps: []\nouts: []\n"
-        + "dep_generations: {}\nfuture_key: some_value\nanother_new_field: 123\n"
+        + "future_key: some_value\nanother_new_field: 123\n"
     )
 
     result = stage_lock.read()
@@ -589,7 +596,6 @@ def test_stage_changed_output_path_added(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={"/path/to/output.csv": {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 
@@ -617,7 +623,6 @@ def test_stage_changed_output_path_removed(tmp_path: Path) -> None:
                 "/path/to/output1.csv": {"hash": "abc123"},
                 "/path/to/output2.csv": {"hash": "def456"},
             },
-            dep_generations={},
         )
     )
 
@@ -642,7 +647,6 @@ def test_stage_changed_output_path_modified(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={"/path/to/output.csv": {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 
@@ -670,7 +674,6 @@ def test_stage_unchanged_with_same_output_paths(tmp_path: Path) -> None:
                 "/path/to/output1.csv": {"hash": "abc123"},
                 "/path/to/output2.csv": {"hash": "def456"},
             },
-            dep_generations={},
         )
     )
 
@@ -696,7 +699,6 @@ def test_stage_unchanged_when_out_paths_none(tmp_path: Path) -> None:
             params={},
             dep_hashes={},
             output_hashes={"/path/to/output.csv": {"hash": "abc123"}},
-            dep_generations={},
         )
     )
 
@@ -721,7 +723,6 @@ def test_dep_path_change_invalidates_cache(tmp_path: Path) -> None:
             params={},
             dep_hashes={"/old/path/data.csv": {"hash": "abc123"}},
             output_hashes={},
-            dep_generations={},
         )
     )
 
@@ -769,7 +770,6 @@ def test_directory_out_trailing_slash_preserved_through_lockfile_roundtrip(
         params={},
         dep_hashes={},
         output_hashes={dir_out_path: dir_hash},
-        dep_generations={},
     )
 
     stage_lock.write(data)
@@ -798,7 +798,6 @@ def test_pipeline_prefixed_stage_name_creates_subdirectory(tmp_path: Path) -> No
         params={"lr": 0.01},
         dep_hashes={},
         output_hashes={},
-        dep_generations={},
     )
 
     stage_lock.write(data)

--- a/packages/pivot/tests/storage/test_restore.py
+++ b/packages/pivot/tests/storage/test_restore.py
@@ -30,7 +30,6 @@ deps:
 outs:
   - path: model.pkl
     hash: ghi789
-dep_generations: {}
 """
     result = restore._parse_lock_data_from_bytes(content)
 
@@ -117,7 +116,6 @@ def test_resolve_targets_as_stage(git_repo: GitRepo, monkeypatch: pytest.MonkeyP
         "params": {},
         "deps": [],
         "outs": [{"path": "model.pkl", "hash": "def456"}],
-        "dep_generations": {},
     }
     (repo_path / ".pivot" / "stages" / "train.lock").write_text(yaml.dump(lock_content))
 
@@ -368,7 +366,6 @@ def test_restore_targets_from_revision_output_with_stage(
         "params": {},
         "deps": [],
         "outs": [{"path": "model.pkl", "hash": "def456"}],
-        "dep_generations": {},
     }
     (repo_path / ".pivot" / "stages" / "train.lock").write_text(yaml.dump(lock_content))
 

--- a/packages/pivot/tests/storage/test_state.py
+++ b/packages/pivot/tests/storage/test_state.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from pivot import run_history
-from pivot.storage import state
+from pivot.storage import cache, state
 
 if TYPE_CHECKING:
     from pivot.types import DeferredWrites
@@ -821,6 +821,32 @@ def test_apply_deferred_writes_skips_output_increment_when_flag_absent(
         assert db.get_dep_generations("stage") == {"/dep.csv": 5}
 
 
+def test_apply_deferred_writes_file_hash_entries(tmp_path: pathlib.Path) -> None:
+    """apply_deferred_writes stores file hash entries."""
+    db_path = tmp_path / "state.db"
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("data")
+    file_stat = file_path.stat()
+    file_hash, _ = cache.hash_file(file_path)
+    deferred: DeferredWrites = {
+        "file_hash_entries": [
+            (
+                str(file_path),
+                file_stat.st_mtime_ns,
+                file_stat.st_size,
+                file_stat.st_ino,
+                file_hash,
+            )
+        ]
+    }
+
+    with state.StateDB(db_path) as db:
+        db.apply_deferred_writes("stage", [], deferred)
+        result = db.get(file_path, file_stat)
+
+    assert result == file_hash
+
+
 def test_apply_deferred_writes_run_cache(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes writes run cache entry."""
     db_path = tmp_path / "state.db"
@@ -847,6 +873,10 @@ def test_apply_deferred_writes_all_fields(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes handles all fields atomically."""
     db_path = tmp_path / "state.db"
     output_path = tmp_path / "output.csv"
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("data")
+    input_stat = input_path.stat()
+    input_hash, _ = cache.hash_file(input_path)
     run_cache_entry = run_history.RunCacheEntry(
         run_id="run_456",
         output_hashes=[run_history.OutputHashEntry(path=str(output_path), hash="def456")],
@@ -856,6 +886,15 @@ def test_apply_deferred_writes_all_fields(tmp_path: pathlib.Path) -> None:
         "run_cache_input_hash": "input_abc",
         "run_cache_entry": run_cache_entry,
         "increment_outputs": True,
+        "file_hash_entries": [
+            (
+                str(input_path),
+                input_stat.st_mtime_ns,
+                input_stat.st_size,
+                input_stat.st_ino,
+                input_hash,
+            )
+        ],
     }
 
     with state.StateDB(db_path) as db:
@@ -867,6 +906,7 @@ def test_apply_deferred_writes_all_fields(tmp_path: pathlib.Path) -> None:
         result = db.lookup_run_cache("stage", "input_abc")
         assert result is not None
         assert result["run_id"] == "run_456"
+        assert db.get(input_path, input_stat) == input_hash
 
 
 def test_apply_deferred_writes_empty(tmp_path: pathlib.Path) -> None:

--- a/packages/pivot/tests/test_skip_detection_integration.py
+++ b/packages/pivot/tests/test_skip_detection_integration.py
@@ -1,0 +1,462 @@
+"""Integration tests for skip detection pipeline end-to-end.
+
+These tests exercise the full three-tier skip detection algorithm:
+1. O(1) generation check
+2. O(n) lock file comparison
+3. Run cache lookup
+
+Unlike unit tests that mock internals, these tests use the actual execute_stage()
+function and simulate coordinator behavior (applying deferred writes) between runs.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+from pivot import executor, loaders, outputs, stage_def
+from pivot.executor import worker
+from pivot.storage import cache, lock, state
+
+if TYPE_CHECKING:
+    import inspect
+    import multiprocessing as mp
+    import pathlib
+    from collections.abc import Callable
+
+    from pytest_mock import MockerFixture
+
+    from pivot.executor import WorkerStageInfo
+    from pivot.types import OutputMessage, StageResult
+
+
+# =============================================================================
+# Module-level helpers (required for pickling in worker processes)
+# =============================================================================
+
+
+def _helper_noop() -> None:
+    """No-op stage for skip detection tests."""
+
+
+def _helper_write_output(path: pathlib.Path) -> None:
+    """Write a marker file."""
+    path.write_text("output")
+
+
+def _make_stage_info(
+    func: Callable[..., object],
+    tmp_path: pathlib.Path,
+    *,
+    fingerprint: dict[str, str] | None = None,
+    deps: list[str] | None = None,
+    outs: list[outputs.BaseOut] | None = None,
+    params: stage_def.StageParams | None = None,
+    signature: inspect.Signature | None = None,
+    checkout_modes: list[cache.CheckoutMode] | None = None,
+    run_id: str = "test_run",
+    force: bool = False,
+    no_commit: bool = False,
+    dep_specs: dict[str, stage_def.FuncDepSpec] | None = None,
+    out_specs: dict[str, outputs.BaseOut] | None = None,
+    params_arg_name: str | None = None,
+) -> WorkerStageInfo:
+    """Create a WorkerStageInfo with sensible defaults for testing."""
+    return {
+        "func": func,
+        "fingerprint": fingerprint or {"self:test": "abc123"},
+        "deps": deps or [],
+        "signature": signature,
+        "outs": outs or [],
+        "params": params,
+        "variant": None,
+        "overrides": {},
+        "checkout_modes": checkout_modes
+        or [cache.CheckoutMode.HARDLINK, cache.CheckoutMode.SYMLINK, cache.CheckoutMode.COPY],
+        "run_id": run_id,
+        "force": force,
+        "no_commit": no_commit,
+        "dep_specs": dep_specs or {},
+        "out_specs": out_specs or {},
+        "params_arg_name": params_arg_name,
+        "project_root": tmp_path,
+        "state_dir": tmp_path / ".pivot",
+    }
+
+
+def _apply_deferred_writes(
+    stage_name: str,
+    stage_info: WorkerStageInfo,
+    result: StageResult,
+) -> None:
+    """Simulate coordinator behavior: apply deferred writes from worker result.
+
+    In production, the coordinator (engine) calls apply_deferred_writes after
+    each stage completes. We replicate this to test the full skip detection
+    pipeline end-to-end.
+    """
+    if "deferred_writes" not in result:
+        return
+    deferred = result["deferred_writes"]
+    state_dir = stage_info["state_dir"]
+
+    # Compute output paths (same logic as coordinator)
+    out_paths = [str(out.path) for out in stage_info["outs"]]
+
+    with state.StateDB(state_dir / "state.db") as state_db:
+        state_db.apply_deferred_writes(stage_name, out_paths, deferred)
+
+
+# =============================================================================
+# Test: Generation skip with Pivot-produced deps
+# =============================================================================
+
+
+def test_generation_skip_with_pivot_produced_deps(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """Stage with all Pivot-produced deps skips via generation (no hashing).
+
+    Two-stage pipeline: step1 produces intermediate.txt, step2 consumes it.
+    After both run and deferred writes are applied, step2's second run should
+    skip via generation check (Tier 1) without hashing any files.
+    """
+    (tmp_path / "input.txt").write_text("data")
+
+    def step1_func() -> None:
+        data = (tmp_path / "input.txt").read_text()
+        (tmp_path / "intermediate.txt").write_text(data.upper())
+
+    def step2_func() -> None:
+        data = (tmp_path / "intermediate.txt").read_text()
+        (tmp_path / "final.txt").write_text(f"Final: {data}")
+
+    step1_out = outputs.Out(str(tmp_path / "intermediate.txt"), loader=loaders.PathOnly())
+    step2_out = outputs.Out(str(tmp_path / "final.txt"), loader=loaders.PathOnly())
+
+    step1_info = _make_stage_info(
+        step1_func,
+        tmp_path,
+        fingerprint={"self:step1": "fp1"},
+        deps=["input.txt"],
+        outs=[step1_out],
+    )
+    step2_info = _make_stage_info(
+        step2_func,
+        tmp_path,
+        fingerprint={"self:step2": "fp2"},
+        deps=["intermediate.txt"],
+        outs=[step2_out],
+    )
+
+    # First run: both stages execute
+    result1_step1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
+    assert result1_step1["status"] == "ran"
+    _apply_deferred_writes("step1", step1_info, result1_step1)
+
+    result1_step2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
+    assert result1_step2["status"] == "ran"
+    _apply_deferred_writes("step2", step2_info, result1_step2)
+
+    assert (tmp_path / "final.txt").read_text() == "Final: DATA"
+
+    # Second run: step1 skips (external dep falls through to hash check)
+    result2_step1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
+    assert result2_step1["status"] == "skipped"
+    # No need to re-apply deferred writes for skipped stages (no deferred_writes in result)
+
+    # Second run: step2 should skip via generation check (intermediate.txt is Pivot-produced)
+    hash_spy = mocker.patch(
+        "pivot.executor.worker.hash_dependencies",
+        autospec=True,
+        wraps=worker.hash_dependencies,
+    )
+    result2_step2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
+
+    assert result2_step2["status"] == "skipped", f"Expected skip, got: {result2_step2}"
+    assert result2_step2["reason"] == "unchanged (generation)", (
+        f"Expected generation skip, got: {result2_step2['reason']}"
+    )
+    hash_spy.assert_not_called()
+
+
+# =============================================================================
+# Test: External dep falls through to hash-based check
+# =============================================================================
+
+
+def test_external_dep_falls_through_to_hash_check(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """Stage with external dep (no generation counter) falls through to hash-based check.
+
+    External files aren't produced by any Pivot stage, so they lack generation
+    counters in StateDB. The generation check returns False and execution falls
+    through to Tier 2 (lock file comparison with full hashing).
+    """
+    (tmp_path / "external_data.txt").write_text("external content")
+
+    def stage_func() -> None:
+        data = (tmp_path / "external_data.txt").read_text()
+        (tmp_path / "output.txt").write_text(data.upper())
+
+    out = outputs.Out(str(tmp_path / "output.txt"), loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        stage_func,
+        tmp_path,
+        fingerprint={"self:stage": "fp1"},
+        deps=["external_data.txt"],
+        outs=[out],
+    )
+
+    # First run
+    result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran"
+    _apply_deferred_writes("test_stage", stage_info, result1)
+
+    # Second run: should skip via hash check (not generation)
+    hash_spy = mocker.patch(
+        "pivot.executor.worker.hash_dependencies",
+        autospec=True,
+        wraps=worker.hash_dependencies,
+    )
+    result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+
+    assert result2["status"] == "skipped"
+    assert result2["reason"] == "unchanged", (
+        f"Expected hash-based skip (not generation), got: {result2['reason']}"
+    )
+    hash_spy.assert_called_once()
+
+
+# =============================================================================
+# Test: Cleared StateDB degrades gracefully to lock comparison
+# =============================================================================
+
+
+def test_cleared_statedb_degrades_to_lock_comparison(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+) -> None:
+    """After clearing StateDB, skip detection degrades to lock comparison.
+
+    The generation check fails (no generations in cleared DB), but the lock
+    file still has valid fingerprint + dep_hashes, so Tier 2 can still skip.
+    """
+    (tmp_path / "input.txt").write_text("data")
+
+    def stage_func() -> None:
+        (tmp_path / "output.txt").write_text("result")
+
+    out = outputs.Out(str(tmp_path / "output.txt"), loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        stage_func,
+        tmp_path,
+        fingerprint={"self:stage": "fp1"},
+        deps=["input.txt"],
+        outs=[out],
+    )
+
+    # First run - creates lock file and populates StateDB
+    result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran"
+    _apply_deferred_writes("test_stage", stage_info, result1)
+
+    # Clear StateDB (simulates DB corruption or manual reset)
+    lmdb_dir = tmp_path / ".pivot" / "state.lmdb"
+    if lmdb_dir.exists():
+        shutil.rmtree(lmdb_dir)
+
+    # Second run: lock file still exists, so hash comparison should detect unchanged
+    result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result2["status"] == "skipped", f"Expected skip via lock comparison, got: {result2}"
+    assert "unchanged" in result2["reason"], (
+        f"Expected 'unchanged' reason, got: {result2['reason']}"
+    )
+    # Should NOT be generation-based (StateDB was cleared)
+    assert "generation" not in result2["reason"], (
+        "Should not use generation skip after StateDB clear"
+    )
+
+
+# =============================================================================
+# Test: Missing lock file triggers full run
+# =============================================================================
+
+
+def test_missing_lock_file_triggers_full_run(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+) -> None:
+    """When lock file doesn't exist, stage must do a full run.
+
+    This is the cold start case — no previous execution recorded.
+    """
+    (tmp_path / "input.txt").write_text("data")
+
+    counter_file = tmp_path / "run_counter.txt"
+    counter_file.write_text("0")
+
+    def stage_func() -> None:
+        count = int(counter_file.read_text())
+        counter_file.write_text(str(count + 1))
+        (tmp_path / "output.txt").write_text("done")
+
+    out = outputs.Out(str(tmp_path / "output.txt"), loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        stage_func,
+        tmp_path,
+        fingerprint={"self:stage": "fp1"},
+        deps=["input.txt"],
+        outs=[out],
+    )
+
+    # Verify no lock file exists
+    stages_dir = lock.get_stages_dir(tmp_path / ".pivot")
+    stage_lock = lock.StageLock("test_stage", stages_dir)
+    assert stage_lock.read() is None, "Lock file should not exist before first run"
+
+    # First run: must execute (no lock file)
+    result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran"
+    assert result1["reason"] == "No previous run"
+    assert counter_file.read_text() == "1", "Stage should have executed once"
+
+    # Lock file should now exist
+    assert stage_lock.read() is not None, "Lock file should exist after first run"
+
+    # Apply deferred writes (coordinator behavior)
+    _apply_deferred_writes("test_stage", stage_info, result1)
+
+    # Second run: should skip
+    result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result2["status"] == "skipped"
+    assert counter_file.read_text() == "1", "Stage should not have re-executed"
+
+
+# =============================================================================
+# Test: Generation invalidation propagates through pipeline
+# =============================================================================
+
+
+def test_generation_invalidation_propagates(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+) -> None:
+    """When upstream re-runs, downstream detects generation change and re-runs.
+
+    step1: input.txt → intermediate.txt
+    step2: intermediate.txt → final.txt
+
+    After modifying input.txt, step1 re-runs and gets new output generation.
+    step2 detects the generation mismatch and re-runs too.
+    """
+    (tmp_path / "input.txt").write_text("original")
+
+    def step1_func() -> None:
+        data = (tmp_path / "input.txt").read_text()
+        (tmp_path / "intermediate.txt").write_text(data.upper())
+
+    def step2_func() -> None:
+        data = (tmp_path / "intermediate.txt").read_text()
+        (tmp_path / "final.txt").write_text(f"Final: {data}")
+
+    step1_out = outputs.Out(str(tmp_path / "intermediate.txt"), loader=loaders.PathOnly())
+    step2_out = outputs.Out(str(tmp_path / "final.txt"), loader=loaders.PathOnly())
+
+    step1_info = _make_stage_info(
+        step1_func,
+        tmp_path,
+        fingerprint={"self:step1": "fp1"},
+        deps=["input.txt"],
+        outs=[step1_out],
+    )
+    step2_info = _make_stage_info(
+        step2_func,
+        tmp_path,
+        fingerprint={"self:step2": "fp2"},
+        deps=["intermediate.txt"],
+        outs=[step2_out],
+    )
+
+    # First run: both stages execute
+    r1_s1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
+    assert r1_s1["status"] == "ran"
+    _apply_deferred_writes("step1", step1_info, r1_s1)
+
+    r1_s2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
+    assert r1_s2["status"] == "ran"
+    _apply_deferred_writes("step2", step2_info, r1_s2)
+
+    assert (tmp_path / "final.txt").read_text() == "Final: ORIGINAL"
+
+    # Modify input → step1 must re-run
+    (tmp_path / "input.txt").write_text("modified")
+
+    r2_s1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
+    assert r2_s1["status"] == "ran"
+    _apply_deferred_writes("step1", step1_info, r2_s1)
+
+    # step2: intermediate.txt generation changed → must re-run
+    r2_s2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
+    assert r2_s2["status"] == "ran", f"Expected re-run due to generation change, got: {r2_s2}"
+    _apply_deferred_writes("step2", step2_info, r2_s2)
+
+    assert (tmp_path / "final.txt").read_text() == "Final: MODIFIED"
+
+
+# =============================================================================
+# Test: Deferred file hash write-back populates StateDB
+# =============================================================================
+
+
+def test_deferred_file_hash_writeback(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+) -> None:
+    """Workers collect file hash entries during dep hashing and write them back.
+
+    After the coordinator applies deferred writes, the file hashes should be
+    in StateDB, enabling O(1) cache lookups on subsequent runs.
+    """
+    (tmp_path / "input.txt").write_text("data")
+
+    def stage_func() -> None:
+        (tmp_path / "output.txt").write_text("output")
+
+    out = outputs.Out(str(tmp_path / "output.txt"), loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        stage_func,
+        tmp_path,
+        fingerprint={"self:stage": "fp1"},
+        deps=["input.txt"],
+        outs=[out],
+    )
+
+    result = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
+    assert result["status"] == "ran", f"Expected ran, got {result['status']}: {result['reason']}"
+
+    assert "deferred_writes" in result, "Result should have deferred_writes"
+    deferred = result["deferred_writes"]
+    assert "file_hash_entries" in deferred, "Deferred writes should include file_hash_entries"
+    assert len(deferred["file_hash_entries"]) >= 1, "Should have at least 1 file hash entry"
+
+    _apply_deferred_writes("test_stage", stage_info, result)
+
+    input_path = tmp_path / "input.txt"
+    with state.StateDB(stage_info["state_dir"] / "state.db", readonly=True) as state_db:
+        stat = input_path.stat()
+        cached = state_db.get_many([(input_path, stat)])
+        assert cached.get(input_path) is not None, (
+            "File hash should be in StateDB after deferred write-back"
+        )

--- a/packages/pivot/tests/test_status.py
+++ b/packages/pivot/tests/test_status.py
@@ -224,7 +224,7 @@ def test_tracked_files_clean(set_project_root: pathlib.Path) -> None:
 
     data_file = set_project_root / "data.txt"
     data_file.write_text("content")
-    file_hash = cache.hash_file(data_file)
+    file_hash, _ = cache.hash_file(data_file)
 
     pvt_data = track.PvtData(path="data.txt", hash=file_hash, size=7)
     track.write_pvt_file(set_project_root / "data.txt.pvt", pvt_data)
@@ -242,7 +242,7 @@ def test_tracked_files_modified(set_project_root: pathlib.Path) -> None:
 
     data_file = set_project_root / "data.txt"
     data_file.write_text("original")
-    old_hash = cache.hash_file(data_file)
+    old_hash, _ = cache.hash_file(data_file)
 
     pvt_data = track.PvtData(path="data.txt", hash=old_hash, size=8)
     track.write_pvt_file(set_project_root / "data.txt.pvt", pvt_data)
@@ -331,12 +331,14 @@ def test_tracked_files_progress_callback(set_project_root: pathlib.Path) -> None
     # Create two tracked files
     file1 = set_project_root / "file1.txt"
     file1.write_text("content1")
-    pvt1 = track.PvtData(path="file1.txt", hash=cache.hash_file(file1), size=8)
+    hash1, _ = cache.hash_file(file1)
+    pvt1 = track.PvtData(path="file1.txt", hash=hash1, size=8)
     track.write_pvt_file(set_project_root / "file1.txt.pvt", pvt1)
 
     file2 = set_project_root / "file2.txt"
     file2.write_text("content2")
-    pvt2 = track.PvtData(path="file2.txt", hash=cache.hash_file(file2), size=8)
+    hash2, _ = cache.hash_file(file2)
+    pvt2 = track.PvtData(path="file2.txt", hash=hash2, size=8)
     track.write_pvt_file(set_project_root / "file2.txt.pvt", pvt2)
 
     progress_calls = list[tuple[int, int]]()


### PR DESCRIPTION
## Summary

Fixes core cache/state soundness gaps and completes the fingerprint manifest caching system. Makes generation-based skip detection truly O(1), eliminates the dual-source-of-truth for dep_generations, and adds safe-by-default fingerprinting that errors on unsound closure captures.

## Changes

### Skip Detection (C0)
- **Generation skip before dep hashing**: `execute_stage()` now tries O(1) generation-based skip check BEFORE calling `hash_dependencies()`. When generation check passes, deps are never hashed.
- **File-hash write-back**: `hash_dependencies()` collects file stat entries that get persisted to StateDB via `DeferredWrites`, making future hash lookups hit cache.

### State Consolidation (C1)
- **dep_generations removed from lockfiles**: Only lives in StateDB now. Old lockfiles with the field are gracefully ignored (backward compatible).

### Manifest Cache (C2 / #363 / #358)
- **Flush boundaries**: `flush_manifest_cache()` added at discovery, YAML load, and watch-mode reload lifecycle points.
- **Selective re-fingerprinting**: New `invalidate_manifests_for_paths()` scans StateDB `sm:` entries and only invalidates manifests referencing changed files. Unaffected stages keep cached manifests.

### Safe Fingerprinting
- **Mutable closure validation**: Stages closing over mutable state (dict, list, set, non-frozen class instances) now raise `StageDefinitionError` by default.
- **Escape hatch**: `core.unsafe_fingerprinting` config option or `PIVOT_UNSAFE_FINGERPRINTING=1` env var downgrades errors to warnings.
- **Frozen instances allowed**: Frozen dataclasses and frozen Pydantic models pass validation.

### Hardening (from Oracle review)
- `path.stat()` moved after `hash_file()` to prevent stale metadata in cache
- `_current_stage_name` uses `contextvars.ContextVar` instead of module-level global
- `iter_prefix()` materializes results to avoid pinning LMDB read transactions
- Narrowed exception handling in `_is_unsafe_fingerprinting_enabled()`

### Documentation
- New `docs/solutions/2026-02-08-skip-detection-invariants.md` documenting the three-tier skip detection algorithm
- Updated `packages/pivot/src/pivot/storage/AGENTS.md` with StateDB prefix table and dep_generations changes

## Test Coverage
- 6 new integration tests (generation skip, external dep fallback, cleared StateDB, missing lock)
- 12 new safe fingerprinting tests (mutable dict/list/set, frozen dataclass/Pydantic, env var suppression)
- Existing tests updated to remove `dep_generations` from test data
- All 593+ tests pass, 0 basedpyright errors, ruff clean

Closes #363
Closes #358