### PR TITLE
fix(remote): detect URL changes and clear stale push index

### DIFF
--- a/packages/pivot/src/pivot/remote/storage.py
+++ b/packages/pivot/src/pivot/remote/storage.py
@@ -301,6 +301,13 @@ class S3Remote:
     def prefix(self) -> str:
         return self._prefix
 
+    @property
+    def url(self) -> str:
+        """Normalized S3 URL for identity comparison."""
+        if self._prefix:
+            return f"s3://{self._bucket}/{self._prefix.rstrip('/')}"
+        return f"s3://{self._bucket}"
+
     async def exists(self, cache_hash: str) -> bool:
         """Check if hash exists on remote via HEAD request."""
         from botocore import exceptions as botocore_exc

--- a/packages/pivot/src/pivot/remote/sync.py
+++ b/packages/pivot/src/pivot/remote/sync.py
@@ -228,6 +228,30 @@ def get_target_hashes(
     return hashes
 
 
+def _check_remote_url(
+    state_db: state_mod.StateDB,
+    remote_name: str,
+    remote: remote_mod.S3Remote,
+) -> None:
+    """Detect remote URL change and clear stale index."""
+    current_url = remote.url
+    stored_url = state_db.remote_get_url(remote_name)
+    if stored_url is None:
+        # First use — record URL, don't clear (fail-open)
+        state_db.remote_set_url(remote_name, current_url)
+    elif stored_url != current_url:
+        logger.warning(
+            "Remote '%s' URL changed (%s → %s), clearing cached index",
+            remote_name,
+            stored_url,
+            current_url,
+        )
+        state_db.remote_index_clear(remote_name)
+        state_db.remote_set_url(remote_name, current_url)
+    else:
+        logger.debug("Remote '%s' URL unchanged: %s", remote_name, current_url)
+
+
 async def compare_status(
     local_hashes: set[str],
     remote: remote_mod.S3Remote,
@@ -272,6 +296,8 @@ async def _push_async(
     """Push cache files to remote (async implementation)."""
     _t = metrics.start()
     jobs = jobs if jobs is not None else config.get_remote_jobs()
+
+    _check_remote_url(state_db, remote_name, remote)
 
     if targets:
         local_hashes = get_target_hashes(
@@ -360,6 +386,8 @@ async def _pull_async(
     """Pull cache files from remote (async implementation)."""
     _t = metrics.start()
     jobs = jobs if jobs is not None else config.get_remote_jobs()
+
+    _check_remote_url(state_db, remote_name, remote)
 
     if targets:
         needed_hashes = get_target_hashes(

--- a/packages/pivot/src/pivot/storage/AGENTS.md
+++ b/packages/pivot/src/pivot/storage/AGENTS.md
@@ -31,6 +31,7 @@ StateDB uses key prefixes for namespacing. Current prefixes in `pivot/storage/st
 | `sm:` | Fingerprint manifest cache (stage manifests + source maps) |
 | `run:` | Run history entries |
 | `remote:` | Remote index entries |
+| `remote_url:` | Remote URL tracking for change detection |
 | `fp:` | AST fingerprint/hash cache entries |
 
 **When adding new state types**, define a new prefix constant and document it here.

--- a/packages/pivot/src/pivot/storage/state.py
+++ b/packages/pivot/src/pivot/storage/state.py
@@ -24,6 +24,7 @@ _HASH_PREFIX = b"hash:"  # File hash entries
 _GEN_PREFIX = b"gen:"  # Output generation counters
 _DEP_PREFIX = b"dep:"  # Stage dependency generations
 _REMOTE_PREFIX = b"remote:"  # Remote index entries
+_REMOTE_URL_PREFIX = b"remote_url:"  # Remote URL tracking
 _RUN_PREFIX = b"run:"  # Run history entries
 _RUNCACHE_PREFIX = b"runcache:"  # Run cache entries for skip detection
 _FP_PREFIX = b"fp:"  # AST fingerprint/hash cache entries
@@ -527,8 +528,30 @@ class StateDB:
                 key = prefix + hash_.encode()
                 txn.delete(key)
 
+    def remote_get_url(self, remote_name: str) -> str | None:
+        """Get stored URL for a remote. Returns None if not tracked."""
+        self._check_closed()
+        key = _REMOTE_URL_PREFIX + remote_name.encode()
+        with self._env.begin() as txn:
+            value = txn.get(key)
+        if value is None:
+            return None
+        return value.decode("utf-8")
+
+    def remote_set_url(self, remote_name: str, url: str) -> None:
+        """Store URL for a remote."""
+        self._check_closed()
+        self._check_write_allowed()
+        key = _REMOTE_URL_PREFIX + remote_name.encode()
+        value = url.encode("utf-8")
+        try:
+            with self._env.begin(write=True) as txn:
+                txn.put(key, value)
+        except lmdb.MapFullError as e:
+            raise DatabaseFullError(_DB_FULL_MSG) from e
+
     def remote_index_clear(self, remote_name: str) -> None:
-        """Clear all index entries for a remote (force re-indexing)."""
+        """Clear all index entries and stored URL for a remote (force re-indexing)."""
         self._check_closed()
         self._check_write_allowed()
         prefix = _REMOTE_PREFIX + remote_name.encode() + b":"
@@ -542,6 +565,9 @@ class StateDB:
                     keys_to_delete.append(key)
             for key in keys_to_delete:
                 txn.delete(key)
+            # Also delete the remote URL entry
+            url_key = _REMOTE_URL_PREFIX + remote_name.encode()
+            txn.delete(url_key)
 
     # -------------------------------------------------------------------------
     # Run history for tracking pipeline executions

--- a/packages/pivot/tests/remote/test_s3_remote.py
+++ b/packages/pivot/tests/remote/test_s3_remote.py
@@ -120,6 +120,21 @@ def test_s3_remote_init_invalid_url() -> None:
         remote_mod.S3Remote("not-an-s3-url")
 
 
+@pytest.mark.parametrize(
+    "input_url,expected_url",
+    [
+        pytest.param("s3://bucket/prefix", "s3://bucket/prefix", id="basic_prefix"),
+        pytest.param("s3://bucket", "s3://bucket", id="no_prefix"),
+        pytest.param("s3://bucket/path/to/cache", "s3://bucket/path/to/cache", id="nested_prefix"),
+        pytest.param("s3://bucket/prefix/", "s3://bucket/prefix", id="trailing_slash_stripped"),
+    ],
+)
+def test_s3_remote_url_normalization(input_url: str, expected_url: str) -> None:
+    """S3Remote.url property normalizes URLs consistently."""
+    r = remote_mod.S3Remote(input_url)
+    assert r.url == expected_url, f"URL normalization failed for {input_url}"
+
+
 # -----------------------------------------------------------------------------
 # Hash to Key Conversion Tests
 # -----------------------------------------------------------------------------

--- a/packages/pivot/tests/remote/test_transfer.py
+++ b/packages/pivot/tests/remote/test_transfer.py
@@ -887,3 +887,150 @@ async def test_pull_async_with_deps_integration(
     assert out_path.read_bytes() == b"main_file"
     assert dep_path.read_bytes() == b"dependency_file"
     state_db.close()
+
+
+# -----------------------------------------------------------------------------
+# URL Change Detection Tests
+# -----------------------------------------------------------------------------
+
+
+async def test_push_url_change_clears_index(lock_project: Path, mocker: MockerFixture) -> None:
+    """Push detects URL change and clears index."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    files_dir = cache_dir / "files"
+
+    hash1 = "ab" + "c" * 14
+    (files_dir / "ab").mkdir(parents=True)
+    (files_dir / "ab" / ("c" * 14)).write_text("content1")
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/new-prefix"
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = "s3://bucket/old-prefix"
+    mock_state.remote_hashes_intersection.return_value = set()
+    mock_remote.bulk_exists = mocker.AsyncMock(return_value={hash1: False})
+    mock_remote.upload_batch = mocker.AsyncMock(
+        return_value=[TransferResult(hash=hash1, success=True)]
+    )
+
+    await transfer._push_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_index_clear.assert_called_once_with("origin")
+    mock_state.remote_set_url.assert_called_once_with("origin", "s3://bucket/new-prefix")
+
+
+async def test_push_first_use_sets_url_without_clear(
+    lock_project: Path, mocker: MockerFixture
+) -> None:
+    """Push on first use sets URL without clearing."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    files_dir = cache_dir / "files"
+
+    hash1 = "ab" + "c" * 14
+    (files_dir / "ab").mkdir(parents=True)
+    (files_dir / "ab" / ("c" * 14)).write_text("content1")
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/prefix"
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = None
+    mock_state.remote_hashes_intersection.return_value = set()
+    mock_remote.bulk_exists = mocker.AsyncMock(return_value={hash1: False})
+    mock_remote.upload_batch = mocker.AsyncMock(
+        return_value=[TransferResult(hash=hash1, success=True)]
+    )
+
+    await transfer._push_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_set_url.assert_called_once_with("origin", "s3://bucket/prefix")
+    mock_state.remote_index_clear.assert_not_called()
+
+
+async def test_push_same_url_no_clear(lock_project: Path, mocker: MockerFixture) -> None:
+    """Push with same URL does not clear index."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    files_dir = cache_dir / "files"
+
+    hash1 = "ab" + "c" * 14
+    (files_dir / "ab").mkdir(parents=True)
+    (files_dir / "ab" / ("c" * 14)).write_text("content1")
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/prefix"
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = "s3://bucket/prefix"
+    mock_state.remote_hashes_intersection.return_value = set()
+    mock_remote.bulk_exists = mocker.AsyncMock(return_value={hash1: False})
+    mock_remote.upload_batch = mocker.AsyncMock(
+        return_value=[TransferResult(hash=hash1, success=True)]
+    )
+
+    await transfer._push_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_index_clear.assert_not_called()
+    mock_state.remote_set_url.assert_not_called()
+
+
+async def test_pull_url_change_clears_index(lock_project: Path, mocker: MockerFixture) -> None:
+    """Pull detects URL change and clears index."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    (cache_dir / "files").mkdir(parents=True)
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/new-prefix"
+    mock_remote.list_hashes = mocker.AsyncMock(return_value=set())
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = "s3://bucket/old-prefix"
+
+    await transfer._pull_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_index_clear.assert_called_once_with("origin")
+    mock_state.remote_set_url.assert_called_once_with("origin", "s3://bucket/new-prefix")
+
+
+async def test_pull_first_use_sets_url_without_clear(
+    lock_project: Path, mocker: MockerFixture
+) -> None:
+    """Pull on first use sets URL without clearing."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    (cache_dir / "files").mkdir(parents=True)
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/prefix"
+    mock_remote.list_hashes = mocker.AsyncMock(return_value=set())
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = None
+
+    await transfer._pull_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_set_url.assert_called_once_with("origin", "s3://bucket/prefix")
+    mock_state.remote_index_clear.assert_not_called()
+
+
+async def test_pull_same_url_no_clear(lock_project: Path, mocker: MockerFixture) -> None:
+    """Pull with same URL does not clear index."""
+
+    cache_dir = lock_project / ".pivot" / "cache"
+    state_dir = lock_project / ".pivot"
+    (cache_dir / "files").mkdir(parents=True)
+
+    mock_remote = mocker.Mock(spec=remote_mod.S3Remote)
+    mock_remote.url = "s3://bucket/prefix"
+    mock_remote.list_hashes = mocker.AsyncMock(return_value=set())
+    mock_state = mocker.Mock(spec=state_mod.StateDB)
+    mock_state.remote_get_url.return_value = "s3://bucket/prefix"
+
+    await transfer._pull_async(cache_dir, state_dir, mock_remote, mock_state, "origin")
+
+    mock_state.remote_index_clear.assert_not_called()
+    mock_state.remote_set_url.assert_not_called()

--- a/packages/pivot/tests/storage/test_state.py
+++ b/packages/pivot/tests/storage/test_state.py
@@ -639,6 +639,77 @@ def test_remote_hashes_persistence(tmp_path: pathlib.Path) -> None:
         assert db.remote_hash_exists("origin", "persistent_hash")
 
 
+def test_remote_get_url_returns_none_for_unknown(tmp_path: pathlib.Path) -> None:
+    """remote_get_url returns None for untracked remote."""
+    db_path = tmp_path / "state.db"
+
+    with state.StateDB(db_path) as db:
+        result = db.remote_get_url("unknown")
+
+    assert result is None
+
+
+def test_remote_set_url_and_get_url_roundtrip(tmp_path: pathlib.Path) -> None:
+    """remote_set_url stores URL and remote_get_url retrieves it."""
+    db_path = tmp_path / "state.db"
+    test_url = "s3://my-bucket/prefix"
+
+    with state.StateDB(db_path) as db:
+        db.remote_set_url("origin", test_url)
+        result = db.remote_get_url("origin")
+
+    assert result == test_url
+
+
+def test_remote_set_url_overwrites_existing(tmp_path: pathlib.Path) -> None:
+    """remote_set_url overwrites previously stored URL."""
+    db_path = tmp_path / "state.db"
+
+    with state.StateDB(db_path) as db:
+        db.remote_set_url("origin", "s3://old-bucket")
+        db.remote_set_url("origin", "s3://new-bucket")
+        result = db.remote_get_url("origin")
+
+    assert result == "s3://new-bucket"
+
+
+def test_remote_url_persistence(tmp_path: pathlib.Path) -> None:
+    """Remote URLs persist across DB instances."""
+    db_path = tmp_path / "state.db"
+    test_url = "s3://persistent-bucket/path"
+
+    with state.StateDB(db_path) as db:
+        db.remote_set_url("origin", test_url)
+
+    with state.StateDB(db_path) as db:
+        assert db.remote_get_url("origin") == test_url
+
+
+def test_remote_index_clear_also_deletes_url(tmp_path: pathlib.Path) -> None:
+    """remote_index_clear also deletes the remote URL entry."""
+    db_path = tmp_path / "state.db"
+
+    with state.StateDB(db_path) as db:
+        db.remote_set_url("origin", "s3://bucket")
+        db.remote_hashes_add("origin", ["hash1"])
+        db.remote_index_clear("origin")
+
+        assert db.remote_get_url("origin") is None
+        assert not db.remote_hash_exists("origin", "hash1")
+
+
+def test_remote_urls_different_remotes_independent(tmp_path: pathlib.Path) -> None:
+    """Different remotes have independent URL storage."""
+    db_path = tmp_path / "state.db"
+
+    with state.StateDB(db_path) as db:
+        db.remote_set_url("origin", "s3://origin-bucket")
+        db.remote_set_url("backup", "s3://backup-bucket")
+
+        assert db.remote_get_url("origin") == "s3://origin-bucket"
+        assert db.remote_get_url("backup") == "s3://backup-bucket"
+
+
 # -----------------------------------------------------------------------------
 # Readonly mode tests
 # -----------------------------------------------------------------------------
@@ -769,6 +840,20 @@ def test_readonly_blocks_remote_index_clear(tmp_path: pathlib.Path) -> None:
         pytest.raises(RuntimeError, match="readonly StateDB"),
     ):
         db.remote_index_clear("origin")
+
+
+def test_readonly_blocks_remote_set_url(tmp_path: pathlib.Path) -> None:
+    """Readonly mode blocks remote_set_url operation."""
+    db_path = tmp_path / "state.db"
+
+    with state.StateDB(db_path) as db:
+        pass  # Just create
+
+    with (
+        state.StateDB(db_path, readonly=True) as db,
+        pytest.raises(RuntimeError, match="readonly StateDB"),
+    ):
+        db.remote_set_url("origin", "s3://bucket")
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #421 — `pivot push --all` reports "0 transferred, 872 skipped" after changing a remote's S3 bucket URL while keeping the same remote name.

**Root cause**: The StateDB remote index is keyed by remote name (`remote:{name}:{hash}`). When the URL changes but the name stays the same, the stale index makes push think everything is already uploaded to the new (empty) bucket.

**Fix**: Track the remote URL in StateDB and clear the index when a mismatch is detected at push/pull time.

## Changes

- **StateDB** (`state.py`): Add `remote_get_url()` / `remote_set_url()` methods with `remote_url:` prefix. Update `remote_index_clear()` to also delete the URL entry.
- **S3Remote** (`storage.py`): Add `url` property for normalized URL comparison (`s3://bucket/prefix`).
- **sync.py**: Add `_check_remote_url()` helper called from both `_push_async()` and `_pull_async()`:
  - First use (no stored URL) → set URL, don't clear (fail-open)
  - URL changed → log warning, clear index, set new URL
  - Same URL → no-op
- **AGENTS.md**: Document `remote_url:` prefix

## Tests

- 7 new StateDB unit tests (get/set roundtrip, persistence, readonly, clear cleanup, multi-remote isolation)
- 6 new sync integration tests (push/pull × URL change, first use, same URL)
- 4 new S3Remote.url normalization tests (parametrized)
- All 138+ existing tests pass with zero regressions

## Design Decisions

- **Option B** (name-keyed index + URL mismatch detection) chosen over Option A (re-key by URL) — ~30 lines vs ~150+
- Detection at push/pull time, not at config time — keeps config layer clean
- Fail-open on missing URL state — handles both new remotes and upgrades gracefully