### PR TITLE
fix(pipeline): resolve IncrementalOut paths relative to pipeline root

### DIFF
--- a/packages/pivot/src/pivot/pipeline/pipeline.py
+++ b/packages/pivot/src/pivot/pipeline/pipeline.py
@@ -336,12 +336,22 @@ class Pipeline:
                     + "requires override in dep_path_overrides"
                 )
 
+        # 2b. Reject user overrides for IncrementalOut input deps
+        if dep_path_overrides:
+            incremental_dep_names = {
+                name for name, spec in definition.dep_specs.items() if not spec.creates_dep_edge
+            }
+            user_incremental = set(dep_path_overrides.keys()) & incremental_dep_names
+            if user_incremental:
+                raise ValueError(
+                    f"Cannot override IncrementalOut input paths: {sorted(user_incremental)}. "
+                    + "IncrementalOut paths must match between input and output annotations."
+                )
+
         # 3. Resolve annotation paths relative to pipeline root
-        # Skip IncrementalOut - registry disallows path overrides for them
         resolved_deps: dict[str, outputs.PathType] = {
             dep_name: self._resolve_path_type(spec.path)
             for dep_name, spec in definition.dep_specs.items()
-            if spec.creates_dep_edge  # IncrementalOut has creates_dep_edge=False
         }
 
         out_specs = definition.out_specs
@@ -351,12 +361,30 @@ class Pipeline:
         resolved_outs: dict[str, registry.OutOverride] = {
             out_name: registry.OutOverride(path=self._resolve_path_type(spec.path))
             for out_name, spec in out_specs.items()
-            if not isinstance(spec, outputs.IncrementalOut)
         }
 
         # 4. Apply explicit output overrides (also pipeline-relative)
         # (dep overrides are already applied via extract_stage_definition above)
         if out_path_overrides:
+            # Single-output IncrementalOut: reject ALL overrides regardless of key
+            # (registry accepts any single key for single-output stages)
+            if definition.single_out_spec is not None and isinstance(
+                definition.single_out_spec, outputs.IncrementalOut
+            ):
+                raise ValueError(
+                    "Cannot override IncrementalOut output path. "
+                    + "IncrementalOut paths must match between input and output annotations."
+                )
+            # TypedDict-return: reject overrides targeting specific IncrementalOut fields
+            incremental_out_names = {
+                name for name, spec in out_specs.items() if isinstance(spec, outputs.IncrementalOut)
+            }
+            user_incremental = set(out_path_overrides.keys()) & incremental_out_names
+            if user_incremental:
+                raise ValueError(
+                    f"Cannot override IncrementalOut output paths: {sorted(user_incremental)}. "
+                    + "IncrementalOut paths must match between input and output annotations."
+                )
             for out_name, override in out_path_overrides.items():
                 resolved_outs[out_name] = self._resolve_out_override(override)
 

