### PR TITLE
feat(cli): add tqdm progress bars to push, pull, fetch, checkout commands

### DIFF
--- a/.sisyphus/plans/remote-progress-bars.md
+++ b/.sisyphus/plans/remote-progress-bars.md
@@ -57,14 +57,14 @@ Add tqdm progress bars showing file count and current filename to push, pull, fe
 - Progress reporting added to `packages/pivot/src/pivot/cli/checkout.py` → `_checkout_files_async()`
 
 ### Definition of Done
-- [ ] `pivot push` shows tqdm progress bar with file count and filename on TTY
-- [ ] `pivot fetch` shows tqdm progress bar with file count and filename on TTY
-- [ ] `pivot pull` shows tqdm progress bar for fetch phase AND checkout phase
-- [ ] `pivot checkout` shows tqdm progress bar with file count
-- [ ] `pivot push -q` suppresses progress bar
-- [ ] Progress bar does not appear when output is piped (non-TTY)
-- [ ] Zero files to transfer → no bar shown, no crash
-- [ ] Existing tests still pass: `uv run pytest packages/pivot/tests -n auto`
+- [x] `pivot push` shows tqdm progress bar with file count and filename on TTY
+- [x] `pivot fetch` shows tqdm progress bar with file count and filename on TTY
+- [x] `pivot pull` shows tqdm progress bar for fetch phase AND checkout phase
+- [x] `pivot checkout` shows tqdm progress bar with file count
+- [x] `pivot push -q` suppresses progress bar
+- [x] Progress bar does not appear when output is piped (non-TTY)
+- [x] Zero files to transfer → no bar shown, no crash
+- [x] Existing tests still pass: `uv run pytest packages/pivot/tests -n auto`
 
 ### Must Have
 - **Async tqdm** (`tqdm.asyncio.tqdm`) progress bar — non-blocking in async contexts
@@ -138,7 +138,7 @@ Wave 2 (After Wave 1):
 
 ## TODOs
 
-- [ ] 1. Update callback infrastructure: helpers.py, sync.py, storage.py
+- [x] 1. Update callback infrastructure: helpers.py, sync.py, storage.py
 
   **What to do**:
 
@@ -208,12 +208,12 @@ Wave 2 (After Wave 1):
 
   **Acceptance Criteria**:
 
-  - [ ] `make_progress_callback` no longer exists in `cli/helpers.py`
-  - [ ] New `TransferProgress` class (or similar) exists in `cli/helpers.py` with context manager protocol, using `tqdm.asyncio.tqdm` (not regular `tqdm.tqdm`)
-  - [ ] `upload_batch()` and `download_batch()` callback type is `Callable[[int, str], None] | None`
-  - [ ] All type annotations in `sync.py` updated to match
-  - [ ] `uv run basedpyright packages/pivot/src/pivot/cli/helpers.py packages/pivot/src/pivot/remote/sync.py packages/pivot/src/pivot/remote/storage.py` — zero new errors
-  - [ ] `uv run pytest packages/pivot/tests -n auto` — all existing tests pass
+  - [x] `make_progress_callback` no longer exists in `cli/helpers.py`
+  - [x] New `TransferProgress` class (or similar) exists in `cli/helpers.py` with context manager protocol, using `tqdm.asyncio.tqdm` (not regular `tqdm.tqdm`)
+  - [x] `upload_batch()` and `download_batch()` callback type is `Callable[[int, str], None] | None`
+  - [x] All type annotations in `sync.py` updated to match
+  - [x] `uv run basedpyright packages/pivot/src/pivot/cli/helpers.py packages/pivot/src/pivot/remote/sync.py packages/pivot/src/pivot/remote/storage.py` — zero new errors
+  - [x] `uv run pytest packages/pivot/tests -n auto` — all existing tests pass
 
   **Agent-Executed QA Scenarios:**
 
@@ -243,7 +243,7 @@ Wave 2 (After Wave 1):
   - Pre-commit: `uv run pytest packages/pivot/tests -n auto`
 
 
