### PR TITLE
fix(params): normalize tuple→list in model_dump to match YAML round-trip

### DIFF
--- a/packages/pivot/src/pivot/parameters.py
+++ b/packages/pivot/src/pivot/parameters.py
@@ -178,4 +178,4 @@ def get_effective_params(
         return {}
 
     effective = apply_overrides(params_instance, stage_name, overrides)
-    return effective.model_dump()
+    return effective.model_dump(mode="json")

--- a/packages/pivot/tests/config/test_params.py
+++ b/packages/pivot/tests/config/test_params.py
@@ -39,6 +39,11 @@ class ComplexParams(BaseModel):
     debug: bool = False
 
 
+class TupleParams(BaseModel):
+    token_range: tuple[float, float] = (5000.0, 100000000.0)
+    time_buckets: list[tuple[int, int]] = [(1, 15), (16, 60), (60, 240)]
+
+
 # -----------------------------------------------------------------------------
 # load_params_yaml tests
 # -----------------------------------------------------------------------------
@@ -168,6 +173,21 @@ def test_get_effective_params_with_instance() -> None:
     instance = TrainParams(learning_rate=0.05, epochs=50)
     params_dict = parameters.get_effective_params(instance, "train", None)
     assert params_dict == {"learning_rate": 0.05, "epochs": 50, "batch_size": 32}
+
+
+def test_get_effective_params_normalizes_tuples_to_lists() -> None:
+    """get_effective_params converts tuples to lists via model_dump(mode='json')."""
+    instance = TupleParams()
+    result = parameters.get_effective_params(instance, "plot", None)
+
+    # Top-level tuple should be converted to list
+    assert isinstance(result["token_range"], list), "token_range should be a list"
+    assert result["token_range"] == [5000.0, 100000000.0]
+
+    # Nested tuples in list should be converted to lists
+    assert isinstance(result["time_buckets"], list), "time_buckets should be a list"
+    assert isinstance(result["time_buckets"][0], list), "time_buckets[0] should be a list"
+    assert result["time_buckets"] == [[1, 15], [16, 60], [60, 240]]
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
After a full `pivot repro`, 3 stages show as "stale" with "Params changed" because Pydantic `model_dump()` preserves tuples but YAML lockfile round-tripping converts tuples to lists.

## Fix
Changed `model_dump()` to `model_dump(mode="json")` in `get_effective_params()` which normalizes tuples→lists during Pydantic's serialization walk (zero overhead).

## Testing
Added regression test with `TupleParams` model verifying tuple→list conversion.