--- a/packages/pivot/src/pivot/registry.py
+++ b/packages/pivot/src/pivot/registry.py
@@ -150,7 +150,7 @@ def _apply_out_overrides(
             return dataclasses.replace(dir_out, path=path, cache=cache)
         return dir_out
 
-    # IncrementalOut - can update cache but not path (handled by _resolve_out_spec)
+    # IncrementalOut - can update path and/or cache
     if isinstance(out_spec, outputs.IncrementalOut):
         # Cast to IncrementalOut[Any, Any] - isinstance narrows but basedpyright keeps Unknown params
         inc_out = cast("outputs.IncrementalOut[Any, Any]", out_spec)
@@ -198,37 +198,23 @@ def _expand_out_spec(out_spec: outputs.BaseOut) -> list[outputs.BaseOut]:
 
 
 def _resolve_out_spec(
-    out_name: str,
     out_spec: outputs.BaseOut,
     override: OutOverride | None,
-    stage_name: str,
 ) -> tuple[outputs.BaseOut, list[outputs.BaseOut]]:
     """Apply overrides to an output spec and expand for DAG/caching.
 
-    Validates that IncrementalOut outputs aren't overridden, applies path/cache overrides,
-    and expands multi-file specs into individual output objects.
+    Applies path/cache overrides and expands multi-file specs into individual
+    output objects.
 
     Args:
-        out_name: Output key name (for error messages).
         out_spec: Original output spec from function annotations.
-        override: Path/cache override from YAML (or None).
-        stage_name: Stage name (for error messages).
+        override: Path/cache override (or None).
 
     Returns:
         Tuple of (resolved_spec, expanded_specs) where:
         - resolved_spec: Single output with overrides applied (may have list/tuple path)
         - expanded_specs: List of outputs with single-string paths for DAG/caching
-
-    Raises:
-        ValidationError: If trying to override an IncrementalOut path.
     """
-    # IncrementalOut paths must match between input and output - disallow overrides
-    if override is not None and isinstance(out_spec, outputs.IncrementalOut):
-        raise exceptions.ValidationError(
-            f"Stage '{stage_name}': cannot override IncrementalOut output path for '{out_name}'. "
-            + "IncrementalOut paths must match between input and output annotations."
-        )
-
     resolved = _apply_out_overrides(out_spec, override)
     expanded = _expand_out_spec(resolved)
     return resolved, expanded
@@ -358,16 +344,6 @@ class StageRegistry:
                         f"Stage '{stage_name}': dep_path_overrides contains unknown deps: {unknown}. "
                         + f"Available: {list(dep_specs.keys())}"
                     )
-                # Disallow overrides for IncrementalOut inputs - path must match output annotation
-                incremental_overrides = [
-                    name for name in dep_path_overrides if not dep_specs[name].creates_dep_edge
-                ]
-                if incremental_overrides:
-                    raise exceptions.ValidationError(
-                        f"Stage '{stage_name}': cannot override IncrementalOut input paths: "
-                        + f"{incremental_overrides}. IncrementalOut paths must match between "
-                        + "input and output annotations."
-                    )
 
             # Build deps dict from specs, applying path overrides where provided
             # (Pipeline resolves annotation paths to pipeline-relative before passing as overrides)
@@ -417,7 +393,7 @@ class StageRegistry:
                 for out_name, out_spec in return_out_specs.items():
                     raw_override = out_path_overrides.get(out_name) if out_path_overrides else None
                     override = _normalize_out_override(raw_override) if raw_override else None
-                    resolved, expanded = _resolve_out_spec(out_name, out_spec, override, stage_name)
+                    resolved, expanded = _resolve_out_spec(out_spec, override)
                     out_specs[out_name] = resolved
                     outs_from_annotations.extend(expanded)
 
@@ -435,9 +411,7 @@ class StageRegistry:
                     # Get the single override (whatever key the user used)
                     override = _normalize_out_override(next(iter(out_path_overrides.values())))
 
-                resolved, expanded = _resolve_out_spec(
-                    stage_def.SINGLE_OUTPUT_KEY, single_out_spec, override, stage_name
-                )
+                resolved, expanded = _resolve_out_spec(single_out_spec, override)
                 out_specs[stage_def.SINGLE_OUTPUT_KEY] = resolved
                 outs_from_annotations.extend(expanded)
 
@@ -449,6 +423,11 @@ class StageRegistry:
             _validate_stage_registration(
                 self._stages, stage_name, all_deps_flat, outs_paths, self.validation_mode
             )