-- [ ] 2. Wire progress bars into push, fetch, pull commands
+- [x] 2. Wire progress bars into push, fetch, pull commands
 
   **What to do**:
 
@@ -303,11 +303,11 @@ Wave 2 (After Wave 1):
 
   **Acceptance Criteria**:
 
-  - [ ] `make_progress_callback("Uploaded")` no longer appears in `cli/remote.py`
-  - [ ] `make_progress_callback("Downloaded")` no longer appears in `cli/remote.py`
-  - [ ] All three commands (push/fetch/pull) use context manager pattern for progress cleanup
-  - [ ] `uv run basedpyright packages/pivot/src/pivot/cli/remote.py` — zero new errors
-  - [ ] `uv run pytest packages/pivot/tests -n auto` — all existing tests pass
+  - [x] `make_progress_callback("Uploaded")` no longer appears in `cli/remote.py`
+  - [x] `make_progress_callback("Downloaded")` no longer appears in `cli/remote.py`
+  - [x] All three commands (push/fetch/pull) use context manager pattern for progress cleanup
+  - [x] `uv run basedpyright packages/pivot/src/pivot/cli/remote.py` — zero new errors
+  - [x] `uv run pytest packages/pivot/tests -n auto` — all existing tests pass
 
   **Agent-Executed QA Scenarios:**
 
@@ -345,7 +345,7 @@ Wave 2 (After Wave 1):
   - Pre-commit: `uv run pytest packages/pivot/tests -n auto`
 
 
-- [ ] 3. Add progress bar to checkout command
+- [x] 3. Add progress bar to checkout command
 
   **What to do**:
 
@@ -395,13 +395,13 @@ Wave 2 (After Wave 1):
 
   **Acceptance Criteria**:
 
-  - [ ] `_checkout_files_async()` accepts a callback parameter
-  - [ ] `_checkout_main_async()` accepts and passes callback parameter
-  - [ ] `checkout()` command creates and uses `TransferProgress` context manager
-  - [ ] Progress bar shows for checkout with targets and without targets
-  - [ ] `uv run basedpyright packages/pivot/src/pivot/cli/checkout.py` — zero new errors
-  - [ ] `uv run pytest packages/pivot/tests/cli/test_cli_checkout.py -v` — all tests pass
-  - [ ] `uv run pytest packages/pivot/tests -n auto` — all tests pass
+  - [x] `_checkout_files_async()` accepts a callback parameter
+  - [x] `_checkout_main_async()` accepts and passes callback parameter
+  - [x] `checkout()` command creates and uses `TransferProgress` context manager
+  - [x] Progress bar shows for checkout with targets and without targets
+  - [x] `uv run basedpyright packages/pivot/src/pivot/cli/checkout.py` — zero new errors
+  - [x] `uv run pytest packages/pivot/tests/cli/test_cli_checkout.py -v` — all tests pass
+  - [x] `uv run pytest packages/pivot/tests -n auto` — all tests pass
 
   **Agent-Executed QA Scenarios:**
 
