### PR TITLE
fix(cli): allow track/status without pipeline definition, add --all to list/dag

### DIFF
--- a/packages/pivot/src/pivot/cli/AGENTS.md
+++ b/packages/pivot/src/pivot/cli/AGENTS.md
@@ -34,8 +34,11 @@ Set `auto_discover=False` only for commands that don't use the stage registry:
 
 | Command | auto_discover | Reason |
 |---------|---------------|--------|
-| run, list, export | True (default) | Need registry to find stages |
-| checkout, track | True (default) | Need registry for validation |
+| run, export | True (default) | Need registry to find stages |
+| list, dag | True (default), allow_all=True | Need registry; --all for multi-pipeline |
+| checkout | True (default) | Need registry; handles None pipeline gracefully |
+| track | True (default) | Handles None pipeline gracefully (no overlap check) |
+| status | True (default), allow_all=True | Handles None pipeline gracefully (skips stages section) |
 | init | False | Creates new project (no pipeline yet) |
 | schema | False | Outputs JSON schema only |
 | push, pull, fetch | True (default) | Need registry for output cache filtering |

--- a/packages/pivot/src/pivot/cli/dag.py
+++ b/packages/pivot/src/pivot/cli/dag.py
@@ -47,7 +47,7 @@ def _get_upstream_subgraph(
     return bipartite_graph.subgraph(nodes_to_include)
 
 
-@cli_decorators.pivot_command("dag")
+@cli_decorators.pivot_command("dag", allow_all=True)
 @click.argument("targets", nargs=-1)
 @click.option("--dot", "output_format", flag_value="dot", help="Output Graphviz DOT format")
 @click.option("--mermaid", "output_format", flag_value="mermaid", help="Output Mermaid format")

--- a/packages/pivot/src/pivot/cli/helpers.py
+++ b/packages/pivot/src/pivot/cli/helpers.py
@@ -25,11 +25,9 @@ class NoPipelineError(exceptions.PivotError):
     @override
     def format_user_message(self) -> str:
         return (
-            "No pipeline found. This command requires a Pivot project.\n"
+            "No pipeline definition found.\n"
             "\n"
-            "To create a new project, run: pivot init\n"
-            "\n"
-            "If you're in an existing project, ensure one of these exists:\n"
+            "This command requires a pipeline to be defined in one of:\n"
             "  - pivot.yaml (or pivot.yml)\n"
             "  - pipeline.py"
         )

--- a/packages/pivot/src/pivot/cli/list.py
+++ b/packages/pivot/src/pivot/cli/list.py
@@ -34,7 +34,7 @@ def _get_output_sources(stage_list: list[str]) -> dict[str, str]:
     }
 
 
-@cli_decorators.pivot_command("list")
+@cli_decorators.pivot_command("list", allow_all=True)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 @click.option("--deps", "show_deps", is_flag=True, help="Show stage dependencies")
 @click.pass_context

