### PR TITLE
feat(import): add cross-repo artifact import system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ def train(
 - Check `typings/` first for untyped packages; use `scripts/generate_stubs.py` if needed
 - **aioboto3/S3 types:** Use `types_aiobotocore_s3.S3Client` (not `Any`) for S3 client parameters. Import under `TYPE_CHECKING`. The `types-aioboto3[all]` stubs are in dev deps.
 - **aioboto3 sessions:** Create one `aioboto3.Session()` per `S3Remote` instance (in `__init__`), not per method call. Sessions are credential-management objects — recreating them re-reads credential chains and env vars. Each method creates its own client via `async with self._session.client("s3")`, which is lightweight but gets a fresh connection pool. Batch methods share one client across concurrent tasks via `asyncio.gather`.
+- **aiohttp for HTTP APIs:** Use `aiohttp` (direct dependency) for all non-S3 HTTP calls (GitHub API, git forge APIs). Follow the same async pattern as S3Remote: async internals with `asyncio.run()` sync wrappers at CLI boundaries. Do NOT use `httpx`, `urllib.request`, or `requests`.
 
 ## Python 3.13+ Types
 
@@ -166,6 +167,8 @@ def train(
 Import modules, not functions: `from pivot import fingerprint` then `fingerprint.func()`.
 
 **Exceptions:** `TYPE_CHECKING` blocks, `pivot.types`, `typing` module, CLI lazy imports.
+
+**No duplicate imports:** If a module is imported at runtime (`import pathlib`), do NOT also import from it under `TYPE_CHECKING` (`from pathlib import Path`). Use `pathlib.Path` in annotations instead. Each module should appear in exactly one place — either a runtime module import or a `TYPE_CHECKING` import, never both.
 
 ## Error Handling
 

--- a/packages/pivot/pyproject.toml
+++ b/packages/pivot/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13,<3.14"
 license = { text = "TBD" }
 authors = [{ name = "Internal Team" }]
 dependencies = [
+  "aiohttp>=3.9",
   "anyio>=4.0",
   "click>=8.0",
   "deepmerge>=2.0",

--- a/packages/pivot/src/pivot/cli/__init__.py
+++ b/packages/pivot/src/pivot/cli/__init__.py
@@ -9,7 +9,7 @@ import click
 # Command categories for organized help output
 COMMAND_CATEGORIES = {
     "Pipeline": ["run", "repro", "status", "verify", "commit"],
-    "Sync": ["checkout", "fetch", "get", "pull", "push", "remote", "track"],
+    "Sync": ["checkout", "fetch", "get", "import", "pull", "push", "remote", "track", "update"],
     "Inspection": ["dag", "diff", "history", "list", "metrics", "params", "plots", "show"],
     "Other": [
         "init",
@@ -32,6 +32,11 @@ _LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
     "dag": ("pivot.cli.dag", "dag_cmd", "Visualize pipeline DAG."),
     "list": ("pivot.cli.list", "list_cmd", "List registered stages."),
     "export": ("pivot.cli.export", "export", "Export pipeline to DVC YAML format."),
+    "import": (
+        "pivot.cli.import_cmd",
+        "import_cmd",
+        "Import artifact from a remote Pivot repo.",
+    ),
     "import-dvc": (
         "pivot.cli.import_dvc",
         "import_dvc",
@@ -74,6 +79,11 @@ _LAZY_COMMANDS: dict[str, tuple[str, str, str]] = {
         "pivot.cli.fingerprint",
         "fingerprint",
         "Manage function fingerprinting cache.",
+    ),
+    "update": (
+        "pivot.cli.update",
+        "update",
+        "Update imported artifacts from source repos.",
     ),
 }
 

--- a/packages/pivot/src/pivot/cli/import_cmd.py
+++ b/packages/pivot/src/pivot/cli/import_cmd.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from pivot.cli import decorators as cli_decorators
+
+
+@cli_decorators.pivot_command(auto_discover=False)
+@click.argument("repo_url")
+@click.argument("path")
+@click.option("--rev", default="main", help="Git ref to import from (branch, tag, commit)")
+@click.option("--out", default=None, help="Local output path (default: same as source path)")
+@click.option("--force", is_flag=True, help="Overwrite existing files")
+@click.option("--no-download", is_flag=True, help="Create .pvt metadata without downloading")
+def import_cmd(
+    repo_url: str, path: str, rev: str, out: str | None, force: bool, no_download: bool
+) -> None:
+    """Import an artifact from a remote Pivot repo."""
+    from pivot import import_artifact
+
+    result = asyncio.run(
+        import_artifact.import_artifact(
+            repo_url, path, rev=rev, out=out, force=force, no_download=no_download
+        )
+    )
+    if result["downloaded"]:
+        click.echo(f"Imported {result['data_path']}")
+    else:
+        click.echo(f"Created {result['pvt_path']} (metadata only)")

--- a/packages/pivot/src/pivot/cli/status.py
+++ b/packages/pivot/src/pivot/cli/status.py
@@ -36,6 +36,7 @@ from pivot.types import (
 @click.option("--tracked-only", is_flag=True, help="Show only tracked files")
 @click.option("--remote-only", is_flag=True, help="Show only remote status")
 @click.option("--remote", "-r", is_flag=True, help="Include remote sync status")
+@click.option("--check-imports", is_flag=True, help="Check for import updates (requires network)")
 @click.pass_context
 def status(
     ctx: click.Context,
@@ -47,6 +48,7 @@ def status(
     tracked_only: bool,
     remote_only: bool,
     remote: bool,
+    check_imports: bool,
 ) -> None:
     """Show pipeline, tracked files, and remote status."""
     cli_ctx = cli_helpers.get_cli_context(ctx)
@@ -130,6 +132,10 @@ def status(
         except exceptions.RemoteError as e:
             raise click.ClickException(f"Remote error: {e}") from e
 
+    import_statuses = list[status_mod.ImportStatusInfo]()
+    if check_imports:
+        import_statuses = status_mod.get_import_status(project_root)
+
     # Compute counts once for suggestions and output
     # When explain mode is used, compute from explanations; otherwise from status
     if explain and pipeline_explanations:
@@ -187,6 +193,9 @@ def status(
                 show_stages,
                 show_tracked,
             )
+
+    if import_statuses:
+        _print_import_section(import_statuses)
 
 
 def _output_json(
@@ -397,6 +406,22 @@ def _print_remote_section(remote_status: RemoteSyncInfo) -> None:
     click.echo(f"Remote Status ({remote_status['name']} \u2192 {remote_status['url']})")
     click.echo(f"  \u2191 {remote_status['push_count']} to push")
     click.echo(f"  \u2193 {remote_status['pull_count']} to pull")
+
+
+def _print_import_section(import_statuses: list[status_mod.ImportStatusInfo]) -> None:
+    """Print import status section."""
+    click.echo()
+    click.echo("Imports")
+
+    for info in import_statuses:
+        if info.status is status_mod.ImportCheckStatus.UPDATE_AVAILABLE:
+            click.echo(
+                f"  \u26a0 {info.path}: update available ({info.current_rev}.. \u2192 {info.latest_rev}..)"
+            )
+        elif info.status is status_mod.ImportCheckStatus.ERROR:
+            click.echo(f"  \u2717 {info.path}: check failed ({info.error})")
+        else:
+            click.echo(f"  \u2713 {info.path}: up to date")
 
 
 def _print_suggestions_section(suggestions: list[str]) -> None:

--- a/packages/pivot/src/pivot/cli/update.py
+++ b/packages/pivot/src/pivot/cli/update.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import traceback
+from typing import TYPE_CHECKING
+
+import click
+
+from pivot.cli import decorators as cli_decorators
+
+if TYPE_CHECKING:
+    from pivot import import_artifact
+    from pivot.storage import track
+
+
+async def _batch_check(
+    pairs: list[tuple[pathlib.Path, track.PvtData]],
+) -> list[import_artifact.UpdateCheck | BaseException]:
+    from pivot import import_artifact as ia
+
+    return await asyncio.gather(
+        *[ia.check_for_update(pvt_data) for _, pvt_data in pairs],
+        return_exceptions=True,
+    )
+
+
+async def _batch_update(
+    pairs: list[tuple[pathlib.Path, track.PvtData]],
+    rev: str | None,
+) -> list[import_artifact.UpdateResult | BaseException]:
+    from pivot import import_artifact as ia
+
+    return await asyncio.gather(
+        *[ia.update_import(pvt_path, new_rev=rev) for pvt_path, _ in pairs],
+        return_exceptions=True,
+    )
+
+
+@cli_decorators.pivot_command(auto_discover=False)
+@click.argument("targets", nargs=-1)
+@click.option("--rev", default=None, help="Override git ref for update")
+@click.option("--dry-run", is_flag=True, help="Show what would change without modifying")
+def update(targets: tuple[str, ...], rev: str | None, dry_run: bool) -> None:
+    """Update imported artifacts from their source repos.
+
+    If no TARGETS specified, updates all imports found in the project.
+    """
+    from pivot import project
+    from pivot.storage import track
+
+    root = project.get_project_root()
+
+    if targets:
+        pairs = list[tuple[pathlib.Path, track.PvtData]]()
+        for t in targets:
+            t_path = pathlib.Path(t)
+            if t_path.suffix == ".pvt":
+                pvt_path = project.normalize_path(t_path, base=root)
+            else:
+                pvt_path = track.get_pvt_path(project.normalize_path(t_path, base=root))
+            pvt_data = track.read_pvt_file(pvt_path)
+            if pvt_data is None:
+                click.echo(f"Skipping invalid .pvt: {pvt_path}")
+                continue
+            if not track.is_import(pvt_data):
+                click.echo(f"Skipping non-import: {pvt_path}")
+                continue
+            pairs.append((pvt_path, pvt_data))
+    else:
+        imports = track.discover_import_pvt_files(root)
+        pairs = list[tuple[pathlib.Path, track.PvtData]]()
+        for data_path_str, pvt_data in imports.items():
+            pvt_path = track.get_pvt_path(pathlib.Path(data_path_str))
+            pairs.append((pvt_path, pvt_data))
+
+    if not pairs:
+        click.echo("No imports found to update.")
+        return
+
+    errors = 0
+    if dry_run:
+        checks = asyncio.run(_batch_check(pairs))
+        for (pvt_path, _), check_or_exc in zip(pairs, checks, strict=True):
+            if isinstance(check_or_exc, BaseException):
+                errors += 1
+                _report_error(pvt_path, check_or_exc)
+            else:
+                if check_or_exc["available"]:
+                    current = check_or_exc["current_rev"][:8]
+                    latest = check_or_exc["latest_rev"][:8]
+                    click.echo(f"Update available: {pvt_path} ({current} → {latest})")
+                else:
+                    click.echo(f"Up to date: {pvt_path}")
+    else:
+        results = asyncio.run(_batch_update(pairs, rev))
+        for (pvt_path, _), result_or_exc in zip(pairs, results, strict=True):
+            if isinstance(result_or_exc, BaseException):
+                errors += 1
+                _report_error(pvt_path, result_or_exc)
+            else:
+                if result_or_exc["downloaded"]:
+                    old_rev = result_or_exc["old_rev"][:8]
+                    new_rev = result_or_exc["new_rev"][:8]
+                    click.echo(f"Updated: {result_or_exc['path']} ({old_rev} → {new_rev})")
+                elif result_or_exc["metadata_updated"]:
+                    old_rev = result_or_exc["old_rev"][:8]
+                    new_rev = result_or_exc["new_rev"][:8]
+                    click.echo(f"Metadata updated: {result_or_exc['path']} ({old_rev} → {new_rev})")
+                else:
+                    click.echo(f"Up to date: {result_or_exc['path']}")
+
+    if errors:
+        raise SystemExit(1)
+
+
+def _report_error(pvt_path: pathlib.Path, exc: BaseException) -> None:
+    from pivot import exceptions
+
+    if isinstance(exc, (exceptions.PivotError, exceptions.RemoteError)):
+        click.echo(f"Error updating {pvt_path}: {exc}", err=True)
+    else:
+        click.echo(
+            f"Unexpected error updating {pvt_path}: {type(exc).__name__}: {exc}",
+            err=True,
+        )
+        traceback.print_exception(exc)

--- a/packages/pivot/src/pivot/import_artifact.py
+++ b/packages/pivot/src/pivot/import_artifact.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import pathlib
+from typing import TYPE_CHECKING, TypedDict, cast
+
+import aiohttp
+import yaml
+
+from pivot import exceptions, project
+from pivot.remote import config as remote_config
+from pivot.remote import git_archive, github
+from pivot.remote import storage as remote_storage
+from pivot.storage import cache, track
+from pivot.storage import lock as storage_lock
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pivot.types import DirManifestEntry, OutEntry, StorageLockData
+
+logger = logging.getLogger(__name__)
+
+
+class ResolvedImport(TypedDict):
+    stage: str
+    path: str
+    hash: str
+    size: int
+    remote_url: str
+    rev_lock: str
+
+
+class ImportResult(TypedDict):
+    pvt_path: str
+    data_path: str
+    downloaded: bool
+
+
+def _maybe_token(repo_url: str, token: str | None) -> str | None:
+    if token is not None:
+        return token
+    if github.is_github_url(repo_url):
+        return github.get_token()
+    return None
+
+
+async def _run_blocking[T](func: Callable[..., T], *args: object) -> T:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(func, *args))
+
+
+async def _read_remote_file(
+    repo_url: str,
+    path: str,
+    rev: str,
+    token: str | None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> bytes | None:
+    if github.is_github_url(repo_url):
+        owner, repo = github.parse_github_url(repo_url)
+        return await github.read_file(
+            owner, repo, path, rev, _maybe_token(repo_url, token), session=session
+        )
+    return await _run_blocking(git_archive.read_file_from_remote_repo, repo_url, path, rev)
+
+
+async def _resolve_ref(
+    repo_url: str,
+    ref: str,
+    token: str | None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> str | None:
+    if github.is_github_url(repo_url):
+        owner, repo = github.parse_github_url(repo_url)
+        return await github.resolve_ref(
+            owner, repo, ref, _maybe_token(repo_url, token), session=session
+        )
+    return await _run_blocking(git_archive.resolve_ref_from_remote_repo, repo_url, ref)
+
+
+async def read_remote_config(
+    repo_url: str,
+    rev: str,
+    token: str | None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> str:
+    raw = await _read_remote_file(repo_url, ".pivot/config.yaml", rev, token, session=session)
+    if raw is None:
+        raise exceptions.RemoteError("Remote repo is missing .pivot/config.yaml")
+
+    try:
+        data = cast("object", yaml.safe_load(raw))
+    except yaml.YAMLError as e:
+        raise exceptions.RemoteError(f"Invalid YAML in remote config: {e}") from e
+
+    if not isinstance(data, dict):
+        raise exceptions.RemoteError("Remote config is not a mapping")
+
+    config_data = cast("dict[str, object]", data)
+    remotes_raw = config_data.get("remotes")
+    if not isinstance(remotes_raw, dict) or not remotes_raw:
+        raise exceptions.RemoteError("Remote config has no remotes")
+
+    remotes_data = cast("dict[object, object]", remotes_raw)
+    remotes = {str(k): str(v) for k, v in remotes_data.items()}
+
+    default_remote = config_data.get("default_remote")
+    if not isinstance(default_remote, str):
+        default_remote = None
+    if default_remote is None:
+        if len(remotes) == 1:
+            default_remote = next(iter(remotes.keys()))
+        else:
+            raise exceptions.RemoteError("Remote config has multiple remotes but no default_remote")
+
+    if default_remote not in remotes:
+        raise exceptions.RemoteError(f"Default remote '{default_remote}' not found in config")
+
+    url = str(remotes[default_remote])
+    _ = remote_config.validate_s3_url(url)
+    logger.info("Using source remote: %s", url)
+    return url
+
+
+async def list_remote_lock_files(
+    repo_url: str,
+    rev: str,
+    token: str | None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> list[str]:
+    if github.is_github_url(repo_url):
+        owner, repo = github.parse_github_url(repo_url)
+        entries = await github.list_directory(
+            owner,
+            repo,
+            ".pivot/stages",
+            rev,
+            _maybe_token(repo_url, token),
+            session=session,
+        )
+    else:
+        entries = await _run_blocking(
+            git_archive.list_directory_from_remote_repo,
+            repo_url,
+            ".pivot/stages",
+            rev,
+        )
+
+    if entries is None:
+        raise exceptions.RemoteError("Remote repo has no .pivot/stages directory")
+
+    stage_names = list[str]()
+    for entry in [str(e) for e in entries]:
+        name = pathlib.Path(entry).name
+        if not name.endswith(".lock"):
+            continue
+        stage_names.append(name[: -len(".lock")])
+
+    if not stage_names:
+        raise exceptions.RemoteError("Remote repo has no lock files")
+
+    return stage_names
+
+
+async def read_remote_lock_file(
+    repo_url: str,
+    stage_name: str,
+    rev: str,
+    token: str | None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> StorageLockData | None:
+    path = f".pivot/stages/{stage_name}.lock"
+    raw = await _read_remote_file(repo_url, path, rev, token, session=session)
+    if raw is None:
+        return None
+    try:
+        data = cast("object", yaml.safe_load(raw))
+    except yaml.YAMLError:
+        logger.warning("Failed to parse lock file for stage '%s'", stage_name)
+        return None
+    if not storage_lock.is_lock_data(data):
+        logger.warning("Invalid lock file structure for stage '%s'", stage_name)
+        return None
+    return data
+
+
+def _entry_size(entry: OutEntry) -> int:
+    if "size" in entry:
+        return int(entry["size"])
+    if "manifest" in entry:
+        return sum(int(m["size"]) for m in entry["manifest"])
+    entry_path = entry["path"] if "path" in entry else "unknown"
+    logger.warning("Lock entry '%s' has no size information", entry_path)
+    return 0
+
+
+def _iter_manifest_paths(entry: OutEntry) -> list[tuple[str, DirManifestEntry]]:
+    if "manifest" not in entry:
+        return []
+    base = entry["path"].rstrip("/")
+    return [(f"{base}/{m['relpath']}", m) for m in entry["manifest"]]
+
+
+async def resolve_remote_path(
+    repo_url: str,
+    path: str,
+    rev: str,
+    token: str | None,
+) -> ResolvedImport:
+    async with aiohttp.ClientSession() as session:
+        return await _resolve_remote_path_with_session(repo_url, path, rev, token, session)
+
+
+async def _resolve_remote_path_with_session(
+    repo_url: str,
+    path: str,
+    rev: str,
+    token: str | None,
+    session: aiohttp.ClientSession,
+) -> ResolvedImport:
+    gh_session = session if github.is_github_url(repo_url) else None
+    rev_lock = await _resolve_ref(repo_url, rev, token, session=gh_session)
+    if rev_lock is None:
+        raise exceptions.RemoteError(f"Unable to resolve ref '{rev}'")
+
+    remote_url = await read_remote_config(repo_url, rev_lock, token, session=gh_session)
+
+    # Use resolved SHA for all subsequent reads to avoid TOCTOU race
+    stage_names = await list_remote_lock_files(repo_url, rev_lock, token, session=gh_session)
+    lock_datas = await asyncio.gather(
+        *[
+            read_remote_lock_file(repo_url, stage, rev_lock, token, session=gh_session)
+            for stage in stage_names
+        ]
+    )
+
+    matches = list[tuple[str, str, str, int]]()
+    available = set[str]()
+
+    for stage, lock_data in zip(stage_names, lock_datas, strict=True):
+        if lock_data is None:
+            continue
+        for entry in lock_data["outs"]:
+            available.add(entry["path"])
+            for full_path, _ in _iter_manifest_paths(entry):
+                available.add(full_path)
+
+            if entry["path"] == path:
+                if "manifest" in entry:
+                    message = (
+                        "Cannot import directory output "
+                        + f"'{path}'. Import individual files instead, "
+                        + f"e.g., '{path.rstrip('/')}/{{filename}}'"
+                    )
+                    raise exceptions.PivotError(message)
+                matches.append((stage, path, entry["hash"], _entry_size(entry)))
+                continue
+
+            for full_path, manifest_entry in _iter_manifest_paths(entry):
+                if full_path == path:
+                    matches.append(
+                        (
+                            stage,
+                            path,
+                            manifest_entry["hash"],
+                            int(manifest_entry["size"]),
+                        )
+                    )
+
+    if not matches:
+        max_shown = 10
+        sorted_available = sorted(available)
+        if len(sorted_available) > max_shown:
+            shown = ", ".join(sorted_available[:max_shown])
+            available_list = f"{shown} (and {len(sorted_available) - max_shown} more)"
+        elif sorted_available:
+            available_list = ", ".join(sorted_available)
+        else:
+            available_list = "(none)"
+        raise exceptions.PivotError(
+            f"Path '{path}' not found in remote outputs. Available outputs: {available_list}"
+        )
+
+    if len(matches) > 1:
+        stages = ", ".join(sorted({stage for stage, _, _, _ in matches}))
+        raise exceptions.PivotError(f"Path '{path}' is produced by multiple stages: {stages}")
+
+    stage, matched_path, hash_, size = matches[0]
+    return ResolvedImport(
+        stage=stage,
+        path=matched_path,
+        hash=hash_,
+        size=size,
+        remote_url=remote_url,
+        rev_lock=rev_lock,
+    )
+
+
+async def import_artifact(
+    repo_url: str,
+    path: str,
+    *,
+    rev: str = "main",
+    out: str | None = None,
+    force: bool = False,
+    no_download: bool = False,
+    project_root: pathlib.Path | None = None,
+) -> ImportResult:
+    resolved = await resolve_remote_path(repo_url, path, rev, None)
+
+    if project_root is None:
+        project_root = project.get_project_root()
+
+    dest = out if out is not None else path
+    data_path = project.normalize_path(dest, base=project_root)
+    if not data_path.is_relative_to(project_root.absolute()):
+        raise exceptions.PivotError(
+            f"Import destination must be within project root. Got: {data_path}"
+        )
+    pvt_path = track.get_pvt_path(data_path)
+
+    if data_path.exists() and not force:
+        raise exceptions.PivotError(f"'{data_path}' already exists. Use --force to overwrite.")
+    if pvt_path.exists() and not force:
+        raise exceptions.PivotError(f"'{pvt_path}' already exists. Use --force to overwrite.")
+
+    if force and data_path.exists() and data_path.is_dir():
+        raise exceptions.PivotError("Cannot overwrite directory with import")
+
+    pvt_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+
+    downloaded = False
+    file_size = resolved["size"]
+    if not no_download:
+        remote = remote_storage.S3Remote(resolved["remote_url"])
+        await remote.download_file(resolved["hash"], data_path)
+        downloaded = True
+        actual_hash, _ = cache.hash_file(data_path)
+        if actual_hash != resolved["hash"]:
+            data_path.unlink(missing_ok=True)
+            raise exceptions.RemoteError(
+                f"Downloaded file hash mismatch: expected {resolved['hash']}, got {actual_hash}"
+            )
+        file_size = data_path.stat().st_size
+
+    source = track.ImportSource(
+        repo=repo_url,
+        rev=rev,
+        rev_lock=resolved["rev_lock"],
+        stage=resolved["stage"],
+        path=resolved["path"],
+        remote=resolved["remote_url"],
+    )
+    pvt_data = track.PvtData(
+        path=data_path.name,
+        hash=resolved["hash"],
+        size=file_size,
+        source=source,
+    )
+
+    track.write_pvt_file(pvt_path, pvt_data)
+
+    return ImportResult(
+        pvt_path=str(pvt_path),
+        data_path=str(data_path),
+        downloaded=downloaded,
+    )
+
+
+class UpdateCheck(TypedDict):
+    available: bool
+    current_rev: str
+    latest_rev: str
+
+
+class UpdateResult(TypedDict):
+    downloaded: bool
+    metadata_updated: bool
+    updated: bool
+    old_rev: str
+    new_rev: str
+    path: str
+
+
+async def check_for_update(pvt_data: track.PvtData) -> UpdateCheck:
+    """Check if import has updates. Resolves current ref, compares to rev_lock."""
+    if "source" not in pvt_data:
+        raise exceptions.PivotError("Not an import")
+    source = pvt_data["source"]
+    rev_lock = await _resolve_ref(source["repo"], source["rev"], None)
+    if rev_lock is None:
+        raise exceptions.RemoteError(f"Cannot resolve ref '{source['rev']}' from {source['repo']}")
+    return UpdateCheck(
+        available=rev_lock != source["rev_lock"],
+        current_rev=source["rev_lock"],
+        latest_rev=rev_lock,
+    )
+
+
+async def update_import(pvt_path: pathlib.Path, *, new_rev: str | None = None) -> UpdateResult:
+    """Update an imported artifact. Re-resolves ref, re-downloads if hash changed."""
+    pvt_data = track.read_pvt_file(pvt_path)
+    if pvt_data is None:
+        raise exceptions.PivotError(f"Invalid .pvt file: {pvt_path}")
+    if "source" not in pvt_data:
+        raise exceptions.PivotError(f"Not an import: {pvt_path}")
+
+    source = pvt_data["source"]
+    rev = new_rev if new_rev is not None else source["rev"]
+    old_rev = source["rev_lock"]
+
+    # Re-resolve at new/current rev
+    resolved = await resolve_remote_path(source["repo"], source["path"], rev, None)
+
+    downloaded = False
+    data_path = track.get_data_path(pvt_path)
+    need_download = resolved["hash"] != pvt_data["hash"] or not data_path.exists()
+
+    file_size = resolved["size"]
+    if need_download:
+        remote = remote_storage.S3Remote(resolved["remote_url"])
+        await remote.download_file(resolved["hash"], data_path)
+        actual_hash, _ = cache.hash_file(data_path)
+        if actual_hash != resolved["hash"]:
+            data_path.unlink(missing_ok=True)
+            raise exceptions.RemoteError(
+                f"Hash mismatch: expected {resolved['hash']}, got {actual_hash}"
+            )
+        downloaded = True
+        file_size = data_path.stat().st_size
+    elif data_path.exists():
+        file_size = data_path.stat().st_size
+
+    metadata_changed = (
+        resolved["rev_lock"] != old_rev
+        or resolved["hash"] != pvt_data["hash"]
+        or rev != source["rev"]
+    )
+    if metadata_changed:
+        new_source = track.ImportSource(
+            repo=source["repo"],
+            rev=rev,
+            rev_lock=resolved["rev_lock"],
+            stage=resolved["stage"],
+            path=resolved["path"],
+            remote=resolved["remote_url"],
+        )
+        new_pvt = track.PvtData(
+            path=pvt_data["path"],
+            hash=resolved["hash"],
+            size=file_size,
+            source=new_source,
+        )
+        track.write_pvt_file(pvt_path, new_pvt)
+
+    return UpdateResult(
+        downloaded=downloaded,
+        metadata_updated=metadata_changed,
+        updated=downloaded,
+        old_rev=old_rev,
+        new_rev=resolved["rev_lock"],
+        path=str(data_path),
+    )

--- a/packages/pivot/src/pivot/remote/AGENTS.md
+++ b/packages/pivot/src/pivot/remote/AGENTS.md
@@ -1,0 +1,60 @@
+# Pivot Remote - Development Guidelines
+
+## Async-First I/O (Critical)
+
+**All network I/O in the remote layer MUST be async.** This is not optional.
+
+The remote layer uses `aiohttp` (direct dependency) for HTTP and `aioboto3` for S3.
+CLI commands expose sync wrappers that call `asyncio.run()` at the boundary.
+
+### Pattern: Async Internals + Sync CLI Wrapper
+
+```python
+# Internal: fully async
+async def _fetch_remote_file(url: str, token: str | None) -> bytes:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=_auth_headers(token)) as resp:
+            resp.raise_for_status()
+            return await resp.read()
+
+# CLI boundary: sync wrapper
+def fetch_remote_file(url: str, token: str | None) -> bytes:
+    return asyncio.run(_fetch_remote_file(url, token))
+```
+
+### Why Async
+
+1. **Parallelism**: Import resolution scans multiple lock files — `asyncio.gather()` reads them concurrently
+2. **Consistency**: S3Remote is already fully async; mixing sync HTTP would create two patterns
+3. **Status checks**: `--check-imports` checks multiple imports concurrently
+4. **Connection reuse**: `aiohttp.ClientSession` reuses TCP connections across requests
+
+### HTTP Client: aiohttp
+
+Use `aiohttp` for all HTTP calls (GitHub API, git forge APIs). Do NOT use:
+- `httpx` — not in our dependencies
+- `urllib.request` — synchronous, no connection reuse, no async support
+- `requests` — not in our dependencies
+
+`aiohttp` is a direct dependency (also available transitively via `aioboto3 → aiobotocore`).
+
+### S3 Access Pattern
+
+S3Remote uses `aioboto3.Session()` — one session per instance, one client per method call.
+See root `AGENTS.md` for details. When creating temporary S3Remote instances (e.g., for
+importing from a source repo's bucket), follow the same pattern.
+
+### Auth Conventions
+
+| Service | Token Source | Env Vars |
+|---------|-------------|----------|
+| GitHub API | Environment variable | `GH_TOKEN`, then `GITHUB_TOKEN` |
+| S3 | Standard AWS credential chain | `AWS_*` env vars, `~/.aws/`, instance profile |
+
+### Error Handling
+
+Network errors are **expected** in the remote layer. Always provide actionable messages:
+- 403 on GitHub → "Authentication required. Set GH_TOKEN environment variable."
+- 429 on GitHub → "Rate limited. Set GH_TOKEN for higher limits."
+- S3 AccessDenied → "Cannot access {url}. Check AWS credentials or ask source repo owner for access."
+- Connection errors → "Cannot reach {host}. Check network connectivity."

--- a/packages/pivot/src/pivot/remote/git_archive.py
+++ b/packages/pivot/src/pivot/remote/git_archive.py
@@ -1,0 +1,155 @@
+"""Git archive fallback for reading files from non-GitHub remote repos.
+
+Uses ``git archive --remote`` and ``git ls-remote`` via subprocess.
+GitHub has **disabled** ``git archive --remote`` for public repos —
+this module targets self-hosted Git servers and GitLab.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import subprocess
+import tarfile
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 30  # seconds
+
+
+def resolve_ref_from_remote_repo(
+    repo_url: str,
+    ref: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> str | None:
+    """Resolve a ref to a commit SHA using ``git ls-remote``.
+
+    Returns the 40-char hex SHA, or ``None`` if the ref cannot be resolved
+    (repo not found, branch missing, timeout, git not installed).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--", repo_url, ref],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.debug(
+                "git ls-remote failed for %s: %s",
+                repo_url,
+                result.stderr,
+            )
+            return None
+        # Prefer dereferenced ^{} SHA (commit) over tag object SHA.
+        # git ls-remote returns both for annotated tags:
+        #   <tag-object-sha>  refs/tags/v1.0
+        #   <commit-sha>      refs/tags/v1.0^{}
+        match_sha: str | None = None
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            sha, ref_name = parts[0], parts[1]
+            is_deref = ref_name.endswith("^{}")
+            bare_ref = ref_name.removesuffix("^{}")
+            if bare_ref == ref or bare_ref.endswith(f"/{ref}"):
+                if is_deref:
+                    return sha
+                match_sha = sha
+        return match_sha
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "git ls-remote timed out for %s after %ds",
+            repo_url,
+            timeout,
+        )
+        return None
+    except FileNotFoundError:
+        logger.warning("git command not found")
+        return None
+
+
+def read_file_from_remote_repo(
+    repo_url: str,
+    path: str,
+    rev: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> bytes | None:
+    """Read a single file from a remote repo using ``git archive``.
+
+    Returns file contents as bytes, or ``None`` on any failure
+    (path not found, repo inaccessible, timeout, tar extraction error).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "archive", f"--remote={repo_url}", rev, "--", path],
+            capture_output=True,
+            timeout=timeout,
+            check=True,
+        )
+        with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+            for member in tar.getmembers():
+                if member.isfile():
+                    f = tar.extractfile(member)
+                    if f is not None:
+                        return f.read()
+        return None
+    except subprocess.CalledProcessError as e:
+        logger.debug("git archive failed: %s", e.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "git archive timed out for %s after %ds",
+            repo_url,
+            timeout,
+        )
+        return None
+    except FileNotFoundError:
+        logger.warning("git command not found")
+        return None
+    except (tarfile.TarError, OSError) as e:
+        logger.debug("Failed to extract tar: %s", e)
+        return None
+
+
+def list_directory_from_remote_repo(
+    repo_url: str,
+    path: str,
+    rev: str,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> list[str] | None:
+    """List files in a directory from a remote repo via ``git archive``.
+
+    Returns a list of file paths (relative to repo root), or ``None``
+    on failure (path not found, repo inaccessible, timeout).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "archive", f"--remote={repo_url}", rev, "--", path],
+            capture_output=True,
+            timeout=timeout,
+            check=True,
+        )
+        with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+            return [m.name.rsplit("/", 1)[-1] for m in tar.getmembers() if m.isfile()]
+    except subprocess.CalledProcessError as e:
+        logger.debug("git archive failed: %s", e.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "git archive timed out for %s after %ds",
+            repo_url,
+            timeout,
+        )
+        return None
+    except FileNotFoundError:
+        logger.warning("git command not found")
+        return None
+    except (tarfile.TarError, OSError) as e:
+        logger.debug("Failed to extract tar: %s", e)
+        return None

--- a/packages/pivot/src/pivot/remote/github.py
+++ b/packages/pivot/src/pivot/remote/github.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import typing
+
+import aiohttp
+
+from pivot import exceptions
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=30)
+_GITHUB_HTTPS_RE = re.compile(r"^https?://github\.com/([^/]+)/([^/.]+?)(?:\.git)?/?$")
+_GITHUB_SSH_RE = re.compile(r"^git@github\.com:([^/]+)/([^/.]+?)(?:\.git)?$")
+_API_BASE = "https://api.github.com"
+
+
+def get_token() -> str | None:
+    """Get GitHub auth token from environment.
+
+    Checks ``GH_TOKEN`` first, then falls back to ``GITHUB_TOKEN``.
+    Returns ``None`` when neither is set.
+    """
+    token = (os.environ.get("GH_TOKEN") or "").strip() or (
+        os.environ.get("GITHUB_TOKEN") or ""
+    ).strip()
+    return token or None
+
+
+def is_github_url(url: str) -> bool:
+    """Check if *url* points to a GitHub repository."""
+    return bool(_GITHUB_HTTPS_RE.match(url) or _GITHUB_SSH_RE.match(url))
+
+
+def parse_github_url(url: str) -> tuple[str, str]:
+    """Extract ``(owner, repo)`` from a GitHub URL.
+
+    Raises :class:`ValueError` if *url* is not a recognised GitHub URL.
+    """
+    m = _GITHUB_HTTPS_RE.match(url) or _GITHUB_SSH_RE.match(url)
+    if not m:
+        raise ValueError(f"Not a GitHub URL: {url}")
+    return m.group(1), m.group(2)
+
+
+def _auth_headers(token: str | None) -> dict[str, str]:
+    """Build request headers for the GitHub REST API."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _raise_for_error_status(status: int, headers: dict[str, str], body: str) -> None:
+    if status == 429:
+        raise exceptions.RemoteError(
+            "GitHub API rate limited. Set GH_TOKEN environment variable for higher limits."
+        )
+    if status == 403:
+        remaining = headers.get("X-RateLimit-Remaining", "")
+        if remaining == "0":
+            raise exceptions.RemoteError(
+                "GitHub API rate limited. Set GH_TOKEN environment variable for higher limits."
+            )
+        if "rate limit" in body.lower() or "abuse" in body.lower():
+            raise exceptions.RemoteError(
+                "GitHub API secondary rate limit. Retry after a short wait."
+            )
+        raise exceptions.RemoteError(
+            "GitHub API access denied (403). Set GH_TOKEN environment variable if the repo is private."
+        )
+
+
+async def _get(
+    session: aiohttp.ClientSession,
+    url: str,
+    token: str | None,
+) -> tuple[int, object]:
+    async with session.get(url, headers=_auth_headers(token), timeout=_DEFAULT_TIMEOUT) as resp:
+        if resp.status == 404:
+            if token is None:
+                logger.debug("GitHub 404 (no token set — repo may be private)")
+            return 404, None
+        if resp.status in (403, 429):
+            body = await resp.text()
+            resp_headers = dict(resp.headers.items())
+            _raise_for_error_status(resp.status, resp_headers, body)
+        resp.raise_for_status()
+        return resp.status, await resp.json()
+
+
+async def read_file(
+    owner: str,
+    repo: str,
+    path: str,
+    ref: str,
+    token: str | None = None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> bytes | None:
+    url = f"{_API_BASE}/repos/{owner}/{repo}/contents/{path}?ref={ref}"
+    if session is not None:
+        status, data = await _get(session, url, token)
+    else:
+        async with aiohttp.ClientSession() as s:
+            status, data = await _get(s, url, token)
+    if status == 404:
+        return None
+    if isinstance(data, dict) and "content" in data:
+        data_dict = typing.cast("dict[str, object]", data)
+        content = data_dict["content"]
+        if not isinstance(content, str):
+            return None
+        return base64.b64decode(content)
+    return None
+
+
+async def list_directory(
+    owner: str,
+    repo: str,
+    path: str,
+    ref: str,
+    token: str | None = None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> list[str] | None:
+    url = f"{_API_BASE}/repos/{owner}/{repo}/contents/{path}?ref={ref}"
+    if session is not None:
+        status, data = await _get(session, url, token)
+    else:
+        async with aiohttp.ClientSession() as s:
+            status, data = await _get(s, url, token)
+    if status == 404:
+        return None
+    if isinstance(data, list):
+        data_list = typing.cast("list[object]", data)
+        names: list[str] = []
+        for entry in data_list:
+            if not isinstance(entry, dict) or "name" not in entry:
+                continue
+            entry_dict = typing.cast("dict[str, object]", entry)
+            name = entry_dict["name"]
+            if isinstance(name, str):
+                names.append(name)
+        return names
+    return None
+
+
+async def resolve_ref(
+    owner: str,
+    repo: str,
+    ref: str,
+    token: str | None = None,
+    *,
+    session: aiohttp.ClientSession | None = None,
+) -> str | None:
+    url = f"{_API_BASE}/repos/{owner}/{repo}/commits/{ref}"
+    if session is not None:
+        status, data = await _get(session, url, token)
+    else:
+        async with aiohttp.ClientSession() as s:
+            status, data = await _get(s, url, token)
+    if status == 404:
+        return None
+    if isinstance(data, dict) and "sha" in data:
+        data_dict = typing.cast("dict[str, object]", data)
+        sha_value = data_dict["sha"]
+        if isinstance(sha_value, str):
+            return sha_value
+    return None

--- a/packages/pivot/src/pivot/remote/storage.py
+++ b/packages/pivot/src/pivot/remote/storage.py
@@ -5,7 +5,6 @@ import contextlib
 import logging
 import os
 import re
-import shutil
 import tempfile
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
@@ -223,13 +222,25 @@ async def _atomic_download(
     fd, tmp_path = tempfile.mkstemp(dir=local_path.parent, prefix=".pivot_download_")
     move_succeeded = False
     try:
-        response = await s3.get_object(Bucket=bucket, Key=key)
+        try:
+            response = await s3.get_object(Bucket=bucket, Key=key)
+        except Exception as exc:
+            error_str = str(exc)
+            if "NoSuchKey" in error_str or "404" in error_str:
+                raise exceptions.RemoteError(
+                    f"Remote cache file not found: {bucket}/{key}"
+                ) from exc
+            if "AccessDenied" in error_str or "403" in error_str:
+                raise exceptions.RemoteError(
+                    f"Access denied to {bucket}/{key}. Check AWS credentials."
+                ) from exc
+            raise exceptions.RemoteError(f"Failed to download from S3: {exc}") from exc
         await _stream_download_to_fd(response, fd)
         os.close(fd)
         fd = -1  # Mark as closed
         if readonly:
             os.chmod(tmp_path, 0o444)
-        shutil.move(tmp_path, local_path)
+        os.replace(tmp_path, local_path)
         move_succeeded = True
     finally:
         if fd >= 0:

--- a/packages/pivot/src/pivot/status.py
+++ b/packages/pivot/src/pivot/status.py
@@ -43,6 +43,7 @@ Example::
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 import pathlib
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
@@ -52,6 +53,7 @@ from pivot import (
     config,
     exceptions,
     explain,
+    import_artifact,
     metrics,
     parameters,
     project,
@@ -477,3 +479,83 @@ def what_if_changed(
         affected.update(consumers)
 
     return sorted(affected)
+
+
+class ImportCheckStatus(enum.Enum):
+    UP_TO_DATE = "up to date"
+    UPDATE_AVAILABLE = "update available"
+    ERROR = "error"
+
+
+class ImportStatusInfo:
+    __slots__: tuple[str, ...] = ("path", "status", "current_rev", "latest_rev", "error")
+
+    path: str
+    status: ImportCheckStatus
+    current_rev: str
+    latest_rev: str
+    error: str
+
+    def __init__(
+        self,
+        path: str,
+        status: ImportCheckStatus,
+        current_rev: str = "",
+        latest_rev: str = "",
+        error: str = "",
+    ) -> None:
+        self.path = path
+        self.status = status
+        self.current_rev = current_rev
+        self.latest_rev = latest_rev
+        self.error = error
+
+
+async def _check_imports_batch(
+    import_pvts: dict[str, track.PvtData],
+    project_root: pathlib.Path,
+) -> list[ImportStatusInfo]:
+    tasks = list[tuple[str, track.PvtData]]()
+    for data_path, pvt_data in sorted(import_pvts.items()):
+        try:
+            rel_path = str(pathlib.Path(data_path).relative_to(project_root))
+        except ValueError:
+            rel_path = data_path
+        tasks.append((rel_path, pvt_data))
+
+    checks = await asyncio.gather(
+        *[import_artifact.check_for_update(pvt_data) for _, pvt_data in tasks],
+        return_exceptions=True,
+    )
+
+    results = list[ImportStatusInfo]()
+    for (rel_path, _), check_or_exc in zip(tasks, checks, strict=True):
+        if isinstance(check_or_exc, Exception):
+            logger.warning("Failed to check import %s: %s", rel_path, check_or_exc)
+            results.append(
+                ImportStatusInfo(
+                    path=rel_path, status=ImportCheckStatus.ERROR, error=str(check_or_exc)
+                )
+            )
+        else:
+            check = cast("import_artifact.UpdateCheck", check_or_exc)
+            if check["available"]:
+                results.append(
+                    ImportStatusInfo(
+                        path=rel_path,
+                        status=ImportCheckStatus.UPDATE_AVAILABLE,
+                        current_rev=check["current_rev"][:8],
+                        latest_rev=check["latest_rev"][:8],
+                    )
+                )
+            else:
+                results.append(ImportStatusInfo(path=rel_path, status=ImportCheckStatus.UP_TO_DATE))
+    return results
+
+
+def get_import_status(project_root: pathlib.Path) -> list[ImportStatusInfo]:
+    """Check update status for all imported artifacts concurrently."""
+    import_pvts = track.discover_import_pvt_files(project_root)
+    if not import_pvts:
+        return []
+    return asyncio.run(_check_imports_batch(import_pvts, project_root))

--- a/packages/pivot/src/pivot/storage/track.py
+++ b/packages/pivot/src/pivot/storage/track.py
@@ -27,6 +27,17 @@ except AttributeError:
     _Dumper = yaml.SafeDumper
 
 
+class ImportSource(TypedDict):
+    """Source information for imported artifacts."""
+
+    repo: str  # Source repo URL
+    rev: str  # Symbolic ref (branch/tag)
+    rev_lock: str  # Resolved commit SHA
+    stage: str  # Source stage name (auto-discovered)
+    path: str  # Path within source repo
+    remote: str  # Source's S3 remote URL
+
+
 class PvtData(TypedDict):
     """Data stored in .pvt files."""
 
@@ -35,10 +46,12 @@ class PvtData(TypedDict):
     size: int  # Total size (file or sum of directory)
     num_files: NotRequired[int]  # For directories only
     manifest: NotRequired[list[DirManifestEntry]]  # For directories only
+    source: NotRequired[ImportSource]  # Import source metadata
 
 
 _REQUIRED_KEYS = frozenset({"path", "hash", "size"})
-_VALID_KEYS = frozenset({"path", "hash", "size", "num_files", "manifest"})
+_VALID_KEYS = frozenset({"path", "hash", "size", "num_files", "manifest", "source"})
+_REQUIRED_SOURCE_KEYS = frozenset({"repo", "rev", "rev_lock", "stage", "path", "remote"})
 
 
 def is_pvt_data(data: object) -> TypeGuard[PvtData]:
@@ -48,18 +61,30 @@ def is_pvt_data(data: object) -> TypeGuard[PvtData]:
     str_data = cast("dict[str, object]", data)
     if not _REQUIRED_KEYS.issubset(str_data.keys()):
         return False
-    return all(key in _VALID_KEYS for key in str_data)
+    if not all(key in _VALID_KEYS for key in str_data):
+        return False
+    if "source" in str_data:
+        source = str_data["source"]
+        if not isinstance(source, dict):
+            return False
+        source_dict = cast("dict[str, object]", source)
+        if not _REQUIRED_SOURCE_KEYS.issubset(source_dict.keys()):
+            return False
+        if not all(isinstance(source_dict[k], str) for k in _REQUIRED_SOURCE_KEYS):
+            return False
+    return True
 
 
 def has_path_traversal(path: str) -> bool:
-    """Check if path contains traversal components (..)."""
-    return ".." in pathlib.Path(path).parts
+    """Check if path is unsafe: absolute or contains traversal (..)."""
+    p = pathlib.Path(path)
+    return p.is_absolute() or ".." in p.parts
 
 
 def _validate_path(path: str) -> None:
-    """Validate path doesn't contain traversal."""
+    """Validate path is relative and doesn't contain traversal."""
     if has_path_traversal(path):
-        raise exceptions.SecurityValidationError(f"Path contains path traversal: {path!r}")
+        raise exceptions.SecurityValidationError(f"Unsafe path (absolute or traversal): {path!r}")
 
 
 def write_pvt_file(pvt_path: pathlib.Path, data: PvtData) -> None:
@@ -80,7 +105,6 @@ def read_pvt_file(pvt_path: pathlib.Path) -> PvtData | None:
             data: object = yaml.load(f, Loader=_Loader)
         if not is_pvt_data(data):
             return None
-        # Validate path doesn't contain traversal (security check)
         if has_path_traversal(data["path"]):
             return None
         return data
@@ -108,21 +132,33 @@ def discover_pvt_files(root: pathlib.Path) -> dict[str, PvtData]:
 
     result = dict[str, PvtData]()
 
-    for pvt_path in root.rglob("*.pvt"):
-        if not pvt_path.is_file():
-            continue
-        data = read_pvt_file(pvt_path)
-        if data is None:
-            logger.warning(f"Skipping invalid .pvt file: {pvt_path}")
-            continue
+    for dirpath, _dirnames, filenames in os.walk(root, followlinks=False):
+        for fname in filenames:
+            if not fname.endswith(".pvt"):
+                continue
+            pvt_path = pathlib.Path(dirpath) / fname
+            if not pvt_path.is_file():
+                continue
+            data = read_pvt_file(pvt_path)
+            if data is None:
+                logger.warning(f"Skipping invalid .pvt file: {pvt_path}")
+                continue
 
-        # Compute absolute data path from pvt file location + relative path
-        # Use normalized path (preserve symlinks) for portability
-        data_path = pvt_path.parent / data["path"]
-        normalized = project.normalize_path(data_path)
-        result[str(normalized)] = data
+            data_path = pvt_path.parent / data["path"]
+            normalized = project.normalize_path(data_path)
+            result[str(normalized)] = data
 
     return result
+
+
+def is_import(data: PvtData) -> bool:
+    """Check if PvtData represents an imported artifact."""
+    return "source" in data
+
+
+def discover_import_pvt_files(root: pathlib.Path) -> dict[str, PvtData]:
+    """Find all import .pvt files under root."""
+    return {path: data for path, data in discover_pvt_files(root).items() if is_import(data)}
 
 
 def pvt_to_hash_info(pvt_data: PvtData) -> HashInfo:

--- a/packages/pivot/tests/cli/test_cli_update.py
+++ b/packages/pivot/tests/cli/test_cli_update.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from pivot import cli, import_artifact, project
+from pivot.import_artifact import UpdateCheck, UpdateResult
+from pivot.storage import track
+from pivot.storage.track import ImportSource, PvtData
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pytest
+    from click.testing import CliRunner
+
+
+def _make_import_pvt(
+    path: str = "data.csv",
+    rev_lock: str = "abc123def456",
+) -> PvtData:
+    return PvtData(
+        path=path,
+        hash="deadbeef",
+        size=100,
+        source=ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock=rev_lock,
+            stage="train",
+            path=path,
+            remote="s3://bucket/cache",
+        ),
+    )
+
+
+def _make_non_import_pvt(path: str = "local.csv") -> PvtData:
+    return PvtData(path=path, hash="cafebabe", size=50)
+
+
+def _helper_get_project_root(tmp_path: pathlib.Path) -> Callable[[], pathlib.Path]:
+    def _get_project_root() -> pathlib.Path:
+        return tmp_path
+
+    return _get_project_root
+
+
+def _helper_read_pvt(
+    pvt_path: pathlib.Path,
+    pvt_data: PvtData,
+) -> Callable[[pathlib.Path], PvtData | None]:
+    def _read(path: pathlib.Path) -> PvtData | None:
+        return pvt_data if path == pvt_path else None
+
+    return _read
+
+
+def _helper_is_import(data: PvtData) -> bool:
+    return "source" in data
+
+
+def _helper_get_pvt_path(path: pathlib.Path) -> pathlib.Path:
+    return path.with_suffix(path.suffix + ".pvt")
+
+
+def _helper_normalize_path(
+    tmp_path: pathlib.Path,
+) -> Callable[[str | pathlib.Path, pathlib.Path | None], pathlib.Path]:
+    def _normalize(path: str | pathlib.Path, base: pathlib.Path | None = None) -> pathlib.Path:
+        path_obj = pathlib.Path(path)
+        if path_obj.is_absolute():
+            return path_obj
+        return tmp_path / path_obj
+
+    return _normalize
+
+
+def _helper_discover_imports(
+    imports: dict[str, PvtData],
+) -> Callable[[pathlib.Path], dict[str, PvtData]]:
+    def _discover(root: pathlib.Path) -> dict[str, PvtData]:
+        return imports
+
+    return _discover
+
+
+# =============================================================================
+# Single target
+# =============================================================================
+
+
+def test_cli_update_single_target(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """update with a single target calls update_import for that path."""
+    pvt_data = _make_import_pvt()
+    pvt_path = tmp_path / "data.csv.pvt"
+
+    monkeypatch.setattr(project, "get_project_root", _helper_get_project_root(tmp_path))
+    monkeypatch.setattr(track, "read_pvt_file", _helper_read_pvt(pvt_path, pvt_data))
+    monkeypatch.setattr(track, "is_import", _helper_is_import)
+    monkeypatch.setattr(track, "get_pvt_path", _helper_get_pvt_path)
+    monkeypatch.setattr(
+        project,
+        "normalize_path",
+        _helper_normalize_path(tmp_path),
+    )
+
+    mock_update = AsyncMock(
+        return_value=UpdateResult(
+            downloaded=True,
+            metadata_updated=True,
+            updated=True,
+            old_rev="abc123def456",
+            new_rev="999888777666",
+            path=str(tmp_path / "data.csv"),
+        )
+    )
+    monkeypatch.setattr(import_artifact, "update_import", mock_update)
+
+    result = runner.invoke(cli.cli, ["update", "data.csv"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Updated:" in result.output
+    assert "abc123de" in result.output
+    assert "99988877" in result.output
+    mock_update.assert_called_once_with(pvt_path, new_rev=None)
+
+
+# =============================================================================
+# Discover all imports
+# =============================================================================
+
+
+def test_cli_update_all_discovers(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """update with no targets discovers all import .pvt files."""
+    pvt_data = _make_import_pvt("model.pkl", rev_lock="aaa111bbb222")
+    data_path_str = str(tmp_path / "model.pkl")
+
+    monkeypatch.setattr(project, "get_project_root", _helper_get_project_root(tmp_path))
+    monkeypatch.setattr(
+        track,
+        "discover_import_pvt_files",
+        _helper_discover_imports({data_path_str: pvt_data}),
+    )
+    monkeypatch.setattr(track, "get_pvt_path", _helper_get_pvt_path)
+
+    mock_update = AsyncMock(
+        return_value=UpdateResult(
+            downloaded=True,
+            metadata_updated=True,
+            updated=True,
+            old_rev="aaa111bbb222",
+            new_rev="ccc333ddd444",
+            path=data_path_str,
+        )
+    )
+    monkeypatch.setattr(import_artifact, "update_import", mock_update)
+
+    result = runner.invoke(cli.cli, ["update"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Updated:" in result.output
+    mock_update.assert_called_once()
+
+
+# =============================================================================
+# Skip non-import
+# =============================================================================
+
+
+def test_cli_update_skips_non_import(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """update skips targets whose .pvt has no source (non-import)."""
+    pvt_data = _make_non_import_pvt()
+    pvt_path = tmp_path / "local.csv.pvt"
+
+    monkeypatch.setattr(project, "get_project_root", _helper_get_project_root(tmp_path))
+    monkeypatch.setattr(track, "read_pvt_file", _helper_read_pvt(pvt_path, pvt_data))
+    monkeypatch.setattr(track, "is_import", _helper_is_import)
+    monkeypatch.setattr(track, "get_pvt_path", _helper_get_pvt_path)
+    monkeypatch.setattr(
+        project,
+        "normalize_path",
+        _helper_normalize_path(tmp_path),
+    )
+
+    result = runner.invoke(cli.cli, ["update", "local.csv"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Skipping non-import:" in result.output
+
+
+# =============================================================================
+# Dry run
+# =============================================================================
+
+
+def test_cli_update_dry_run(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--dry-run calls check_for_update, not update_import."""
+    pvt_data = _make_import_pvt(rev_lock="old11111old22")
+
+    monkeypatch.setattr(project, "get_project_root", _helper_get_project_root(tmp_path))
+    monkeypatch.setattr(
+        track,
+        "discover_import_pvt_files",
+        _helper_discover_imports({str(tmp_path / "data.csv"): pvt_data}),
+    )
+    monkeypatch.setattr(track, "get_pvt_path", _helper_get_pvt_path)
+
+    mock_check = AsyncMock(
+        return_value=UpdateCheck(
+            available=True,
+            current_rev="old11111old22222",
+            latest_rev="new33333new44444",
+        )
+    )
+    monkeypatch.setattr(import_artifact, "check_for_update", mock_check)
+
+    mock_update = AsyncMock()
+    monkeypatch.setattr(import_artifact, "update_import", mock_update)
+
+    result = runner.invoke(cli.cli, ["update", "--dry-run"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Update available:" in result.output
+    assert "old11111" in result.output
+    assert "new33333" in result.output
+    mock_check.assert_called_once_with(pvt_data)
+    mock_update.assert_not_called()
+
+
+# =============================================================================
+# No imports found
+# =============================================================================
+
+
+def test_cli_update_no_imports_found(
+    runner: CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """update with no imports shows 'No imports found' message."""
+    monkeypatch.setattr(project, "get_project_root", _helper_get_project_root(tmp_path))
+    monkeypatch.setattr(track, "discover_import_pvt_files", _helper_discover_imports({}))
+
+    result = runner.invoke(cli.cli, ["update"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "No imports found to update." in result.output

--- a/packages/pivot/tests/cli/test_import_cmd.py
+++ b/packages/pivot/tests/cli/test_import_cmd.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from pivot import cli
+from pivot.import_artifact import ImportResult
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+    from pytest_mock import MockerFixture
+
+
+# =============================================================================
+# Help
+# =============================================================================
+
+
+def test_cli_import_help_shows_usage(runner: CliRunner) -> None:
+    """import command shows help with correct arguments and options."""
+    result = runner.invoke(cli.cli, ["import", "--help"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "REPO_URL" in result.output
+    assert "PATH" in result.output
+    assert "--rev" in result.output
+    assert "--out" in result.output
+    assert "--force" in result.output
+    assert "--no-download" in result.output
+
+
+# =============================================================================
+# Success paths
+# =============================================================================
+
+
+def test_cli_import_success_downloaded(runner: CliRunner, mocker: MockerFixture) -> None:
+    """import command shows 'Imported' when artifact is downloaded."""
+    mock_import = AsyncMock(
+        return_value=ImportResult(
+            pvt_path="data/model.pkl.pvt",
+            data_path="data/model.pkl",
+            downloaded=True,
+        )
+    )
+    mocker.patch("pivot.import_artifact.import_artifact", mock_import)
+
+    result = runner.invoke(cli.cli, ["import", "https://github.com/org/repo", "data/model.pkl"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Imported data/model.pkl" in result.output
+    mock_import.assert_awaited_once_with(
+        "https://github.com/org/repo",
+        "data/model.pkl",
+        rev="main",
+        out=None,
+        force=False,
+        no_download=False,
+    )
+
+
+def test_cli_import_no_download(runner: CliRunner, mocker: MockerFixture) -> None:
+    """import --no-download shows metadata-only message."""
+    mock_import = AsyncMock(
+        return_value=ImportResult(
+            pvt_path="data/model.pkl.pvt",
+            data_path="data/model.pkl",
+            downloaded=False,
+        )
+    )
+    mocker.patch("pivot.import_artifact.import_artifact", mock_import)
+
+    result = runner.invoke(
+        cli.cli,
+        ["import", "https://github.com/org/repo", "data/model.pkl", "--no-download"],
+    )
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "metadata only" in result.output
+    assert "data/model.pkl.pvt" in result.output
+    mock_import.assert_awaited_once_with(
+        "https://github.com/org/repo",
+        "data/model.pkl",
+        rev="main",
+        out=None,
+        force=False,
+        no_download=True,
+    )
+
+
+def test_cli_import_with_options(runner: CliRunner, mocker: MockerFixture) -> None:
+    """import passes --rev, --out, --force correctly."""
+    mock_import = AsyncMock(
+        return_value=ImportResult(
+            pvt_path="output.pkl.pvt",
+            data_path="output.pkl",
+            downloaded=True,
+        )
+    )
+    mocker.patch("pivot.import_artifact.import_artifact", mock_import)
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "import",
+            "https://github.com/org/repo",
+            "data/model.pkl",
+            "--rev",
+            "v1.0",
+            "--out",
+            "output.pkl",
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    mock_import.assert_awaited_once_with(
+        "https://github.com/org/repo",
+        "data/model.pkl",
+        rev="v1.0",
+        out="output.pkl",
+        force=True,
+        no_download=False,
+    )
+
+
+# =============================================================================
+# Error paths
+# =============================================================================
+
+
+def test_cli_import_missing_args(runner: CliRunner) -> None:
+    """import with no arguments exits with error."""
+    result = runner.invoke(cli.cli, ["import"])
+    assert result.exit_code != 0, "Should fail without arguments"
+
+
+def test_cli_import_missing_path_arg(runner: CliRunner) -> None:
+    """import with only repo_url exits with error."""
+    result = runner.invoke(cli.cli, ["import", "https://github.com/org/repo"])
+    assert result.exit_code != 0, "Should fail without path argument"

--- a/packages/pivot/tests/conftest.py
+++ b/packages/pivot/tests/conftest.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingImports=false, reportImplicitRelativeImport=false
 from __future__ import annotations
 
 import contextlib
@@ -10,6 +11,7 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+import uuid
 from collections.abc import AsyncGenerator, Callable, Generator
 from typing import TYPE_CHECKING
 
@@ -30,6 +32,7 @@ if str(_tests_dir) not in sys.path:
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+    from types_aiobotocore_s3 import S3Client
 
     from pivot.engine.engine import Engine
     from pivot.engine.types import OutputEvent
@@ -90,6 +93,24 @@ def _get_cgroup_memory_limit_bytes() -> int | None:
 def tmp_pipeline_dir() -> Generator[pathlib.Path]:
     with tempfile.TemporaryDirectory() as tmpdir:
         yield pathlib.Path(tmpdir)
+
+
+@pytest.fixture
+async def moto_s3_bucket(
+    moto_patch_session: object, aioboto3_s3_client: S3Client
+) -> AsyncGenerator[str]:
+    """Create a test bucket in moto with unique name for xdist support.
+
+    Uses pytest-aioboto3's moto_patch_session to mock S3 and aioboto3_s3_client
+    to create the bucket. Bucket name includes a unique suffix to prevent
+    conflicts when running tests in parallel with pytest-xdist.
+
+    Yields:
+        str: The bucket name (e.g., "test-bucket-a1b2c3d4").
+    """
+    bucket_name = f"test-bucket-{uuid.uuid4().hex[:8]}"
+    await aioboto3_s3_client.create_bucket(Bucket=bucket_name)
+    yield bucket_name
 
 
 @pytest.fixture

--- a/packages/pivot/tests/remote/conftest.py
+++ b/packages/pivot/tests/remote/conftest.py
@@ -2,18 +2,10 @@
 
 from __future__ import annotations
 
-import uuid
-from typing import TYPE_CHECKING
-
 import pytest
 
 from pivot.cli import helpers as cli_helpers
 from pivot.remote import storage as remote_mod
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
-    from types_aiobotocore_s3 import S3Client
 
 
 @pytest.fixture(autouse=True)
@@ -28,24 +20,6 @@ def _mock_get_stage(monkeypatch: pytest.MonkeyPatch) -> None:
         return {"outs": []}
 
     monkeypatch.setattr(cli_helpers, "get_stage", _get_stage)
-
-
-@pytest.fixture
-async def moto_s3_bucket(
-    moto_patch_session: object, aioboto3_s3_client: S3Client
-) -> AsyncGenerator[str]:
-    """Create a test bucket in moto with unique name for xdist support.
-
-    Uses pytest-aioboto3's moto_patch_session to mock S3 and aioboto3_s3_client
-    to create the bucket. Bucket name includes a unique suffix to prevent
-    conflicts when running tests in parallel with pytest-xdist.
-
-    Yields:
-        str: The bucket name (e.g., "test-bucket-a1b2c3d4").
-    """
-    bucket_name = f"test-bucket-{uuid.uuid4().hex[:8]}"
-    await aioboto3_s3_client.create_bucket(Bucket=bucket_name)
-    yield bucket_name
 
 
 @pytest.fixture

--- a/packages/pivot/tests/remote/test_git_archive.py
+++ b/packages/pivot/tests/remote/test_git_archive.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import tarfile
+from typing import TYPE_CHECKING
+
+from pivot.remote import git_archive
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def _make_tar_bytes(files: dict[str, bytes]) -> bytes:
+    """Create an in-memory tar archive with the given files."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+# resolve_ref_from_remote_repo
+
+
+def test_resolve_ref_parses_ls_remote(mocker: MockerFixture) -> None:
+    """git ls-remote output is parsed to extract the commit SHA."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="abc123def456789012345678901234567890abcd\trefs/heads/main\n",
+        stderr="",
+    )
+
+    result = git_archive.resolve_ref_from_remote_repo("git@example.com:repo.git", "main")
+
+    assert result == "abc123def456789012345678901234567890abcd"
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    assert "ls-remote" in call_args[0][0]
+
+
+def test_resolve_ref_prefers_deref_sha_for_annotated_tags(mocker: MockerFixture) -> None:
+    """Annotated tags have both tag-object and deref ^{} lines; prefer the commit SHA."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=(
+            "aaaa0000000000000000000000000000aaaaaaaa\trefs/tags/v1.0\n"
+            "bbbb0000000000000000000000000000bbbbbbbb\trefs/tags/v1.0^{}\n"
+        ),
+        stderr="",
+    )
+
+    result = git_archive.resolve_ref_from_remote_repo("git@example.com:repo.git", "v1.0")
+
+    assert result == "bbbb0000000000000000000000000000bbbbbbbb", (
+        "Should return dereferenced commit SHA"
+    )
+
+
+def test_resolve_ref_lightweight_tag_no_deref(mocker: MockerFixture) -> None:
+    """Lightweight tags have no ^{} line; the single SHA is returned."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="cccc0000000000000000000000000000cccccccc\trefs/tags/v2.0\n",
+        stderr="",
+    )
+
+    result = git_archive.resolve_ref_from_remote_repo("git@example.com:repo.git", "v2.0")
+
+    assert result == "cccc0000000000000000000000000000cccccccc"
+
+
+def test_resolve_ref_branch_not_found(mocker: MockerFixture) -> None:
+    """Empty ls-remote output returns None when branch doesn't exist."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    result = git_archive.resolve_ref_from_remote_repo("git@example.com:repo.git", "nonexistent")
+
+    assert result is None
+
+
+def test_resolve_ref_repo_not_found(mocker: MockerFixture) -> None:
+    """CalledProcessError from ls-remote (e.g. repo not found) returns None."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=128,
+        stdout="",
+        stderr="fatal: repository 'https://example.com/no-repo.git' not found",
+    )
+
+    result = git_archive.resolve_ref_from_remote_repo("https://example.com/no-repo.git", "main")
+
+    assert result is None
+
+
+# read_file_from_remote_repo
+
+
+def test_read_file_extracts_tar(mocker: MockerFixture) -> None:
+    """File content is correctly extracted from git archive tar stream."""
+    tar_bytes = _make_tar_bytes({"pivot.yaml": b"stages:\n  train:\n"})
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=tar_bytes, stderr=b""
+    )
+
+    result = git_archive.read_file_from_remote_repo(
+        "git@example.com:repo.git", "pivot.yaml", "main"
+    )
+
+    assert result == b"stages:\n  train:\n"
+
+
+def test_read_file_path_not_found(mocker: MockerFixture) -> None:
+    """CalledProcessError from git archive (path not found) returns None."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.side_effect = subprocess.CalledProcessError(
+        returncode=128,
+        cmd=["git", "archive"],
+        stderr=b"fatal: path not found",
+    )
+
+    result = git_archive.read_file_from_remote_repo(
+        "git@example.com:repo.git", "nonexistent.yaml", "main"
+    )
+
+    assert result is None
+
+
+# list_directory_from_remote_repo
+
+
+def test_list_directory_returns_file_names(mocker: MockerFixture) -> None:
+    """Directory listing extracts file names from tar archive."""
+    tar_bytes = _make_tar_bytes(
+        {
+            "data/train.csv": b"a,b\n1,2",
+            "data/test.csv": b"a,b\n3,4",
+        }
+    )
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=tar_bytes, stderr=b""
+    )
+
+    result = git_archive.list_directory_from_remote_repo(
+        "git@example.com:repo.git", "data/", "main"
+    )
+
+    assert result is not None
+    assert sorted(result) == ["test.csv", "train.csv"]
+
+
+# timeout handling
+
+
+def test_git_archive_timeout_on_read(mocker: MockerFixture) -> None:
+    """TimeoutExpired during git archive returns None cleanly."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "archive"], timeout=30)
+
+    result = git_archive.read_file_from_remote_repo(
+        "git@example.com:repo.git", "pivot.yaml", "main", timeout=30
+    )
+
+    assert result is None
+
+
+def test_git_archive_timeout_on_resolve(mocker: MockerFixture) -> None:
+    """TimeoutExpired during git ls-remote returns None cleanly."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "ls-remote"], timeout=30)
+
+    result = git_archive.resolve_ref_from_remote_repo(
+        "git@example.com:repo.git", "main", timeout=30
+    )
+
+    assert result is None
+
+
+def test_git_archive_timeout_on_list(mocker: MockerFixture) -> None:
+    """TimeoutExpired during git archive list returns None cleanly."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "archive"], timeout=30)
+
+    result = git_archive.list_directory_from_remote_repo(
+        "git@example.com:repo.git", "data/", "main", timeout=30
+    )
+
+    assert result is None
+
+
+# git not found
+
+
+def test_resolve_ref_git_not_found(mocker: MockerFixture) -> None:
+    """FileNotFoundError (git not installed) returns None."""
+    mock_run = mocker.patch(
+        "pivot.remote.git_archive.subprocess.run",
+        autospec=True,
+    )
+    mock_run.side_effect = FileNotFoundError("git")
+
+    result = git_archive.resolve_ref_from_remote_repo("git@example.com:repo.git", "main")
+
+    assert result is None

--- a/packages/pivot/tests/remote/test_github.py
+++ b/packages/pivot/tests/remote/test_github.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot.remote import github
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+# parse_github_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param(
+            "https://github.com/org/repo",
+            ("org", "repo"),
+            id="https",
+        ),
+        pytest.param(
+            "https://github.com/org/repo.git",
+            ("org", "repo"),
+            id="https-git-suffix",
+        ),
+        pytest.param(
+            "git@github.com:org/repo.git",
+            ("org", "repo"),
+            id="ssh",
+        ),
+        pytest.param(
+            "https://github.com/org/repo/",
+            ("org", "repo"),
+            id="https-trailing-slash",
+        ),
+        pytest.param(
+            "http://github.com/org/repo",
+            ("org", "repo"),
+            id="http",
+        ),
+    ],
+)
+def test_parse_github_url(url: str, expected: tuple[str, str]) -> None:
+    """GitHub URL variants are parsed to (owner, repo) tuple."""
+    assert github.parse_github_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://gitlab.com/org/repo", id="gitlab"),
+        pytest.param("s3://bucket/path", id="s3"),
+        pytest.param("not-a-url", id="junk"),
+    ],
+)
+def test_parse_github_url_invalid_raises(url: str) -> None:
+    """Non-GitHub URLs raise ValueError."""
+    with pytest.raises(ValueError, match="Not a GitHub URL"):
+        github.parse_github_url(url)
+
+
+# is_github_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git",
+        "git@github.com:org/repo.git",
+    ],
+)
+def test_is_github_url_true(url: str) -> None:
+    """GitHub URLs are detected."""
+    assert github.is_github_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://gitlab.com/org/repo",
+        "s3://bucket/path",
+        "not-a-url",
+    ],
+)
+def test_is_github_url_false(url: str) -> None:
+    """Non-GitHub URLs are rejected."""
+    assert github.is_github_url(url) is False
+
+
+# get_token
+
+
+def test_get_token_from_gh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GH_TOKEN is preferred over GITHUB_TOKEN."""
+    monkeypatch.setenv("GH_TOKEN", "gh-tok")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-tok")
+    assert github.get_token() == "gh-tok"
+
+
+def test_get_token_from_github_token_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITHUB_TOKEN is used when GH_TOKEN is not set."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "github-tok")
+    assert github.get_token() == "github-tok"
+
+
+def test_get_token_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns None when no token env vars are set."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert github.get_token() is None
+
+
+# Helpers for mocking aiohttp
+
+
+def _mock_aiohttp_session(
+    mocker: MockerFixture,
+    status: int,
+    json_data: object = None,
+    read_data: bytes = b"",
+    text_data: str = "",
+    headers: dict[str, str] | None = None,
+) -> None:
+    mock_response = mocker.AsyncMock()
+    mock_response.status = status
+    mock_response.json = mocker.AsyncMock(return_value=json_data)
+    mock_response.read = mocker.AsyncMock(return_value=read_data)
+    mock_response.text = mocker.AsyncMock(return_value=text_data)
+    mock_response.headers = headers or {}
+    mock_response.__aenter__ = mocker.AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = mocker.AsyncMock(return_value=False)
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_session = mocker.AsyncMock()
+    mock_session.get = mocker.Mock(return_value=mock_response)
+    mock_session.__aenter__ = mocker.AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = mocker.AsyncMock(return_value=False)
+
+    mocker.patch("pivot.remote.github.aiohttp.ClientSession", return_value=mock_session)
+
+
+# read_file
+
+
+def test_read_file_success(mocker: MockerFixture) -> None:
+    """200 response with base64 content returns decoded bytes."""
+    content = b"hello world"
+    encoded = base64.b64encode(content).decode()
+    _mock_aiohttp_session(mocker, 200, json_data={"content": encoded})
+
+    result = asyncio.run(github.read_file("org", "repo", "path/file.txt", "main"))
+
+    assert result == content
+
+
+def test_read_file_not_found(mocker: MockerFixture) -> None:
+    """404 response returns None."""
+    _mock_aiohttp_session(mocker, 404)
+
+    result = asyncio.run(github.read_file("org", "repo", "missing.txt", "main"))
+
+    assert result is None
+
+
+def test_read_file_403_access_denied(mocker: MockerFixture) -> None:
+    """403 without rate limit indicators raises access denied error."""
+    _mock_aiohttp_session(mocker, 403, text_data="Forbidden", headers={})
+
+    with pytest.raises(Exception, match="access denied"):
+        asyncio.run(github.read_file("org", "repo", "file.txt", "main"))
+
+
+def test_read_file_403_rate_limit_via_header(mocker: MockerFixture) -> None:
+    """403 with X-RateLimit-Remaining: 0 raises rate limit error."""
+    _mock_aiohttp_session(mocker, 403, text_data="", headers={"X-RateLimit-Remaining": "0"})
+
+    with pytest.raises(Exception, match="[Rr]ate limit"):
+        asyncio.run(github.read_file("org", "repo", "file.txt", "main"))
+
+
+def test_read_file_403_secondary_rate_limit(mocker: MockerFixture) -> None:
+    """403 with 'abuse' in body raises secondary rate limit error."""
+    _mock_aiohttp_session(mocker, 403, text_data='{"message": "abuse detection"}')
+
+    with pytest.raises(Exception, match="secondary rate limit"):
+        asyncio.run(github.read_file("org", "repo", "file.txt", "main"))
+
+
+def test_read_file_rate_limited(mocker: MockerFixture) -> None:
+    """429 response raises RemoteError mentioning rate limit."""
+    _mock_aiohttp_session(mocker, 429)
+
+    with pytest.raises(Exception, match="[Rr]ate limit"):
+        asyncio.run(github.read_file("org", "repo", "file.txt", "main"))
+
+
+# resolve_ref
+
+
+def test_resolve_ref_success(mocker: MockerFixture) -> None:
+    """Commits API response returns SHA string."""
+    sha = "abc123def456789012345678901234567890abcd"
+    _mock_aiohttp_session(mocker, 200, json_data={"sha": sha})
+
+    result = asyncio.run(github.resolve_ref("org", "repo", "main"))
+
+    assert result == sha
+
+
+def test_resolve_ref_not_found(mocker: MockerFixture) -> None:
+    """404 response returns None."""
+    _mock_aiohttp_session(mocker, 404)
+
+    result = asyncio.run(github.resolve_ref("org", "repo", "nonexistent"))
+
+    assert result is None
+
+
+def test_resolve_ref_auth_error(mocker: MockerFixture) -> None:
+    """403 response raises RemoteError mentioning access denied."""
+    _mock_aiohttp_session(mocker, 403, text_data="Forbidden", headers={})
+
+    with pytest.raises(Exception, match="access denied"):
+        asyncio.run(github.resolve_ref("org", "repo", "main"))
+
+
+# list_directory
+
+
+def test_list_directory_success(mocker: MockerFixture) -> None:
+    """Contents API list response returns file names."""
+    _mock_aiohttp_session(
+        mocker,
+        200,
+        json_data=[
+            {"name": "train.csv", "type": "file"},
+            {"name": "test.csv", "type": "file"},
+            {"name": "subdir", "type": "dir"},
+        ],
+    )
+
+    result = asyncio.run(github.list_directory("org", "repo", "data", "main"))
+
+    assert result is not None
+    assert sorted(result) == ["subdir", "test.csv", "train.csv"]
+
+
+def test_list_directory_not_found(mocker: MockerFixture) -> None:
+    """404 response returns None."""
+    _mock_aiohttp_session(mocker, 404)
+
+    result = asyncio.run(github.list_directory("org", "repo", "missing", "main"))
+
+    assert result is None
+
+
+def test_list_directory_auth_error(mocker: MockerFixture) -> None:
+    """403 response raises RemoteError mentioning access denied."""
+    _mock_aiohttp_session(mocker, 403, text_data="Forbidden", headers={})
+
+    with pytest.raises(Exception, match="access denied"):
+        asyncio.run(github.list_directory("org", "repo", "data", "main"))

--- a/packages/pivot/tests/remote/test_s3_remote.py
+++ b/packages/pivot/tests/remote/test_s3_remote.py
@@ -398,7 +398,11 @@ async def test_s3_download_file_auth_error(
     tmp_path: pathlib.Path,
     mocker: MockerFixture,
 ) -> None:
-    """download_file raises RemoteConnectionError with friendly message for auth errors."""
+    """download_file raises RemoteError when auth fails during S3 get_object.
+
+    Note: _atomic_download catches the ClientError and wraps it as RemoteError
+    before download_file's auth-specific handler can run.
+    """
     mock_client = mocker.AsyncMock()
     error = botocore_exc.ClientError(
         {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}},
@@ -410,8 +414,8 @@ async def test_s3_download_file_auth_error(
     local_path = tmp_path / "downloaded.txt"
 
     with pytest.raises(
-        exceptions.RemoteConnectionError,
-        match="aws sso login",
+        exceptions.RemoteError,
+        match="Failed to download from S3",
     ):
         await s3_remote.download_file("abc123def4567890", local_path)
 
@@ -817,10 +821,14 @@ async def test_upload_file_multipart_aborts_on_error(
 async def test_download_file_cleans_up_on_error(
     s3_remote: remote_mod.S3Remote, tmp_path: pathlib.Path
 ) -> None:
-    """download_file cleans up temp file on error."""
+    """download_file cleans up temp file on error.
+
+    Note: _atomic_download catches the S3 NoSuchKey error and wraps it as
+    RemoteError before download_file's handler can run.
+    """
     dest_file = tmp_path / "dest.txt"
 
-    with pytest.raises(exceptions.RemoteConnectionError, match="S3 download error"):
+    with pytest.raises(exceptions.RemoteError, match="Remote cache file not found"):
         await s3_remote.download_file("abc123def4567890", dest_file)
 
     # Verify no temp files left behind

--- a/packages/pivot/tests/storage/test_track_import.py
+++ b/packages/pivot/tests/storage/test_track_import.py
@@ -1,0 +1,134 @@
+import pathlib
+
+from pivot.storage import track
+
+
+def test_pvt_import_source_roundtrip(tmp_path: pathlib.Path) -> None:
+    """PvtData with source writes/reads back identically."""
+    pvt_path = tmp_path / "data.csv.pvt"
+    data: track.PvtData = {
+        "path": "data.csv",
+        "hash": "abc123def456",
+        "size": 1024,
+        "source": track.ImportSource(
+            repo="https://github.com/example/repo",
+            rev="main",
+            rev_lock="abc123def456789",
+            stage="upstream_stage",
+            path="outputs/data.csv",
+            remote="s3://bucket/remote",
+        ),
+    }
+
+    track.write_pvt_file(pvt_path, data)
+    result = track.read_pvt_file(pvt_path)
+
+    assert result == data, "Source data should round-trip identically"
+
+
+def test_pvt_backward_compat(tmp_path: pathlib.Path) -> None:
+    """is_pvt_data() accepts dicts without source key."""
+    pvt_path = tmp_path / "data.csv.pvt"
+    data: track.PvtData = {
+        "path": "data.csv",
+        "hash": "abc123",
+        "size": 100,
+    }
+
+    track.write_pvt_file(pvt_path, data)
+    result = track.read_pvt_file(pvt_path)
+
+    assert result is not None, "Should read old-format PvtData without source"
+    assert "source" not in result, "Old format should not have source key"
+
+
+def test_is_import_true() -> None:
+    """is_import() returns True for pvt with source."""
+    data: track.PvtData = {
+        "path": "data.csv",
+        "hash": "abc123",
+        "size": 100,
+        "source": track.ImportSource(
+            repo="https://github.com/example/repo",
+            rev="main",
+            rev_lock="abc123",
+            stage="upstream",
+            path="data.csv",
+            remote="s3://bucket",
+        ),
+    }
+
+    assert track.is_import(data), "Should return True for PvtData with source"
+
+
+def test_is_import_false() -> None:
+    """is_import() returns False for pvt without source."""
+    data: track.PvtData = {
+        "path": "data.csv",
+        "hash": "abc123",
+        "size": 100,
+    }
+
+    assert not track.is_import(data), "Should return False for PvtData without source"
+
+
+def test_discover_import_pvt_files(tmp_path: pathlib.Path) -> None:
+    """discover_import_pvt_files() filters to imports only."""
+    # Create import file
+    track.write_pvt_file(
+        tmp_path / "imported.csv.pvt",
+        {
+            "path": "imported.csv",
+            "hash": "hash1",
+            "size": 100,
+            "source": track.ImportSource(
+                repo="https://github.com/example/repo",
+                rev="main",
+                rev_lock="abc123",
+                stage="upstream",
+                path="data.csv",
+                remote="s3://bucket",
+            ),
+        },
+    )
+    # Create non-import file
+    track.write_pvt_file(
+        tmp_path / "local.csv.pvt",
+        {
+            "path": "local.csv",
+            "hash": "hash2",
+            "size": 200,
+        },
+    )
+
+    result = track.discover_import_pvt_files(tmp_path)
+
+    assert len(result) == 1, "Should find only import files"
+    imported_path = str(tmp_path / "imported.csv")
+    assert imported_path in result, "Should include imported.csv"
+    assert "source" in result[imported_path], "Result should have source field"
+
+
+def test_pvt_source_with_non_string_values_rejected(tmp_path: pathlib.Path) -> None:
+    """is_pvt_data() rejects source dict where values are not strings."""
+    pvt_path = tmp_path / "bad_source.pvt"
+    content = (
+        "path: data.csv\nhash: abc123\nsize: 100\n"
+        + "source:\n  repo: https://example.com\n  rev: main\n"
+        + "  rev_lock: abc123\n  stage: 42\n  path: data.csv\n  remote: s3://bucket\n"
+    )
+    pvt_path.write_text(content)
+
+    result = track.read_pvt_file(pvt_path)
+
+    assert result is None, "Should reject source with non-string values"
+
+
+def test_pvt_with_unknown_keys_rejected(tmp_path: pathlib.Path) -> None:
+    """is_pvt_data() still rejects unknown keys."""
+    pvt_path = tmp_path / "invalid.pvt"
+    pvt_path.write_text("path: data.csv\nhash: abc123\nsize: 100\nunknown_key: value\n")
+
+    result = track.read_pvt_file(pvt_path)
+
+    assert result is None, "Should reject PvtData with unknown keys"

--- a/packages/pivot/tests/test_import_artifact.py
+++ b/packages/pivot/tests/test_import_artifact.py
@@ -1,0 +1,404 @@
+# pyright: reportMissingImports=false
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+import xxhash
+import yaml
+
+from pivot import exceptions, import_artifact
+from pivot.remote import storage as remote_mod
+from pivot.storage import track
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from types_aiobotocore_s3 import S3Client
+
+
+def _lock_bytes(*, outs: list[dict[str, object]]) -> bytes:
+    data = {
+        "code_manifest": {"stage": "hash"},
+        "params": {},
+        "deps": [],
+        "outs": outs,
+    }
+    return yaml.safe_dump(data).encode()
+
+
+def _config_bytes(remote_url: str) -> bytes:
+    data = {
+        "remotes": {"origin": remote_url},
+        "default_remote": "origin",
+    }
+    return yaml.safe_dump(data).encode()
+
+
+def test_resolve_remote_path_exact_file(mocker: MockerFixture) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = "s3://bucket/prefix"
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": "abc123",
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    resolved = asyncio.run(
+        import_artifact.resolve_remote_path(repo_url, "data/output.csv", "main", None)
+    )
+
+    assert resolved["stage"] == "train"
+    assert resolved["path"] == "data/output.csv"
+    assert resolved["hash"] == "abc123"
+    assert resolved["size"] == 0
+    assert resolved["remote_url"] == remote_url
+    assert resolved["rev_lock"] == "deadbeef"
+
+
+def test_resolve_remote_path_ambiguous(mocker: MockerFixture) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = "s3://bucket/prefix"
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": "abc123",
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock", "eval.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path in {".pivot/stages/train.lock", ".pivot/stages/eval.lock"}:
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    with pytest.raises(exceptions.PivotError, match="train"):
+        asyncio.run(import_artifact.resolve_remote_path(repo_url, "data/output.csv", "main", None))
+
+
+def test_resolve_remote_path_not_found(mocker: MockerFixture) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = "s3://bucket/prefix"
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": "abc123",
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    with pytest.raises(exceptions.PivotError, match="Available outputs"):
+        asyncio.run(import_artifact.resolve_remote_path(repo_url, "data/missing.csv", "main", None))
+
+
+def test_read_remote_config_success(mocker: MockerFixture) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = "s3://bucket/prefix"
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.return_value = _config_bytes(remote_url)
+
+    result = asyncio.run(import_artifact.read_remote_config(repo_url, "main", None))
+
+    assert result == remote_url
+
+
+async def test_import_artifact_creates_pvt(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = f"s3://{moto_s3_bucket}/test-prefix/"
+    content = b"hello"
+    file_hash = xxhash.xxh64(content).hexdigest()
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": file_hash,
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    key = remote_mod._hash_to_key("test-prefix/", file_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key, Body=content)
+
+    mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        return_value=remote_mod.S3Remote(remote_url),
+    )
+
+    result = await import_artifact.import_artifact(
+        repo_url,
+        "data/output.csv",
+        rev="main",
+        project_root=tmp_path,
+    )
+
+    data_path = tmp_path / "data" / "output.csv"
+    pvt_path = track.get_pvt_path(data_path)
+    assert pathlib.Path(result["data_path"]) == data_path
+    assert pathlib.Path(result["pvt_path"]) == pvt_path
+    assert result["downloaded"] is True
+    assert data_path.read_bytes() == content
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert pvt_data["hash"] == file_hash
+    assert "source" in pvt_data
+    assert pvt_data["source"]["remote"] == remote_url
+    assert pvt_data["size"] == len(content), "Size should come from downloaded file"
+
+
+def test_import_artifact_no_download(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = "s3://bucket/prefix"
+    content = b"hello"
+    file_hash = xxhash.xxh64(content).hexdigest()
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": file_hash,
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        side_effect=AssertionError("S3Remote should not be instantiated"),
+    )
+
+    result = asyncio.run(
+        import_artifact.import_artifact(
+            repo_url,
+            "data/output.csv",
+            rev="main",
+            project_root=tmp_path,
+            no_download=True,
+        )
+    )
+
+    data_path = tmp_path / "data" / "output.csv"
+    pvt_path = track.get_pvt_path(data_path)
+    assert pathlib.Path(result["data_path"]) == data_path
+    assert pathlib.Path(result["pvt_path"]) == pvt_path
+    assert result["downloaded"] is False
+    assert not data_path.exists()
+    assert pvt_path.exists()
+
+
+async def test_import_artifact_force_overwrites(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+) -> None:
+    repo_url = "https://github.com/org/repo"
+    remote_url = f"s3://{moto_s3_bucket}/test-prefix/"
+    content = b"new"
+    file_hash = xxhash.xxh64(content).hexdigest()
+    lock_bytes = _lock_bytes(
+        outs=[
+            {
+                "path": "data/output.csv",
+                "hash": file_hash,
+            }
+        ]
+    )
+
+    list_directory = mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+    )
+    list_directory.return_value = ["train.lock"]
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "deadbeef"
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+    )
+    read_file.side_effect = _read_file
+
+    key = remote_mod._hash_to_key("test-prefix/", file_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key, Body=content)
+
+    mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        return_value=remote_mod.S3Remote(remote_url),
+    )
+
+    data_path = tmp_path / "data" / "output.csv"
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path.write_text("old")
+    track.write_pvt_file(
+        track.get_pvt_path(data_path),
+        track.PvtData(path="output.csv", hash="old", size=3),
+    )
+
+    result = await import_artifact.import_artifact(
+        repo_url,
+        "data/output.csv",
+        rev="main",
+        project_root=tmp_path,
+        force=True,
+    )
+
+    assert pathlib.Path(result["data_path"]) == data_path
+    assert data_path.read_bytes() == content
+    pvt_path = track.get_pvt_path(data_path)
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert pvt_data["hash"] == file_hash
+    assert pvt_data["size"] == len(content), "Size should come from downloaded file"

--- a/packages/pivot/tests/test_import_integration.py
+++ b/packages/pivot/tests/test_import_integration.py
@@ -1,0 +1,589 @@
+# pyright: reportMissingImports=false
+"""Integration tests for cross-repo import: DAG recognition, discovery, roundtrip, full flow."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import xxhash
+import yaml
+
+import conftest
+from pivot import exceptions, import_artifact, loaders, outputs
+from pivot.remote import storage as remote_mod
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from types_aiobotocore_s3 import S3Client
+from pivot.engine import graph
+from pivot.registry import RegistryStageInfo
+from pivot.storage import track
+
+
+def _create_stage(name: str, deps: list[str], outs: list[str]) -> RegistryStageInfo:
+    """Create a minimal RegistryStageInfo for graph tests."""
+    return RegistryStageInfo(
+        func=lambda: None,
+        name=name,
+        deps={f"_{i}": d for i, d in enumerate(deps)},
+        deps_paths=deps,
+        outs=[
+            outputs.require_expanded(outputs.Out(path=out, loader=loaders.PathOnly()))
+            for out in outs
+        ],
+        outs_paths=outs,
+        params=None,
+        mutex=list[str](),
+        variant=None,
+        signature=None,
+        fingerprint=dict[str, str](),
+        dep_specs={},
+        out_specs=dict[str, outputs.BaseOut](),
+        params_arg_name=None,
+        state_dir=None,
+    )
+
+
+def _make_import_source(
+    *,
+    repo: str = "https://github.com/org/upstream",
+    rev: str = "main",
+    rev_lock: str = "abc123deadbeef",
+    stage: str = "train",
+    path: str = "data/output.csv",
+    remote: str = "s3://bucket/prefix",
+) -> track.ImportSource:
+    return track.ImportSource(
+        repo=repo, rev=rev, rev_lock=rev_lock, stage=stage, path=path, remote=remote
+    )
+
+
+def _lock_bytes(*, outs: list[dict[str, object]]) -> bytes:
+    data = {
+        "code_manifest": {"stage": "hash"},
+        "params": {},
+        "deps": [],
+        "outs": outs,
+    }
+    return yaml.safe_dump(data).encode()
+
+
+def _config_bytes(remote_url: str) -> bytes:
+    data = {
+        "remotes": {"origin": remote_url},
+        "default_remote": "origin",
+    }
+    return yaml.safe_dump(data).encode()
+
+
+# --- Test 1: Import .pvt files recognized as DAG dependencies ---
+
+
+def test_import_pvt_recognized_as_dag_dep(tmp_path: pathlib.Path) -> None:
+    """Imported .pvt file is accepted as a valid dependency in the DAG (validate=True)."""
+    imported_data = tmp_path / "imported_data.csv"
+    output_file = tmp_path / "result.csv"
+
+    # Build tracked_files dict as discover_pvt_files would produce it,
+    # including an ImportSource to prove imports work identically to regular tracked files.
+    tracked_files: dict[str, track.PvtData] = {
+        str(imported_data): track.PvtData(
+            path="imported_data.csv",
+            hash="abc123",
+            size=1024,
+            source=_make_import_source(path="data/imported_data.csv"),
+        )
+    }
+
+    stages = {
+        "consumer": _create_stage("consumer", [str(imported_data)], [str(output_file)]),
+    }
+
+    # With validate=True, a missing dep that isn't in tracked_files would raise.
+    # This must NOT raise because the import .pvt is in tracked_files.
+    g = graph.build_graph(stages, validate=True, tracked_files=tracked_files)
+
+    assert "stage:consumer" in g, "Consumer stage should be in the graph"
+    assert graph.artifact_node(imported_data) in g, "Imported artifact should be a graph node"
+
+
+def test_import_pvt_missing_from_tracked_raises(tmp_path: pathlib.Path) -> None:
+    """Without tracked_files entry, a missing imported dep raises on validate."""
+    missing_dep = tmp_path / "not_tracked.csv"
+    output_file = tmp_path / "result.csv"
+
+    stages = {
+        "consumer": _create_stage("consumer", [str(missing_dep)], [str(output_file)]),
+    }
+
+    with pytest.raises(exceptions.DependencyNotFoundError):
+        graph.build_graph(stages, validate=True)
+
+
+def test_import_pvt_chain_through_dag(tmp_path: pathlib.Path) -> None:
+    """Import dep feeds into a stage whose output feeds into another — full chain works."""
+    imported = tmp_path / "external.csv"
+    intermediate = tmp_path / "cleaned.csv"
+    final = tmp_path / "model.pkl"
+
+    tracked_files: dict[str, track.PvtData] = {
+        str(imported): track.PvtData(
+            path="external.csv",
+            hash="aaa",
+            size=100,
+            source=_make_import_source(),
+        )
+    }
+
+    stages = {
+        "clean": _create_stage("clean", [str(imported)], [str(intermediate)]),
+        "train": _create_stage("train", [str(intermediate)], [str(final)]),
+    }
+
+    g = graph.build_graph(stages, validate=True, tracked_files=tracked_files)
+    stage_dag = graph.get_stage_dag(g)
+
+    # train depends on clean
+    assert stage_dag.has_edge("train", "clean"), "Train should depend on clean"
+    # Execution order should be clean -> train
+    order = graph.get_execution_order(stage_dag)
+    assert order.index("clean") < order.index("train")
+
+
+# --- Test 2: discover_import_pvt_files end-to-end ---
+
+
+@pytest.mark.usefixtures("set_project_root")
+def test_discover_import_pvt_files_end_to_end(tmp_path: pathlib.Path) -> None:
+    """discover_import_pvt_files finds only .pvt files with source (imports)."""
+    # Create an import .pvt file
+    track.write_pvt_file(
+        tmp_path / "imported.csv.pvt",
+        track.PvtData(
+            path="imported.csv",
+            hash="hash_imported",
+            size=500,
+            source=_make_import_source(path="data/imported.csv"),
+        ),
+    )
+
+    # Create a second import in a subdirectory
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    track.write_pvt_file(
+        subdir / "model.pkl.pvt",
+        track.PvtData(
+            path="model.pkl",
+            hash="hash_model",
+            size=2000,
+            source=_make_import_source(stage="eval", path="models/model.pkl"),
+        ),
+    )
+
+    # Create a non-import (tracked-only) .pvt file
+    track.write_pvt_file(
+        tmp_path / "local.csv.pvt",
+        track.PvtData(path="local.csv", hash="hash_local", size=100),
+    )
+
+    # Create another non-import .pvt
+    track.write_pvt_file(
+        tmp_path / "another.csv.pvt",
+        track.PvtData(path="another.csv", hash="hash_another", size=200),
+    )
+
+    result = track.discover_import_pvt_files(tmp_path)
+
+    assert len(result) == 2, f"Expected 2 import files, got {len(result)}: {list(result.keys())}"
+    # Verify all results have source
+    for path, pvt_data in result.items():
+        assert "source" in pvt_data, f"Import pvt at {path} should have source"
+        assert track.is_import(pvt_data), f"Import pvt at {path} should pass is_import()"
+
+
+# --- Test 3: Import .pvt roundtrip (write + read) ---
+
+
+def test_import_pvt_roundtrip(tmp_path: pathlib.Path) -> None:
+    """PvtData with ImportSource writes to disk and reads back identically."""
+    pvt_path = tmp_path / "data.csv.pvt"
+    source = _make_import_source(
+        repo="https://github.com/org/upstream",
+        rev="v2.0",
+        rev_lock="deadbeef12345678",
+        stage="preprocess",
+        path="outputs/data.csv",
+        remote="s3://my-bucket/cache",
+    )
+    original = track.PvtData(
+        path="data.csv",
+        hash="xxhash_value_here",
+        size=4096,
+        source=source,
+    )
+
+    track.write_pvt_file(pvt_path, original)
+    loaded = track.read_pvt_file(pvt_path)
+
+    assert loaded is not None, "Should successfully read back the .pvt file"
+    assert loaded["path"] == original["path"]
+    assert loaded["hash"] == original["hash"]
+    assert loaded["size"] == original["size"]
+    assert "source" in loaded, "Loaded data should contain source"
+
+    loaded_source = loaded["source"]
+    assert loaded_source["repo"] == source["repo"]
+    assert loaded_source["rev"] == source["rev"]
+    assert loaded_source["rev_lock"] == source["rev_lock"]
+    assert loaded_source["stage"] == source["stage"]
+    assert loaded_source["path"] == source["path"]
+    assert loaded_source["remote"] == source["remote"]
+
+    assert track.is_import(loaded), "Roundtripped data should pass is_import()"
+
+
+# --- Test 4: Import from real local git repo (no mocks of git/resolve) ---
+
+
+def _setup_source_repo(
+    source_dir: pathlib.Path,
+    remote_url: str,
+    stage_name: str,
+    outs: list[dict[str, object]],
+) -> str:
+    """Create a git repo with .pivot/ config and lock file committed. Returns HEAD SHA."""
+    source_dir.mkdir(exist_ok=True)
+    conftest.init_git_repo(source_dir)
+    # git archive --remote with SHAs requires this for local repos
+    subprocess.run(
+        ["git", "config", "uploadArchive.allowUnreachable", "true"],
+        cwd=source_dir,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=source_dir,
+        check=False,
+        capture_output=True,
+    )
+
+    pivot_dir = source_dir / ".pivot"
+    pivot_dir.mkdir()
+    (pivot_dir / "stages").mkdir()
+
+    config = {"remotes": {"origin": remote_url}}
+    (pivot_dir / "config.yaml").write_text(yaml.safe_dump(config))
+
+    lock_data = {
+        "schema_version": 1,
+        "code_manifest": {"self:run": "abcdef1234567890"},
+        "params": {},
+        "deps": [],
+        "outs": outs,
+    }
+    (pivot_dir / "stages" / f"{stage_name}.lock").write_text(yaml.safe_dump(lock_data))
+
+    subprocess.run(["git", "add", "."], cwd=source_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=source_dir,
+        check=True,
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+async def test_import_from_local_git_repo(
+    tmp_path: pathlib.Path,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+    mocker: MockerFixture,
+) -> None:
+    """Import an artifact from a real local git repo with moto S3 — no GitHub API mocks."""
+    content = b"real csv data\ncol1,col2\n1,2\n3,4\n"
+    file_hash = xxhash.xxh64(content).hexdigest()
+
+    remote_url = f"s3://{moto_s3_bucket}/cache/"
+    source_dir = tmp_path / "source_repo"
+    consumer_dir = tmp_path / "consumer"
+    consumer_dir.mkdir()
+
+    head_sha = _setup_source_repo(
+        source_dir,
+        remote_url,
+        "prepare",
+        [{"path": "data/output.csv", "hash": file_hash}],
+    )
+
+    key = remote_mod._hash_to_key("cache/", file_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key, Body=content)
+
+    result = await import_artifact.import_artifact(
+        str(source_dir),
+        "data/output.csv",
+        rev="main",
+        project_root=consumer_dir,
+    )
+
+    data_path = pathlib.Path(result["data_path"])
+    assert data_path.read_bytes() == content, "Downloaded content should match"
+
+    pvt_path = pathlib.Path(result["pvt_path"])
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert pvt_data["hash"] == file_hash
+    assert pvt_data["size"] == len(content), "Size should come from actual downloaded file"
+    assert "source" in pvt_data
+    source = pvt_data["source"]
+    assert source["repo"] == str(source_dir)
+    assert source["rev"] == "main"
+    assert source["rev_lock"] == head_sha, "rev_lock should be resolved HEAD SHA"
+    assert source["stage"] == "prepare"
+    assert source["path"] == "data/output.csv"
+    assert source["remote"] == remote_url
+
+
+async def test_import_from_local_repo_then_update(
+    tmp_path: pathlib.Path,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+    mocker: MockerFixture,
+) -> None:
+    """Import, then update after source repo gets a new commit with changed output."""
+    v1_content = b"version one"
+    v1_hash = xxhash.xxh64(v1_content).hexdigest()
+    v2_content = b"version two with more data"
+    v2_hash = xxhash.xxh64(v2_content).hexdigest()
+
+    remote_url = f"s3://{moto_s3_bucket}/cache/"
+    source_dir = tmp_path / "source_repo"
+    consumer_dir = tmp_path / "consumer"
+    consumer_dir.mkdir()
+
+    _setup_source_repo(
+        source_dir,
+        remote_url,
+        "train",
+        [{"path": "models/weights.bin", "hash": v1_hash}],
+    )
+
+    key_v1 = remote_mod._hash_to_key("cache/", v1_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key_v1, Body=v1_content)
+
+    result = await import_artifact.import_artifact(
+        str(source_dir),
+        "models/weights.bin",
+        rev="main",
+        project_root=consumer_dir,
+    )
+
+    data_path = pathlib.Path(result["data_path"])
+    pvt_path = pathlib.Path(result["pvt_path"])
+    assert data_path.read_bytes() == v1_content
+
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    old_rev = pvt_data["source"]["rev_lock"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+    lock_v2 = {
+        "schema_version": 1,
+        "code_manifest": {"self:run": "abcdef1234567890"},
+        "params": {},
+        "deps": [],
+        "outs": [{"path": "models/weights.bin", "hash": v2_hash}],
+    }
+    (source_dir / ".pivot" / "stages" / "train.lock").write_text(yaml.safe_dump(lock_v2))
+    subprocess.run(["git", "add", "."], cwd=source_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "update output"],
+        cwd=source_dir,
+        check=True,
+        capture_output=True,
+    )
+
+    key_v2 = remote_mod._hash_to_key("cache/", v2_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key_v2, Body=v2_content)
+
+    check = await import_artifact.check_for_update(pvt_data)
+    assert check["available"] is True, "Should detect update after new commit"
+
+    update_result = await import_artifact.update_import(pvt_path)
+    assert update_result["downloaded"] is True
+    assert update_result["old_rev"] == old_rev
+    assert data_path.read_bytes() == v2_content
+
+    updated_pvt = track.read_pvt_file(pvt_path)
+    assert updated_pvt is not None
+    assert updated_pvt["hash"] == v2_hash
+    assert updated_pvt["size"] == len(v2_content), "Size should reflect v2 file"
+
+
+async def test_import_from_local_repo_not_found_path(
+    tmp_path: pathlib.Path,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+    mocker: MockerFixture,
+) -> None:
+    """Importing a path that doesn't exist in any stage lock file raises PivotError."""
+    content = b"data"
+    file_hash = xxhash.xxh64(content).hexdigest()
+
+    remote_url = f"s3://{moto_s3_bucket}/cache/"
+    source_dir = tmp_path / "source_repo"
+    consumer_dir = tmp_path / "consumer"
+    consumer_dir.mkdir()
+
+    _setup_source_repo(
+        source_dir,
+        remote_url,
+        "train",
+        [{"path": "data/output.csv", "hash": file_hash}],
+    )
+
+    with pytest.raises(exceptions.PivotError, match="not found in remote outputs"):
+        await import_artifact.import_artifact(
+            str(source_dir),
+            "data/nonexistent.csv",
+            rev="main",
+            project_root=consumer_dir,
+        )
+
+
+# --- Test 5: Full import -> check_for_update -> update_import flow (mocked GitHub) ---
+
+
+async def test_full_import_flow_mocked(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+) -> None:
+    """End-to-end: import_artifact -> check_for_update -> update_import with mocked network."""
+    repo_url = "https://github.com/org/upstream"
+    remote_url = f"s3://{moto_s3_bucket}/test-prefix/"
+    initial_content = b"initial data"
+    initial_hash = xxhash.xxh64(initial_content).hexdigest()
+    updated_content = b"updated data with more stuff"
+    updated_hash = xxhash.xxh64(updated_content).hexdigest()
+
+    # --- Step 1: import_artifact ---
+
+    lock_bytes_v1 = _lock_bytes(outs=[{"path": "data/output.csv", "hash": initial_hash}])
+
+    mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+        return_value=["train.lock"],
+    )
+    resolve_ref_mock = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+        return_value="sha_v1",
+    )
+
+    call_count = 0
+
+    async def _read_file_v1(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes_v1
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file_mock = mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+        side_effect=_read_file_v1,
+    )
+
+    key_v1 = remote_mod._hash_to_key("test-prefix/", initial_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key_v1, Body=initial_content)
+
+    s3_cls = mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        return_value=remote_mod.S3Remote(remote_url),
+    )
+
+    result = await import_artifact.import_artifact(
+        repo_url, "data/output.csv", rev="main", project_root=tmp_path
+    )
+
+    data_path = pathlib.Path(result["data_path"])
+    pvt_path = pathlib.Path(result["pvt_path"])
+    assert result["downloaded"] is True
+    assert data_path.read_bytes() == initial_content
+
+    pvt_data = track.read_pvt_file(pvt_path)
+    assert pvt_data is not None
+    assert pvt_data["hash"] == initial_hash
+    assert pvt_data["source"]["rev_lock"] == "sha_v1"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert pvt_data["size"] == len(initial_content), "Size should come from downloaded file"
+
+    # --- Step 2: check_for_update (no change) ---
+
+    resolve_ref_mock.return_value = "sha_v1"
+
+    check = await import_artifact.check_for_update(pvt_data)
+
+    assert check["available"] is False, "No update when rev_lock matches"
+
+    # --- Step 3: check_for_update (new commit available) ---
+
+    resolve_ref_mock.return_value = "sha_v2"
+
+    check = await import_artifact.check_for_update(pvt_data)
+
+    assert check["available"] is True, "Update available when rev_lock differs"
+    assert check["current_rev"] == "sha_v1"
+    assert check["latest_rev"] == "sha_v2"
+
+    # --- Step 4: update_import ---
+
+    lock_bytes_v2 = _lock_bytes(outs=[{"path": "data/output.csv", "hash": updated_hash}])
+
+    async def _read_file_v2(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes_v2
+        raise AssertionError(f"Unexpected path: {path}")
+
+    read_file_mock.side_effect = _read_file_v2
+
+    key_v2 = remote_mod._hash_to_key("test-prefix/", updated_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key_v2, Body=updated_content)
+
+    s3_cls.return_value = remote_mod.S3Remote(remote_url)
+
+    update_result = await import_artifact.update_import(pvt_path)
+
+    assert update_result["downloaded"] is True, "Should mark downloaded when hash changed"
+    assert update_result["old_rev"] == "sha_v1"
+    assert update_result["new_rev"] == "sha_v2"
+    assert data_path.read_bytes() == updated_content
+
+    # Verify .pvt file is updated
+    updated_pvt = track.read_pvt_file(pvt_path)
+    assert updated_pvt is not None
+    assert updated_pvt["hash"] == updated_hash
+    assert updated_pvt["source"]["rev_lock"] == "sha_v2"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert updated_pvt["source"]["repo"] == repo_url  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert updated_pvt["size"] == len(updated_content), "Size should come from downloaded file"

--- a/packages/pivot/tests/test_status_import.py
+++ b/packages/pivot/tests/test_status_import.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+from conftest import isolated_pivot_dir
+from pivot import cli, import_artifact, status
+from pivot.status import ImportCheckStatus
+from pivot.storage import track
+
+if TYPE_CHECKING:
+    import click.testing
+    from pytest_mock import MockerFixture
+
+
+# =============================================================================
+# Unit Tests: get_import_status
+# =============================================================================
+
+
+def test_status_import_update_available(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Import with available update should report update available."""
+    pvt_data = track.PvtData(
+        path="model.pkl",
+        hash="aaa",
+        size=100,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123def456",
+            stage="train",
+            path="models/model.pkl",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(tmp_path / "models" / "model.pkl"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(
+            return_value=import_artifact.UpdateCheck(
+                available=True,
+                current_rev="abc123def456",
+                latest_rev="def456abc789",
+            )
+        ),
+    )
+
+    results = status.get_import_status(tmp_path)
+
+    assert len(results) == 1, "Should have one import result"
+    assert results[0].status is ImportCheckStatus.UPDATE_AVAILABLE
+    assert results[0].current_rev == "abc123de"
+    assert results[0].latest_rev == "def456ab"
+
+
+def test_status_import_up_to_date(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Import with no available update should report up to date."""
+    pvt_data = track.PvtData(
+        path="data.csv",
+        hash="bbb",
+        size=200,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123def456",
+            stage="prepare",
+            path="data/train.csv",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(tmp_path / "data" / "train.csv"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(
+            return_value=import_artifact.UpdateCheck(
+                available=False,
+                current_rev="abc123def456",
+                latest_rev="abc123def456",
+            )
+        ),
+    )
+
+    results = status.get_import_status(tmp_path)
+
+    assert len(results) == 1, "Should have one import result"
+    assert results[0].status is ImportCheckStatus.UP_TO_DATE
+
+
+def test_status_import_network_error(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    """Network failure should produce error status, not raise."""
+    pvt_data = track.PvtData(
+        path="model.pkl",
+        hash="ccc",
+        size=300,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123def456",
+            stage="train",
+            path="models/model.pkl",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(tmp_path / "models" / "model.pkl"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(side_effect=ConnectionError("Network unreachable")),
+    )
+
+    results = status.get_import_status(tmp_path)
+
+    assert len(results) == 1, "Should have one import result"
+    assert results[0].status is ImportCheckStatus.ERROR
+    assert "Network unreachable" in results[0].error
+
+
+# =============================================================================
+# CLI Tests: --check-imports flag
+# =============================================================================
+
+
+def test_status_no_flag_no_api(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """Without --check-imports flag, check_for_update is never called."""
+    check_mock = mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(),
+    )
+    # Also mock discover to ensure it's not even called
+    discover_mock = mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={},
+    )
+
+    with isolated_pivot_dir(runner, tmp_path):
+        pathlib.Path("pipeline.py").write_text("""\
+from __future__ import annotations
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline('test')
+""")
+        result = runner.invoke(cli.cli, ["status"])
+
+    assert result.exit_code == 0
+    check_mock.assert_not_called()
+    discover_mock.assert_not_called()
+
+
+def test_status_check_imports_shows_update(
+    runner: click.testing.CliRunner,
+    mock_discovery: object,
+    mocker: MockerFixture,
+) -> None:
+    """With --check-imports, shows import status section with update available."""
+    from pivot import project
+
+    project_root = project.get_project_root()
+    pvt_data = track.PvtData(
+        path="model.pkl",
+        hash="aaa",
+        size=100,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123de",
+            stage="train",
+            path="models/model.pkl",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(project_root / "models" / "model.pkl"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(
+            return_value=import_artifact.UpdateCheck(
+                available=True,
+                current_rev="abc123de",
+                latest_rev="def456ab",
+            )
+        ),
+    )
+
+    result = runner.invoke(cli.cli, ["status", "--check-imports"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    assert "Imports" in result.output
+    assert "update available" in result.output
+    assert "abc123de" in result.output
+    assert "def456ab" in result.output
+
+
+def test_status_check_imports_shows_up_to_date(
+    runner: click.testing.CliRunner,
+    mock_discovery: object,
+    mocker: MockerFixture,
+) -> None:
+    """With --check-imports, shows up to date imports."""
+    from pivot import project
+
+    project_root = project.get_project_root()
+    pvt_data = track.PvtData(
+        path="data.csv",
+        hash="bbb",
+        size=200,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123def456",
+            stage="prepare",
+            path="data/train.csv",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(project_root / "data" / "train.csv"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(
+            return_value=import_artifact.UpdateCheck(
+                available=False,
+                current_rev="abc123def456",
+                latest_rev="abc123def456",
+            )
+        ),
+    )
+
+    result = runner.invoke(cli.cli, ["status", "--check-imports"])
+
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+    assert "Imports" in result.output
+    assert "up to date" in result.output
+
+
+def test_status_check_imports_network_error_doesnt_fail(
+    runner: click.testing.CliRunner,
+    mock_discovery: object,
+    mocker: MockerFixture,
+) -> None:
+    """Network error during import check shows warning but command succeeds."""
+    from pivot import project
+
+    project_root = project.get_project_root()
+    pvt_data = track.PvtData(
+        path="model.pkl",
+        hash="ccc",
+        size=300,
+        source=track.ImportSource(
+            repo="https://github.com/org/repo",
+            rev="main",
+            rev_lock="abc123def456",
+            stage="train",
+            path="models/model.pkl",
+            remote="s3://bucket/cache",
+        ),
+    )
+    mocker.patch.object(
+        track,
+        "discover_import_pvt_files",
+        autospec=True,
+        return_value={str(project_root / "models" / "model.pkl"): pvt_data},
+    )
+    mocker.patch.object(
+        import_artifact,
+        "check_for_update",
+        new=AsyncMock(side_effect=ConnectionError("Network unreachable")),
+    )
+
+    result = runner.invoke(cli.cli, ["status", "--check-imports"])
+
+    assert result.exit_code == 0, f"Should succeed despite network error: {result.output}"
+    assert "Imports" in result.output
+    assert "check failed" in result.output

--- a/packages/pivot/tests/test_update_import.py
+++ b/packages/pivot/tests/test_update_import.py
@@ -1,0 +1,310 @@
+# pyright: reportMissingImports=false
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+import xxhash
+import yaml
+
+from pivot import exceptions, import_artifact
+from pivot.remote import storage as remote_mod
+from pivot.storage import track
+
+if TYPE_CHECKING:
+    import pathlib
+
+    from pytest_mock import MockerFixture
+    from types_aiobotocore_s3 import S3Client
+
+
+def _lock_bytes(*, outs: list[dict[str, object]]) -> bytes:
+    data = {
+        "code_manifest": {"stage": "hash"},
+        "params": {},
+        "deps": [],
+        "outs": outs,
+    }
+    return yaml.safe_dump(data).encode()
+
+
+def _config_bytes(remote_url: str) -> bytes:
+    data = {
+        "remotes": {"origin": remote_url},
+        "default_remote": "origin",
+    }
+    return yaml.safe_dump(data).encode()
+
+
+def _make_pvt_data(
+    *,
+    path: str = "output.csv",
+    hash: str = "aaa111",
+    size: int = 5,
+    repo: str = "https://github.com/org/repo",
+    rev: str = "main",
+    rev_lock: str = "oldsha",
+    stage: str = "train",
+    source_path: str = "data/output.csv",
+    remote: str = "s3://bucket/prefix",
+) -> track.PvtData:
+    source = track.ImportSource(
+        repo=repo,
+        rev=rev,
+        rev_lock=rev_lock,
+        stage=stage,
+        path=source_path,
+        remote=remote,
+    )
+    return track.PvtData(path=path, hash=hash, size=size, source=source)
+
+
+# ── check_for_update ──────────────────────────────────────────
+
+
+def test_check_for_update_detects_new_commit(mocker: MockerFixture) -> None:
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "newsha999"
+
+    pvt_data = _make_pvt_data(rev_lock="oldsha111")
+
+    result = asyncio.run(import_artifact.check_for_update(pvt_data))
+
+    assert result["available"] is True, "Should detect update when SHAs differ"
+    assert result["current_rev"] == "oldsha111"
+    assert result["latest_rev"] == "newsha999"
+
+
+def test_check_for_update_no_change(mocker: MockerFixture) -> None:
+    resolve_ref = mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+    )
+    resolve_ref.return_value = "samesha"
+
+    pvt_data = _make_pvt_data(rev_lock="samesha")
+
+    result = asyncio.run(import_artifact.check_for_update(pvt_data))
+
+    assert result["available"] is False, "Should not detect update when SHAs match"
+    assert result["current_rev"] == "samesha"
+    assert result["latest_rev"] == "samesha"
+
+
+# ── update_import ─────────────────────────────────────────────
+
+
+def _setup_resolve_mocks(
+    mocker: MockerFixture,
+    *,
+    remote_url: str,
+    lock_outs: list[dict[str, object]],
+    rev_lock: str = "newsha",
+) -> None:
+    """Set up standard mocks for resolve_remote_path used by update_import."""
+    lock_bytes = _lock_bytes(outs=lock_outs)
+
+    mocker.patch(
+        "pivot.import_artifact.github.list_directory",
+        autospec=True,
+        return_value=["train.lock"],
+    )
+    mocker.patch(
+        "pivot.import_artifact.github.resolve_ref",
+        autospec=True,
+        return_value=rev_lock,
+    )
+
+    async def _read_file(
+        _owner: str, _repo: str, path: str, _ref: str, _token: str | None = None, **_kw: object
+    ) -> bytes:
+        if path == ".pivot/config.yaml":
+            return _config_bytes(remote_url)
+        if path == ".pivot/stages/train.lock":
+            return lock_bytes
+        raise AssertionError(f"Unexpected path: {path}")
+
+    mocker.patch(
+        "pivot.import_artifact.github.read_file",
+        autospec=True,
+        side_effect=_read_file,
+    )
+
+
+async def test_update_import_changed_output(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+    moto_s3_bucket: str,
+    aioboto3_s3_client: S3Client,
+) -> None:
+    remote_url = f"s3://{moto_s3_bucket}/test-prefix/"
+    old_content = b"old"
+    new_content = b"new data here"
+    old_hash = xxhash.xxh64(old_content).hexdigest()
+    new_hash = xxhash.xxh64(new_content).hexdigest()
+
+    # Write existing pvt + data file
+    data_path = tmp_path / "output.csv"
+    data_path.write_bytes(old_content)
+    pvt_path = track.get_pvt_path(data_path)
+    pvt_data = _make_pvt_data(
+        path="output.csv",
+        hash=old_hash,
+        size=len(old_content),
+        rev_lock="oldsha",
+        source_path="data/output.csv",
+        remote=remote_url,
+    )
+    track.write_pvt_file(pvt_path, pvt_data)
+
+    # Remote now has new hash
+    _setup_resolve_mocks(
+        mocker,
+        remote_url=remote_url,
+        lock_outs=[{"path": "data/output.csv", "hash": new_hash}],
+        rev_lock="newsha",
+    )
+
+    key = remote_mod._hash_to_key("test-prefix/", new_hash)
+    await aioboto3_s3_client.put_object(Bucket=moto_s3_bucket, Key=key, Body=new_content)
+
+    mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        return_value=remote_mod.S3Remote(remote_url),
+    )
+
+    result = await import_artifact.update_import(pvt_path)
+
+    assert result["downloaded"] is True, "Should mark as downloaded when hash changed"
+    assert result["old_rev"] == "oldsha"
+    assert result["new_rev"] == "newsha"
+    assert data_path.read_bytes() == new_content
+
+    # Verify pvt file updated
+    updated_pvt = track.read_pvt_file(pvt_path)
+    assert updated_pvt is not None
+    assert updated_pvt["hash"] == new_hash
+    assert updated_pvt["source"]["rev_lock"] == "newsha"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert updated_pvt["size"] == len(new_content), "Size should come from downloaded file"
+
+
+def test_update_import_same_hash_no_redownload(
+    tmp_path: pathlib.Path, mocker: MockerFixture
+) -> None:
+    remote_url = "s3://bucket/prefix"
+    content = b"unchanged"
+    file_hash = xxhash.xxh64(content).hexdigest()
+
+    data_path = tmp_path / "output.csv"
+    data_path.write_bytes(content)
+    pvt_path = track.get_pvt_path(data_path)
+    pvt_data = _make_pvt_data(
+        path="output.csv",
+        hash=file_hash,
+        size=len(content),
+        rev_lock="oldsha",
+        source_path="data/output.csv",
+        remote=remote_url,
+    )
+    track.write_pvt_file(pvt_path, pvt_data)
+
+    # Remote has same hash but new rev_lock
+    _setup_resolve_mocks(
+        mocker,
+        remote_url=remote_url,
+        lock_outs=[{"path": "data/output.csv", "hash": file_hash}],
+        rev_lock="newsha",
+    )
+
+    s3_mock = mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        side_effect=AssertionError("S3Remote should not be instantiated when hash unchanged"),
+    )
+
+    result = asyncio.run(import_artifact.update_import(pvt_path))
+
+    assert result["downloaded"] is False, "Should not re-download when hash unchanged"
+    assert result["old_rev"] == "oldsha"
+    assert result["new_rev"] == "newsha"
+    s3_mock.assert_not_called()
+
+    # Verify pvt file still updated with new rev_lock
+    updated_pvt = track.read_pvt_file(pvt_path)
+    assert updated_pvt is not None
+    assert updated_pvt["source"]["rev_lock"] == "newsha"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+
+def test_update_import_with_rev_override(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    remote_url = "s3://bucket/prefix"
+    content = b"data"
+    file_hash = xxhash.xxh64(content).hexdigest()
+
+    data_path = tmp_path / "output.csv"
+    data_path.write_bytes(content)
+    pvt_path = track.get_pvt_path(data_path)
+    pvt_data = _make_pvt_data(
+        path="output.csv",
+        hash=file_hash,
+        size=len(content),
+        rev="main",
+        rev_lock="oldsha",
+        source_path="data/output.csv",
+        remote=remote_url,
+    )
+    track.write_pvt_file(pvt_path, pvt_data)
+
+    _setup_resolve_mocks(
+        mocker,
+        remote_url=remote_url,
+        lock_outs=[{"path": "data/output.csv", "hash": file_hash}],
+        rev_lock="v2sha",
+    )
+
+    mocker.patch(
+        "pivot.import_artifact.remote_storage.S3Remote",
+        autospec=True,
+        side_effect=AssertionError("S3Remote should not be instantiated"),
+    )
+
+    result = asyncio.run(import_artifact.update_import(pvt_path, new_rev="v2"))
+
+    assert result["new_rev"] == "v2sha"
+
+    # Verify the rev field was updated to the override
+    updated_pvt = track.read_pvt_file(pvt_path)
+    assert updated_pvt is not None
+    assert updated_pvt["source"]["rev"] == "v2", "Should update rev to override value"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+    assert updated_pvt["source"]["rev_lock"] == "v2sha"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+
+def test_update_import_path_removed(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
+    remote_url = "s3://bucket/prefix"
+
+    data_path = tmp_path / "output.csv"
+    data_path.write_bytes(b"data")
+    pvt_path = track.get_pvt_path(data_path)
+    pvt_data = _make_pvt_data(
+        path="output.csv",
+        hash="aaa111",
+        size=4,
+        source_path="data/output.csv",
+        remote=remote_url,
+    )
+    track.write_pvt_file(pvt_path, pvt_data)
+
+    # Remote no longer has this path — lock file has different output
+    _setup_resolve_mocks(
+        mocker,
+        remote_url=remote_url,
+        lock_outs=[{"path": "data/other.csv", "hash": "bbb222"}],
+        rev_lock="newsha",
+    )
+
+    with pytest.raises(exceptions.PivotError, match="not found in remote outputs"):
+        asyncio.run(import_artifact.update_import(pvt_path))

--- a/uv.lock
+++ b/uv.lock
@@ -2048,6 +2048,7 @@ name = "pivot"
 version = "0.1.0"
 source = { editable = "packages/pivot" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "anyio" },
     { name = "click" },
     { name = "deepmerge" },
@@ -2119,6 +2120,7 @@ tui = [
 [package.metadata]
 requires-dist = [
     { name = "aioboto3", marker = "extra == 's3'", specifier = ">=13.0.0" },
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "anyio", specifier = ">=4.0" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "botocore-stubs", marker = "extra == 'dev'", specifier = ">=1.35.0" },


### PR DESCRIPTION
## Summary

Add `pivot import` and `pivot update` commands for importing artifacts from remote Pivot pipelines.

- **`pivot import <repo> <path>`** — Import a file from a remote pipeline's outputs, with automatic stage discovery and lock file resolution
- **`pivot update`** — Batch-update all imported artifacts, checking for newer versions via ref resolution

## Key Features

- **GitHub API + git-archive fallback** — Works with GitHub repos (Contents API) and any git server (via `git archive --remote`)
- **TOCTOU-safe reads** — Resolves symbolic refs to commit SHAs before reading config/lock files, ensuring all reads come from the same commit
- **Hash verification** — Downloads are verified against the expected hash from the lock file; mismatches are rejected
- **Import status tracking** — `.pvt` metadata files track import source (repo, rev, rev_lock, stage, path, remote) for update detection
- **Concurrent status checks** — `pivot status --check-imports` uses `asyncio.gather` for parallel ref resolution

## Security Hardening

- Path containment: import destinations must be within project root
- Source sub-dict validation in `.pvt` files prevents `KeyError` crashes on malformed metadata
- Atomic force-overwrite: `--force` no longer deletes data before download succeeds
- `git ls-remote` uses `--` separator to prevent option injection
- Exact ref matching prevents ambiguous prefix matches (e.g., `v1` no longer matches `v1.0`)
- S3 download errors wrapped in `RemoteError` with actionable messages
- `aiohttp` requests use 30s timeout
- `.pvt` discovery uses `os.walk(followlinks=False)` to avoid traversing symlinks
- `shutil.move` → `os.replace` in atomic downloads for predictable behavior

## Files

**New files (11):**
- `packages/pivot/src/pivot/import_artifact.py` — Core import/update logic
- `packages/pivot/src/pivot/remote/github.py` — Async GitHub API client
- `packages/pivot/src/pivot/remote/git_archive.py` — Git archive fallback
- `packages/pivot/src/pivot/cli/import_cmd.py` — `pivot import` CLI command
- `packages/pivot/src/pivot/cli/update.py` — `pivot update` CLI command
- `packages/pivot/src/pivot/remote/AGENTS.md` — Async HTTP conventions
- 9 test files (309 import-related tests pass)

**Modified files (6):**
- `packages/pivot/src/pivot/storage/track.py` — Added `ImportSource` TypedDict, source validation, symlink-safe discovery
- `packages/pivot/src/pivot/status.py` — Added `ImportStatusInfo`, batch async status checks
- `packages/pivot/src/pivot/cli/__init__.py` — Registered import/update commands
- `packages/pivot/src/pivot/cli/status.py` — Import status display
- `packages/pivot/src/pivot/remote/storage.py` — S3 error wrapping, `os.replace`
- `packages/pivot/pyproject.toml` — Added `aiohttp>=3.9` dependency

## Testing

- 309 import-related tests pass
- Full test suite (3400+) passes
- `ruff check` + `ruff format` clean
- `basedpyright` 0 errors