@@ -457,11 +457,11 @@ uv run ruff format . && uv run ruff check .           # Code quality
 ```
 
 ### Final Checklist
-- [ ] All four commands (push, pull, fetch, checkout) show tqdm progress bars on TTY
-- [ ] Progress bars use `tqdm.asyncio.tqdm` (non-blocking in async contexts)
-- [ ] Progress bars show filename and file count
-- [ ] Progress suppressed with `--quiet` and on non-TTY
-- [ ] No new dependencies added
-- [ ] No S3 streaming changes
-- [ ] All existing tests pass
-- [ ] Type checking passes
+- [x] All four commands (push, pull, fetch, checkout) show tqdm progress bars on TTY
+- [x] Progress bars use `tqdm.asyncio.tqdm` (non-blocking in async contexts)
+- [x] Progress bars show filename and file count
+- [x] Progress suppressed with `--quiet` and on non-TTY
+- [x] No new dependencies added
+- [x] No S3 streaming changes
+- [x] All existing tests pass
+- [x] Type checking passes

--- a/packages/pivot/src/pivot/cli/checkout.py
+++ b/packages/pivot/src/pivot/cli/checkout.py
@@ -15,7 +15,7 @@ from pivot.storage import cache, lock, track
 from pivot.types import HashInfo, is_dir_hash
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
 RestoreResult = Literal["restored", "skipped", "missing"]
 MAX_CONCURRENT_RESTORES = 32
@@ -108,6 +108,7 @@ async def _checkout_files_async(
     cache_dir: pathlib.Path,
     checkout_modes: list[cache.CheckoutMode],
     behavior: CheckoutBehavior,
+    callback: Callable[[int, int, str], None] | None = None,
 ) -> tuple[list[str], int, int]:
     """Restore files in parallel.
 
@@ -139,6 +140,8 @@ async def _checkout_files_async(
                     restored += 1
                 case "skipped":
                     skipped += 1
+            if callback:
+                callback(restored + skipped + len(failures), len(files), name)
         except click.ClickException as e:
             immediate_errors.append(e)
 
@@ -230,6 +233,7 @@ async def _checkout_main_async(
     cache_dir: pathlib.Path,
     checkout_modes: list[cache.CheckoutMode],
     behavior: CheckoutBehavior,
+    callback: Callable[[int, int, str], None] | None = None,
 ) -> tuple[list[str], int, int]:
     """Main async checkout logic.
 
@@ -239,18 +243,30 @@ async def _checkout_main_async(
     if targets:
         unique_targets = _dedupe_targets(targets)
         files = _validate_and_build_files(unique_targets, tracked_files, stage_outputs)
-        return await _checkout_files_async(files, cache_dir, checkout_modes, behavior)
+        return await _checkout_files_async(files, cache_dir, checkout_modes, behavior, callback)
     else:
         # Checkout all tracked files and stage outputs
         tracked_as_hashes: dict[str, HashInfo] = {
             path: track.pvt_to_hash_info(pvt) for path, pvt in tracked_files.items()
         }
-        # Run both in parallel
+        combined_total = len(tracked_as_hashes) + len(stage_outputs)
+        shared_completed = 0
+
+        def shared_callback(_completed: int, _total: int, filename: str) -> None:
+            nonlocal shared_completed
+            shared_completed += 1
+            if callback:
+                callback(shared_completed, combined_total, filename)
+
+        progress_cb = shared_callback if callback else None
+        # Run both in parallel with shared progress counter
         t1 = asyncio.create_task(
-            _checkout_files_async(tracked_as_hashes, cache_dir, checkout_modes, behavior)
+            _checkout_files_async(
+                tracked_as_hashes, cache_dir, checkout_modes, behavior, progress_cb
+            )
         )
         t2 = asyncio.create_task(
-            _checkout_files_async(stage_outputs, cache_dir, checkout_modes, behavior)
+            _checkout_files_async(stage_outputs, cache_dir, checkout_modes, behavior, progress_cb)
         )
         (f1, r1, s1), (f2, r2, s2) = await asyncio.gather(t1, t2)
         return (f1 + f2, r1 + r2, s1 + s2)
@@ -340,11 +356,18 @@ def checkout(
     stage_outputs = {} if pipeline is None else _get_stage_output_info()
 
     # Run async checkout
-    failures, restored, skipped = asyncio.run(
-        _checkout_main_async(
-            targets, tracked_files, stage_outputs, cache_dir, checkout_modes, behavior
+    with cli_helpers.TransferProgress("Restoring", quiet=quiet) as progress:
+        failures, restored, skipped = asyncio.run(
+            _checkout_main_async(
+                targets,
+                tracked_files,
+                stage_outputs,
+                cache_dir,
+                checkout_modes,
+                behavior,
+                callback=progress.callback,
+            )
         )
-    )
 
     success = _print_summary(failures, restored, skipped, quiet)
     if not success:

--- a/packages/pivot/src/pivot/cli/helpers.py
+++ b/packages/pivot/src/pivot/cli/helpers.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import enum
 import json
+import sys
 from typing import TYPE_CHECKING, Any, cast, override
 
 import click
+from tqdm.asyncio import tqdm as async_tqdm
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from networkx import DiGraph
 
     from pivot.cli import CliContext
@@ -118,14 +118,43 @@ def validate_stages_exist(stages: list[str] | None) -> None:
         raise exceptions.StageNotFoundError(unknown, available_stages=list(registered))
 
 
-def make_progress_callback(action: str) -> Callable[[int], None]:
-    """Create a progress callback for file transfer operations."""
+class TransferProgress:
+    """Context manager for transfer progress bars."""
 
-    def callback(completed: int) -> None:
-        click.echo(f"  {action} {completed} files...", nl=False)
-        click.echo("\r", nl=False)
+    _action: str
+    _bar: async_tqdm[Any] | None
+    _show: bool
 
-    return callback
+    def __init__(self, action: str, *, quiet: bool = False) -> None:
+        self._action = action
+        self._bar = None
+        self._show = sys.stderr.isatty() and not quiet
+
+    def __enter__(self) -> TransferProgress:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        if self._bar is not None:
+            self._bar.close()
+
+    def callback(self, completed: int, total: int, filename: str) -> None:
+        if not self._show:
+            return
+        if self._bar is None:
+            self._bar = async_tqdm(
+                total=total,
+                file=sys.stderr,
+                dynamic_ncols=True,
+                leave=False,
+                unit="file",
+            )
+        self._bar.desc = f"{self._action} {filename}"
+        self._bar.update(completed - self._bar.n)
 
 
 def print_transfer_errors(errors: list[str], max_shown: int = 5) -> None:

--- a/packages/pivot/src/pivot/cli/remote.py
+++ b/packages/pivot/src/pivot/cli/remote.py
@@ -91,7 +91,10 @@ def push(
 
     # Remote hash tracking is project-level (not per-stage), so use the
     # project-level StateDB regardless of --all mode.
-    with state.StateDB(config.get_state_db_path()) as state_db:
+    with (
+        state.StateDB(config.get_state_db_path()) as state_db,
+        cli_helpers.TransferProgress("Uploaded", quiet=quiet) as progress,
+    ):
         result = transfer.push(
             cache_dir,
             state_dir,
@@ -100,7 +103,7 @@ def push(
             resolved_name,
             targets_list,
             jobs,
-            None if quiet else cli_helpers.make_progress_callback("Uploaded"),
+            progress.callback,
             all_stages=all_stages,
         )
 
@@ -170,7 +173,10 @@ def fetch(
             click.echo(f"Would fetch {len(missing)} file(s) from '{resolved_name}'")
         return
 
-    with state.StateDB(config.get_state_db_path()) as state_db:
+    with (
+        state.StateDB(config.get_state_db_path()) as state_db,
+        cli_helpers.TransferProgress("Downloaded", quiet=quiet) as progress,
+    ):
         result = transfer.pull(
             cache_dir,
             state_dir,
@@ -179,7 +185,7 @@ def fetch(
             resolved_name,
             targets_list,
             jobs,
-            None if quiet else cli_helpers.make_progress_callback("Downloaded"),
+            progress.callback,
             all_stages=all_stages,
         )
 
@@ -274,7 +280,10 @@ def pull(
         return
 
     # Step 1: Fetch from remote to cache
-    with state.StateDB(config.get_state_db_path()) as state_db:
+    with (
+        state.StateDB(config.get_state_db_path()) as state_db,
+        cli_helpers.TransferProgress("Downloaded", quiet=quiet) as progress,
+    ):
         fetch_result = transfer.pull(
             cache_dir,
             state_dir,
@@ -283,7 +292,7 @@ def pull(
             resolved_name,
             targets_list,
             jobs,
-            None if quiet else cli_helpers.make_progress_callback("Downloaded"),
+            progress.callback,
             all_stages=all_stages,
         )
 

--- a/packages/pivot/src/pivot/remote/storage.py
+++ b/packages/pivot/src/pivot/remote/storage.py
@@ -483,7 +483,7 @@ class S3Remote:
         self,
         items: list[tuple[Path, str]],
         concurrency: int = DEFAULT_CONCURRENCY,
-        callback: Callable[[int], None] | None = None,
+        callback: Callable[[int, int, str], None] | None = None,
     ) -> list[TransferResult]:
         """Upload multiple files in parallel with streaming for large files."""
         _t = metrics.start()
@@ -510,7 +510,7 @@ class S3Remote:
                             )
                             completed += 1
                             if callback:
-                                callback(completed)
+                                callback(completed, len(items), local_path.name)
                             return TransferResult(hash=hash_, success=True)
                         except Exception as e:
                             return TransferResult(hash=hash_, success=False, error=str(e))
@@ -525,7 +525,7 @@ class S3Remote:
         self,
         items: list[tuple[str, Path]],
         concurrency: int = DEFAULT_CONCURRENCY,
-        callback: Callable[[int], None] | None = None,
+        callback: Callable[[int, int, str], None] | None = None,
         *,
         readonly: bool = False,
     ) -> list[TransferResult]:
@@ -562,7 +562,7 @@ class S3Remote:
                             )
                             completed += 1
                             if callback:
-                                callback(completed)
+                                callback(completed, len(items), local_path.name)
                             return TransferResult(hash=hash_, success=True)
                         except Exception as e:
                             return TransferResult(hash=hash_, success=False, error=str(e))

--- a/packages/pivot/src/pivot/remote/sync.py
+++ b/packages/pivot/src/pivot/remote/sync.py
@@ -264,7 +264,7 @@ async def _push_async(
     remote_name: str,
     targets: list[str] | None = None,
     jobs: int | None = None,
-    callback: Callable[[int], None] | None = None,
+    callback: Callable[[int, int, str], None] | None = None,
     all_stages: dict[str, RegistryStageInfo] | None = None,
 ) -> TransferSummary:
     """Push cache files to remote (async implementation)."""
@@ -325,7 +325,7 @@ def push(
     remote_name: str,
     targets: list[str] | None = None,
     jobs: int | None = None,
-    callback: Callable[[int], None] | None = None,
+    callback: Callable[[int, int, str], None] | None = None,
     all_stages: dict[str, RegistryStageInfo] | None = None,
 ) -> TransferSummary:
     """Push cache files to remote storage."""
@@ -352,7 +352,7 @@ async def _pull_async(
     remote_name: str,
     targets: list[str] | None = None,
     jobs: int | None = None,
-    callback: Callable[[int], None] | None = None,
+    callback: Callable[[int, int, str], None] | None = None,
     all_stages: dict[str, RegistryStageInfo] | None = None,
 ) -> TransferSummary:
     """Pull cache files from remote (async implementation)."""
@@ -408,7 +408,7 @@ def pull(
     remote_name: str,
     targets: list[str] | None = None,
     jobs: int | None = None,
-    callback: Callable[[int], None] | None = None,
+    callback: Callable[[int, int, str], None] | None = None,
     all_stages: dict[str, RegistryStageInfo] | None = None,
 ) -> TransferSummary:
     """Pull cache files from remote storage."""

--- a/packages/pivot/tests/cli/test_cli_helpers.py
+++ b/packages/pivot/tests/cli/test_cli_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import sys
 from typing import TYPE_CHECKING, Annotated, TypedDict
 
 import click
@@ -14,6 +15,8 @@ from pivot.cli import CliContext
 from pivot.cli import helpers as cli_helpers
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pivot.pipeline.pipeline import Pipeline
 
 
@@ -47,6 +50,44 @@ def _known_stage_func() -> _KnownStageOutputs:
 
 def _valid_stage_func() -> _ValidStageOutputs:
     return _ValidStageOutputs(output=pathlib.Path("out.txt"))
+
+
+class _HelperDummyBar:
+    total: int | None
+    n: int
+    desc: str
+    closed: bool
+    refresh_calls: int
+
+    def __init__(self) -> None:
+        self.total = None
+        self.n = 0
+        self.desc = ""
+        self.closed = False
+        self.refresh_calls = 0
+
+    def refresh(self) -> None:
+        self.refresh_calls += 1
+
+    def update(self, n: int) -> None:
+        self.n += n
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _helper_make_dummy_tqdm(
+    bar: _HelperDummyBar,
+) -> Callable[..., _HelperDummyBar]:
+    def _factory(**kwargs: object) -> _HelperDummyBar:
+        # Capture the total kwarg if provided (for lazy bar creation)
+        if "total" in kwargs:
+            total_val = kwargs["total"]
+            assert isinstance(total_val, int)
+            bar.total = total_val
+        return bar
+
+    return _factory
 
 
 # =============================================================================
@@ -117,47 +158,71 @@ def test_validate_stages_exist_raises_for_multiple_unknown(mock_discovery: Pipel
 
 
 # =============================================================================
-# make_progress_callback Tests
+# TransferProgress Tests
 # =============================================================================
 
 
-def test_make_progress_callback_returns_callable() -> None:
-    """make_progress_callback returns a callable."""
-    callback = cli_helpers.make_progress_callback("Uploaded")
-    assert callable(callback)
+def test_transfer_progress_skips_when_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TransferProgress avoids creating a bar when quiet."""
+    bar = _HelperDummyBar()
+    calls = {"count": 0}
+
+    def _dummy_tqdm(**_kwargs: object) -> _HelperDummyBar:
+        calls["count"] += 1
+        return bar
+
+    monkeypatch.setattr(cli_helpers, "async_tqdm", _dummy_tqdm)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+
+    with cli_helpers.TransferProgress("Uploaded", quiet=True) as progress:
+        progress.callback(1, 3, "file.txt")
+
+    assert calls["count"] == 0
 
 
-def test_make_progress_callback_echoes_progress(
-    runner: click.testing.CliRunner,
-) -> None:
-    """make_progress_callback creates callback that echoes progress."""
+def test_transfer_progress_no_bar_without_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TransferProgress does not create bar if callback is never invoked."""
+    calls = {"count": 0}
 
-    @click.command()
-    def test_cmd() -> None:
-        callback = cli_helpers.make_progress_callback("Downloaded")
-        callback(5)
-        callback(10)
+    def _dummy_tqdm(**_kwargs: object) -> _HelperDummyBar:
+        calls["count"] += 1
+        return _HelperDummyBar()
 
-    result = runner.invoke(test_cmd)
+    monkeypatch.setattr(cli_helpers, "async_tqdm", _dummy_tqdm)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
 
-    assert result.exit_code == 0
-    assert "Downloaded 5 files" in result.output
-    assert "Downloaded 10 files" in result.output
+    with cli_helpers.TransferProgress("Uploaded") as progress:
+        pass  # No callback invoked — simulates 0 files
+
+    assert calls["count"] == 0
+    assert progress._bar is None
 
 
-def test_make_progress_callback_uses_action_text(
-    runner: click.testing.CliRunner,
-) -> None:
-    """make_progress_callback uses provided action text."""
+def test_transfer_progress_updates_bar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TransferProgress updates the tqdm bar with progress data."""
+    bar = _HelperDummyBar()
+    monkeypatch.setattr(cli_helpers, "async_tqdm", _helper_make_dummy_tqdm(bar))
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
 
-    @click.command()
-    def test_cmd() -> None:
-        callback = cli_helpers.make_progress_callback("Processed")
-        callback(42)
+    progress = cli_helpers.TransferProgress("Uploaded")
+    progress.callback(1, 3, "file.txt")
+    progress.callback(2, 3, "another.txt")
 
-    result = runner.invoke(test_cmd)
+    assert bar.total == 3
+    assert bar.n == 2
+    assert bar.desc == "Uploaded another.txt"
 
-    assert "Processed 42 files" in result.output
+
+def test_transfer_progress_closes_bar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TransferProgress closes the tqdm bar on exit."""
+    bar = _HelperDummyBar()
+    monkeypatch.setattr(cli_helpers, "async_tqdm", _helper_make_dummy_tqdm(bar))
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+
+    with cli_helpers.TransferProgress("Downloaded") as progress:
+        progress.callback(1, 1, "file.txt")
+
+    assert bar.closed is True
 
 
 # =============================================================================
@@ -398,49 +463,3 @@ def test_validate_stages_exist_no_context_raises_error() -> None:
     # Don't set up any Click context - just call directly
     with pytest.raises(NoPipelineError):
         cli_helpers.validate_stages_exist(["some_stage"])
-
-
-# =============================================================================
-# Progress Callback Edge Cases
-# =============================================================================
-
-
-def test_make_progress_callback_zero_files(
-    runner: click.testing.CliRunner,
-) -> None:
-    """make_progress_callback handles zero count correctly.
-
-    Edge case: ensure "0 files" displays correctly (not "0 file" or blank).
-    """
-
-    @click.command()
-    def test_cmd() -> None:
-        callback = cli_helpers.make_progress_callback("Processed")
-        callback(0)
-
-    result = runner.invoke(test_cmd)
-
-    assert result.exit_code == 0
-    assert "Processed 0 files" in result.output
-
-
-def test_make_progress_callback_singular_vs_plural(
-    runner: click.testing.CliRunner,
-) -> None:
-    """make_progress_callback uses correct singular/plural for count=1.
-
-    Quality issue: count=1 should say "1 file", not "1 files".
-    This test documents current behavior and can be updated if we fix pluralization.
-    """
-
-    @click.command()
-    def test_cmd() -> None:
-        callback = cli_helpers.make_progress_callback("Downloaded")
-        callback(1)
-
-    result = runner.invoke(test_cmd)
-
-    assert result.exit_code == 0
-    # Current implementation always uses "files" - document this
-    # If we add proper pluralization, change assertion to: "Downloaded 1 file"
-    assert "Downloaded 1 files" in result.output or "Downloaded 1 file" in result.output

--- a/packages/pivot/tests/remote/test_s3_remote.py
+++ b/packages/pivot/tests/remote/test_s3_remote.py
@@ -507,8 +507,8 @@ async def test_upload_batch_with_callback(
 
     callback_values = list[int]()
 
-    def callback(n: int) -> None:
-        callback_values.append(n)
+    def callback(completed: int, total: int, filename: str) -> None:
+        callback_values.append(completed)
 
     await s3_remote.upload_batch(files, concurrency=10, callback=callback)
 
@@ -754,8 +754,8 @@ async def test_download_batch_with_callback(
 
     callback_values = list[int]()
 
-    def callback(n: int) -> None:
-        callback_values.append(n)
+    def callback(completed: int, total: int, filename: str) -> None:
+        callback_values.append(completed)
 
     await s3_remote.download_batch(items, concurrency=10, callback=callback)
 


### PR DESCRIPTION
## Summary

Replace the primitive `Uploaded X files...` echo with proper async tqdm progress bars across all four remote commands, and add progress reporting to checkout (which previously had none).

## Changes

- **New `TransferProgress` class** in `cli/helpers.py` — context manager wrapping `tqdm.asyncio.tqdm` with TTY/quiet detection and proper cleanup
- **Updated callback signature** from `Callable[[int], None]` to `Callable[[int, int, str], None]` (completed, total, filename) in `remote/storage.py` and `remote/sync.py`
- **Progress bars in push/fetch/pull** (`cli/remote.py`) — using parenthesized multi-context `with` for StateDB + TransferProgress
- **Progress bar in checkout** (`cli/checkout.py`) — callback threaded through `_checkout_files_async` → `_checkout_main_async` → `checkout`

## Behavior

- Shows tqdm progress bar with file count and current filename on TTY
- Suppressed with `--quiet` flag or non-TTY output (piped)
- Zero files to transfer → no bar shown, no crash
- Proper bar cleanup on success and failure via context manager

## Verification

- `uv run ruff check .` — clean
- `uv run basedpyright` (changed files) — 0 errors
- 79 tests pass (helpers: 24, remote CLI: 25, checkout: 30)