+
+            # Defense-in-depth: verify IncrementalOut dep/output paths still match
+            # after overrides are applied (pre-override validation checks annotation
+            # specs; this catches mismatched overrides from direct registry callers)
+            _validate_incremental_paths_post_overrides(stage_name, deps_dict, out_specs, dep_specs)
 
             # Normalize dep paths - flatten, normalize, then rebuild dict
             deps_flat_normalized = _normalize_paths(
@@ -776,6 +755,56 @@ def _validate_incremental_spec_match(
             f"Stage '{stage_name}': IncrementalOut input {name_part}loader "
             + f"{input_spec.loader!r} doesn't match output loader {output_spec.loader!r}"
         )
+
+
+def _validate_incremental_paths_post_overrides(
+    stage_name: str,
+    deps_dict: dict[str, outputs.PathType],
+    out_specs: dict[str, outputs.BaseOut],
+    dep_specs: dict[str, stage_def.FuncDepSpec],
+) -> None:
+    """Defense-in-depth: verify IncrementalOut dep/output paths match after overrides.
+
+    The pre-override validation (_validate_incremental_out_matching) checks raw
+    annotation specs. This function checks the effective paths after dep/out overrides
+    are applied, catching mismatched overrides from direct StageRegistry callers.
+    """
+    # Find IncrementalOut outputs
+    incremental_outs: dict[str, outputs.BaseOut] = {
+        name: spec for name, spec in out_specs.items() if isinstance(spec, outputs.IncrementalOut)
+    }
+    if not incremental_outs:
+        return
+
+    # Find IncrementalOut inputs
+    incremental_deps = {
+        name: dep_specs[name] for name in dep_specs if not dep_specs[name].creates_dep_edge
+    }
+    if not incremental_deps:
+        return
+
+    # For TypedDict returns: output field name matches input param name
+    for out_name, out_spec in incremental_outs.items():
+        if out_name in incremental_deps:
+            dep_path = str(deps_dict[out_name])
+            out_path = str(out_spec.path)
+            if dep_path != out_path:
+                raise exceptions.ValidationError(
+                    f"Stage '{stage_name}': IncrementalOut input '{out_name}' path "
+                    + f"'{dep_path}' doesn't match output path '{out_path}' after "
+                    + "applying overrides."
+                )
+        elif out_name == stage_def.SINGLE_OUTPUT_KEY and len(incremental_deps) == 1:
+            # Single-output stage: one IncrementalOut dep maps to _single output
+            dep_name = next(iter(incremental_deps))
+            dep_path = str(deps_dict[dep_name])
+            out_path = str(out_spec.path)
+            if dep_path != out_path:
+                raise exceptions.ValidationError(
+                    f"Stage '{stage_name}': IncrementalOut input '{dep_name}' path "
+                    + f"'{dep_path}' doesn't match output path '{out_path}' after "
+                    + "applying overrides."
+                )
 
 
 def _validate_incremental_out_matching(

--- a/packages/pivot/tests/pipeline/test_pipeline.py
+++ b/packages/pivot/tests/pipeline/test_pipeline.py
@@ -1252,25 +1252,188 @@ def incremental_cache_stage(
     return existing
 
 
+# Module-level helper for mixed Out and IncrementalOut test
+class _MixedOutputs(TypedDict):
+    result: Annotated[dict[str, str], outputs.Out("result.json", loaders.JSON[dict[str, str]]())]
+    cache: Annotated[
+        dict[str, str], outputs.IncrementalOut("data/cache.json", loaders.JSON[dict[str, str]]())
+    ]
+
+
+def mixed_out_and_incremental_stage(
+    input_data: Annotated[
+        dict[str, str], outputs.Dep("input.json", loaders.JSON[dict[str, str]]())
+    ],
+    cache: Annotated[
+        dict[str, str], outputs.IncrementalOut("data/cache.json", loaders.JSON[dict[str, str]]())
+    ],
+) -> _MixedOutputs:
+    """Stage with both Out and IncrementalOut outputs."""
+    result = {**input_data, **cache}
+    return _MixedOutputs(result=result, cache=cache)
+
+
 def test_pipeline_register_incremental_out_stage(set_project_root: pathlib.Path) -> None:
     """Pipeline.register() should succeed for stages using IncrementalOut.
 
-    IncrementalOut paths cannot be overridden (registry rejects path overrides
-    for them), so Pipeline must NOT pass IncrementalOut paths as overrides.
-    The paths remain as specified in the annotations (normalized by registry).
+    IncrementalOut paths are resolved relative to pipeline root (like all other
+    output types) and then normalized to absolute by the registry.
     """
     p = Pipeline("test", root=set_project_root / "subdir")
 
-    # This should NOT raise - IncrementalOut paths are not overridden
+    # This should NOT raise
     p.register(incremental_cache_stage)
 
     # Verify the stage was registered
     assert "incremental_cache_stage" in p.list_stages()
     info = p.get("incremental_cache_stage")
 
-    # IncrementalOut path is preserved (not resolved relative to pipeline root)
-    # Registry normalizes it to absolute based on project root
+    # IncrementalOut path is resolved relative to pipeline root, then normalized
     assert info["outs_paths"][0].endswith("data/cache.yaml")
+
+
+def test_pipeline_incremental_out_path_resolved_relative_to_pipeline_root(
+    set_project_root: pathlib.Path,
+) -> None:
+    """IncrementalOut paths should be resolved relative to pipeline root.
+
+    When a pipeline lives in a subdirectory, IncrementalOut paths should be
+    resolved relative to that subdirectory, not the project root.
+    """
+    subdir = set_project_root / "subdir"
+    subdir.mkdir(exist_ok=True)
+
+    p = Pipeline("test", root=subdir)
+    p.register(incremental_cache_stage)
+
+    info = p.get("incremental_cache_stage")
+    out_path = pathlib.Path(info["outs_paths"][0])
+
+    # The resolved path should be relative to the pipeline root (subdir)
+    # not the project root
+    expected_path = subdir / "data" / "cache.yaml"
+    assert out_path == expected_path, (
+        f"IncrementalOut path should be resolved relative to pipeline root. "
+        f"Expected {expected_path}, got {out_path}"
+    )
+
+
+def test_pipeline_incremental_out_user_override_rejected(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Pipeline.register() should reject user-provided overrides for IncrementalOut.
+
+    User-provided out_path_overrides targeting IncrementalOut outputs should
+    raise ValueError at the Pipeline level.
+    """
+    p = Pipeline("test", root=set_project_root)
+
+    # incremental_cache_stage is a single-output stage — any key is rejected
+    with pytest.raises(ValueError, match="Cannot override IncrementalOut output path"):
+        p.register(
+            incremental_cache_stage,
+            out_path_overrides={"_single": "data/new_cache.yaml"},
+        )
+
+
+def test_pipeline_incremental_out_user_override_rejected_any_key(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Pipeline rejects IncrementalOut overrides regardless of the key used.
+
+    Single-output stages in the registry accept any single override key, so
+    Pipeline must reject based on the output type, not just key matching.
+    """
+    p = Pipeline("test", root=set_project_root)
+
+    # Even with a non-_single key, the override should be rejected
+    with pytest.raises(ValueError, match="Cannot override IncrementalOut output path"):
+        p.register(
+            incremental_cache_stage,
+            out_path_overrides={"output": "data/new_cache.yaml"},
+        )
+
+
+def test_pipeline_mixed_out_and_incremental_out_paths_resolved_relative_to_pipeline_root(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Both Out and IncrementalOut paths should be resolved relative to pipeline root.
+
+    When a stage has both regular Out and IncrementalOut outputs, both should be
+    resolved relative to the pipeline root (not project root) when the pipeline
+    lives in a subdirectory.
+    """
+    subdir = set_project_root / "subdir"
+    subdir.mkdir(exist_ok=True)
+
+    p = Pipeline("test", root=subdir)
+    p.register(mixed_out_and_incremental_stage)
+
+    info = p.get("mixed_out_and_incremental_stage")
+    outs_paths = [pathlib.Path(path) for path in info["outs_paths"]]
+
+    # Should have 2 outputs: result (Out) and cache (IncrementalOut)
+    assert len(outs_paths) == 2, f"Expected 2 outputs (Out + IncrementalOut), got {len(outs_paths)}"
+
+    # Both paths should be resolved relative to pipeline root (subdir)
+    expected_result_path = subdir / "result.json"
+    expected_cache_path = subdir / "data" / "cache.json"
+
+    assert expected_result_path in outs_paths, (
+        f"Out path should be resolved relative to pipeline root. "
+        f"Expected {expected_result_path} in {outs_paths}"
+    )
+    assert expected_cache_path in outs_paths, (
+        f"IncrementalOut path should be resolved relative to pipeline root. "
+        f"Expected {expected_cache_path} in {outs_paths}"
+    )
+
+
+def test_pipeline_incremental_out_dep_path_resolved_relative_to_pipeline_root(
+    set_project_root: pathlib.Path,
+) -> None:
+    """IncrementalOut input dep paths should be resolved relative to pipeline root.
+
+    When a pipeline lives in a subdirectory, IncrementalOut input paths should
+    resolve to the same location as IncrementalOut output paths.
+    """
+    subdir = set_project_root / "subdir"
+    subdir.mkdir(exist_ok=True)
+
+    p = Pipeline("test", root=subdir)
+    p.register(incremental_cache_stage)
+
+    info = p.get("incremental_cache_stage")
+
+    # Output path should be resolved relative to pipeline root
+    out_path = pathlib.Path(info["outs_paths"][0])
+    expected_path = subdir / "data" / "cache.yaml"
+    assert out_path == expected_path, (
+        f"IncrementalOut output path should be {expected_path}, got {out_path}"
+    )
+
+    # Input dep path should match the output path (same file!)
+    # IncrementalOut deps use the param name as key in info["deps"]
+    dep_path_raw = info["deps"]["existing"]
+    assert isinstance(dep_path_raw, str), "IncrementalOut dep should be a single path"
+    dep_path = pathlib.Path(dep_path_raw)
+    assert dep_path == expected_path, (
+        f"IncrementalOut input dep path should match output path. "
+        f"Expected {expected_path}, got {dep_path}"
+    )
+
+
+def test_pipeline_incremental_out_dep_user_override_rejected(
+    set_project_root: pathlib.Path,
+) -> None:
+    """Pipeline.register() should reject user-provided dep_path_overrides for IncrementalOut."""
+    p = Pipeline("test", root=set_project_root)
+
+    with pytest.raises(ValueError, match="Cannot override IncrementalOut input paths"):
+        p.register(
+            incremental_cache_stage,
+            dep_path_overrides={"existing": "data/other.yaml"},
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

`Pipeline.register()` silently filtered IncrementalOut specs from `resolved_deps` and `resolved_outs`, causing IncrementalOut paths to skip pipeline-root resolution. In subdirectory pipelines, this meant IncrementalOut input and output paths resolved relative to the project root instead of the pipeline root — breaking the core invariant that they must reference the same file.

## Changes

**`pipeline.py` — Pipeline.register():**
- Remove `if not isinstance(spec, outputs.IncrementalOut)` filter from `resolved_outs`
- Remove `if spec.creates_dep_edge` filter from `resolved_deps`
- Add Pipeline-level validation rejecting user-provided `dep_path_overrides` and `out_path_overrides` targeting IncrementalOut specs

**`registry.py` — StageRegistry:**
- Remove blanket IncrementalOut guard from `_resolve_out_spec()` (was blocking Pipeline's internal path resolution alongside user overrides)
- Remove blanket IncrementalOut dep override guard from `register()`
- Clean up now-unused `out_name`/`stage_name` params from `_resolve_out_spec()`

**`test_pipeline.py`:**
- Add test for IncrementalOut output path resolution in subdirectory pipelines
- Add test for IncrementalOut dep path resolution (input/output symmetry)
- Add test for user dep override rejection
- Add test for user output override rejection
- Add test for mixed Out + IncrementalOut path resolution
- Update stale docstring on existing test