--- a/packages/pivot/src/pivot/cli/status.py
+++ b/packages/pivot/src/pivot/cli/status.py
@@ -53,7 +53,9 @@ def status(
     quiet = cli_ctx["quiet"]
 
     stages_list = cli_helpers.stages_to_list(stages)
-    cli_helpers.validate_stages_exist(stages_list)
+    pipeline = cli_decorators.get_pipeline_from_context()
+    if pipeline is not None:
+        cli_helpers.validate_stages_exist(stages_list)
 
     project_root = project.get_project_root()
     resolved_cache_dir = config.get_cache_dir()
@@ -69,7 +71,7 @@ def status(
     tracked_status = list[TrackedFileInfo]()
     remote_status: RemoteSyncInfo | None = None
 
-    if show_stages:
+    if show_stages and pipeline is not None:
         # Build bipartite graph for consistent execution order with Engine
         all_stages = cli_helpers.get_all_stages()
         graph = engine_graph.build_graph(all_stages)

--- a/packages/pivot/src/pivot/cli/track.py
+++ b/packages/pivot/src/pivot/cli/track.py
@@ -196,7 +196,8 @@ def track(ctx: click.Context, paths: tuple[str, ...], force: bool) -> None:
     cache_dir = config.get_cache_dir() / "files"
 
     # Get all stage outputs for overlap detection
-    stage_outputs = _get_all_stage_outputs()
+    pipeline = cli_decorators.get_pipeline_from_context()
+    stage_outputs = {} if pipeline is None else _get_all_stage_outputs()
 
     # Discover existing .pvt files
     existing_tracked = track_mod.discover_pvt_files(project_root)

--- a/packages/pivot/tests/cli/test_cli_list.py
+++ b/packages/pivot/tests/cli/test_cli_list.py
@@ -176,3 +176,15 @@ def test_list_deps_shows_source_stage(
     assert "consumer" in result.output
     # Should show that consumer's dep comes from producer
     assert "from: producer" in result.output
+
+
+# =============================================================================
+# No Pipeline Tests
+# =============================================================================
+
+
+def test_list_accepts_all_flag(runner: click.testing.CliRunner) -> None:
+    """List should accept the --all flag."""
+    result = runner.invoke(cli.cli, ["list", "--help"])
+    assert result.exit_code == 0
+    assert "--all" in result.output, "List should accept --all flag"

--- a/packages/pivot/tests/cli/test_cli_status.py
+++ b/packages/pivot/tests/cli/test_cli_status.py
@@ -868,3 +868,33 @@ def test_explain_command_removed(runner: click.testing.CliRunner, tmp_path: path
 
         assert result.exit_code != 0
         assert "No such command" in result.output or "Error" in result.output
+
+
+# =============================================================================
+# No Pipeline Tests
+# =============================================================================
+
+
+def test_status_works_without_pipeline(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Status should succeed in a Pivot project without a pipeline definition."""
+    with isolated_pivot_dir(runner, tmp_path):
+        result = runner.invoke(cli.cli, ["status"])
+        assert result.exit_code == 0, f"Status should succeed without pipeline: {result.output}"
+        # Should show tracked files section (even if empty)
+        assert "Tracked Files" in result.output or "No tracked files" in result.output, (
+            "Should show tracked files section"
+        )
+
+
+def test_status_json_without_pipeline(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Status --json should work without a pipeline definition."""
+    with isolated_pivot_dir(runner, tmp_path):
+        result = runner.invoke(cli.cli, ["status", "--json"])
+        assert result.exit_code == 0, f"Status --json should succeed: {result.output}"
+        data = json.loads(result.output)
+        assert "stages" in data, "JSON output should include stages key"
+        assert data["stages"] == [], "Stages should be empty without pipeline"

--- a/packages/pivot/tests/cli/test_cli_track.py
+++ b/packages/pivot/tests/cli/test_cli_track.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pathlib
 from typing import TYPE_CHECKING, Annotated, TypedDict
 
+from conftest import isolated_pivot_dir
 from helpers import register_test_stage
 from pivot import cli, loaders, outputs
 from pivot.storage import track
@@ -489,3 +490,37 @@ def test_track_with_normalized_vs_resolved_paths(
     # Both paths should appear in error for clarity
     assert "link_to_real" in result.output, "Should show user's path"
     assert "real" in result.output, "Should show resolved path"
+
+
+# =============================================================================
+# No Pipeline Tests
+# =============================================================================
+
+
+def test_track_works_without_pipeline(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Track should succeed in a Pivot project without a pipeline definition."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        (cwd / "data.csv").write_text("a,b,c\n1,2,3\n")
+        result = runner.invoke(cli.cli, ["track", "data.csv"])
+        assert result.exit_code == 0, f"Track should succeed without pipeline: {result.output}"
+        assert "Tracked: data.csv" in result.output, "Should show tracked confirmation"
+        assert (cwd / "data.csv.pvt").exists(), "PVT file should be created"
+
+
+def test_track_force_works_without_pipeline(
+    runner: click.testing.CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Track --force should work without a pipeline definition."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        (cwd / "data.csv").write_text("a,b,c\n1,2,3\n")
+        # First track
+        runner.invoke(cli.cli, ["track", "data.csv"])
+        # Update and re-track with --force
+        (cwd / "data.csv").write_text("a,b,c\n4,5,6\n")
+        result = runner.invoke(cli.cli, ["track", "--force", "data.csv"])
+        assert result.exit_code == 0, (
+            f"Track --force should succeed without pipeline: {result.output}"
+        )
+        assert "Tracked: data.csv" in result.output

--- a/packages/pivot/tests/cli/test_dag_cmd.py
+++ b/packages/pivot/tests/cli/test_dag_cmd.py
@@ -562,3 +562,15 @@ def test_dag_target_partial_resolution(
     assert "extract" in result.output
     # transform not requested, should not appear in filtered output
     assert "transform" not in result.output
+
+
+# =============================================================================
+# Flag Tests
+# =============================================================================
+
+
+def test_dag_accepts_all_flag(runner: click.testing.CliRunner) -> None:
+    """Dag should accept the --all flag."""
+    result = runner.invoke(cli.cli, ["dag", "--help"])
+    assert result.exit_code == 0
+    assert "--all" in result.output, "Dag should accept --all flag"


### PR DESCRIPTION
## Summary

- `pivot track` and `pivot status` now work in Pivot projects that have `.pivot/` but no pipeline definition (no `pivot.yaml`/`pipeline.py`)
- `pivot list --all` and `pivot dag --all` flags added for multi-pipeline discovery
- `NoPipelineError` message updated to accurately distinguish "no pipeline definition" from "no Pivot project"

## Changes

**track.py**: Guard pattern — skip stage-output overlap check when no pipeline is present (returns empty dict, meaning "nothing to conflict with"). Follows the existing pattern from `checkout.py`.

**status.py**: Guard pattern — skip `validate_stages_exist()` and the stages section when no pipeline is present. Tracked files and remote sections still work. When `show_stages` is true but no pipeline, `_print_pipeline_section` shows "No stages registered".

**list.py / dag.py**: Added `allow_all=True` to `pivot_command` decorator, enabling the `--all` flag for multi-pipeline discovery (matching `repro` and `commit`).

**helpers.py**: Updated `NoPipelineError.format_user_message()` — old message misleadingly said "This command requires a Pivot project"; new message says "No pipeline definition found" and lists where to define one.

**AGENTS.md**: Updated auto_discover table to reflect which commands handle `None` pipeline gracefully.

**Tests**: 5 new tests covering no-pipeline track, no-pipeline status (text + JSON), and `--all` flag acceptance.

## Verification

- 758 CLI tests pass (including 5 new), 4 skipped (pre-existing)
- `ruff format` / `ruff check`: clean
- `basedpyright`: 0 errors, 0 warnings