### PR TITLE
fix(ux): address naterush PR #717 feedback — discovery, auth, repro

### DIFF
--- a/packages/pivot/src/pivot/cli/repro.py
+++ b/packages/pivot/src/pivot/cli/repro.py
@@ -846,19 +846,43 @@ def repro(
 
     stages_list = cli_helpers.stages_to_list(stages)
     if stages_list is not None:
+        # Try pipeline-file resolution first (e.g., "pivot repro path/to/pipeline.py")
+        pipeline_resolved, stages_list, loaded_pipelines = (
+            cli_targets.resolve_pipeline_file_targets(stages_list)
+        )
+
+        if loaded_pipelines:
+            context_pipeline = cli_decorators.get_pipeline_from_context()
+            if context_pipeline is not None:
+                for pipeline in loaded_pipelines:
+                    context_pipeline.include(pipeline)
+            else:
+                from pivot.pipeline import pipeline as pipeline_mod
+
+                combined = pipeline_mod.Pipeline("cli", root=loaded_pipelines[0].root)
+                for pipeline in loaded_pipelines:
+                    combined.include(pipeline)
+                cli_decorators.store_pipeline_in_context(combined)
+
         # Fast-path: if all targets are registered stage names, skip graph construction
         registered = set(cli_helpers.list_stages())
-        if not all(s in registered for s in stages_list):
+
+        resolved = set[str]()
+        unresolved = list[str]()
+
+        if stages_list and not all(s in registered for s in stages_list):
             # Build graph and resolve file paths to producer stages (same as pivot dag)
             all_stages = cli_helpers.get_all_stages()
             bipartite_graph = engine_graph.build_graph(all_stages)
             resolved, unresolved = cli_targets.resolve_targets_to_stages(
                 stages_list, bipartite_graph
             )
-        else:
-            # All targets are registered stages - no resolution needed
+        elif stages_list:
+            # All remaining targets are registered stages - no resolution needed
             resolved = set(stages_list)
-            unresolved: list[str] = []
+
+        # Merge pipeline-file resolved stages
+        resolved |= pipeline_resolved
         if unresolved:
             from difflib import get_close_matches
 

--- a/packages/pivot/src/pivot/cli/targets.py
+++ b/packages/pivot/src/pivot/cli/targets.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import pathlib
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import click
 
-from pivot import outputs, project
+from pivot import discovery, outputs, project
 from pivot.cli import helpers as cli_helpers
 from pivot.engine import graph as engine_graph
 
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
 
     import networkx as nx
 
+    from pivot.pipeline.pipeline import Pipeline
     from pivot.show import plots as plots_mod
 
 logger = logging.getLogger(__name__)
@@ -47,6 +49,41 @@ def validate_targets(targets: tuple[str, ...]) -> list[str]:
         raise TargetValidationError("All targets are empty or whitespace-only")
 
     return valid
+
+
+_PIPELINE_FILENAMES = frozenset((*discovery.PIVOT_YAML_NAMES, discovery.PIPELINE_PY_NAME))
+
+
+def resolve_pipeline_file_targets(
+    targets: list[str],
+) -> tuple[set[str], list[str], list[Pipeline]]:
+    """Resolve targets that are paths to pipeline config files.
+
+    For each target, checks if it's an existing file whose name matches
+    pipeline.py, pivot.yaml, or pivot.yml. If so, loads the pipeline and
+    extracts all stage names.
+
+    Returns:
+        Tuple of (resolved stage names, remaining unresolved targets, loaded pipelines).
+    """
+    resolved = set[str]()
+    remaining = list[str]()
+    pipelines: list[Pipeline] = []
+
+    for target in targets:
+        path = pathlib.Path(target)
+        if path.is_file() and path.name in _PIPELINE_FILENAMES:
+            pipeline = discovery.load_pipeline_from_path(path)
+            if pipeline is not None:
+                for name in pipeline.list_stages():
+                    resolved.add(name)
+                pipelines.append(pipeline)
+            else:
+                remaining.append(target)
+        else:
+            remaining.append(target)
+
+    return resolved, remaining, pipelines
 
 
 def resolve_targets_to_stages(

--- a/packages/pivot/src/pivot/discovery.py
+++ b/packages/pivot/src/pivot/discovery.py
@@ -182,6 +182,7 @@ def _discover_all_pipelines(root: pathlib.Path) -> Pipeline | None:
         pipeline = load_pipeline_from_path(path)
         if pipeline is not None:
             pipelines.append(pipeline)
+            logger.info(f"  {pipeline.name}: {path} ({len(pipeline.list_stages())} stages)")
         else:
             logger.warning(f"--all: failed to load pipeline from {path}, skipping")
 
@@ -312,6 +313,9 @@ _SCAN_EXCLUDE_DIRS = frozenset(
         ".nox",
         ".mypy_cache",
         ".ruff_cache",
+        "site-packages",
+        "dist-packages",
+        ".eggs",
     }
 )
 

--- a/packages/pivot/src/pivot/remote/storage.py
+++ b/packages/pivot/src/pivot/remote/storage.py
@@ -130,6 +130,29 @@ def _is_not_found_error(e: ClientError) -> bool:
     return e.response.get("Error", {}).get("Code") == "404"
 
 
+_AUTH_ERROR_CODES = frozenset(
+    {
+        "ExpiredTokenException",
+        "ExpiredToken",
+        "InvalidIdentityToken",
+        "InvalidGrantException",
+        "UnrecognizedClientException",
+        "InvalidClientTokenId",
+        "SignatureDoesNotMatch",
+    }
+)
+
+_AUTH_ERROR_MESSAGE = (
+    "AWS credentials are expired or invalid. "
+    "Run 'aws sso login' to refresh your credentials, or check your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+)
+
+
+def _is_auth_error(e: ClientError) -> bool:
+    """Check if botocore ClientError is an authentication error."""
+    return e.response.get("Error", {}).get("Code") in _AUTH_ERROR_CODES
+
+
 def _hash_to_key(prefix: str, hash_: str) -> str:
     """Convert cache hash to S3 key (files/XX/YYYYYYYY...)."""
     return f"{prefix}files/{hash_[:2]}/{hash_[2:]}"
@@ -323,7 +346,11 @@ class S3Remote:
             except botocore_exc.ClientError as e:
                 if _is_not_found_error(e):
                     return False
+                if _is_auth_error(e):
+                    raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
                 raise exceptions.RemoteConnectionError(f"S3 error: {e}") from e
+            except botocore_exc.NoCredentialsError as e:
+                raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
     async def bulk_exists(
         self, hashes: list[str], concurrency: int = DEFAULT_CONCURRENCY
@@ -373,7 +400,11 @@ class S3Remote:
                 except botocore_exc.ClientError as e:
                     if _is_not_found_error(e):
                         return (hash_, False)
+                    if _is_auth_error(e):
+                        raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
                     raise exceptions.RemoteConnectionError(f"S3 HEAD error for {hash_}: {e}") from e
+                except botocore_exc.NoCredentialsError as e:
+                    raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
         results = await asyncio.gather(*[check_one(h) for h in hashes], return_exceptions=True)
 
@@ -399,6 +430,8 @@ class S3Remote:
         """
         from collections import defaultdict
 
+        from botocore import exceptions as botocore_exc
+
         # Group hashes by prefix
         by_prefix = defaultdict[str, set[str]](set)
         for h in hashes:
@@ -409,23 +442,30 @@ class S3Remote:
 
         async def list_prefix(prefix: str, wanted: set[str]) -> dict[str, bool]:
             async with semaphore:
-                found = set[str]()
-                s3_prefix = f"{self._prefix}files/{prefix}/"
-                paginator = s3.get_paginator("list_objects_v2")
-                async for page in paginator.paginate(Bucket=self._bucket, Prefix=s3_prefix):
-                    for obj in page.get("Contents", []):
-                        key = obj.get("Key")
-                        if key is None:
-                            continue
-                        hash_ = _key_to_hash(self._prefix, key)
-                        if hash_ and hash_ in wanted:
-                            found.add(hash_)
-                            # Early exit if we found all we're looking for
-                            if found == wanted:
-                                break
-                    if found == wanted:
-                        break
-                return {h: h in found for h in wanted}
+                try:
+                    found = set[str]()
+                    s3_prefix = f"{self._prefix}files/{prefix}/"
+                    paginator = s3.get_paginator("list_objects_v2")
+                    async for page in paginator.paginate(Bucket=self._bucket, Prefix=s3_prefix):
+                        for obj in page.get("Contents", []):
+                            key = obj.get("Key")
+                            if key is None:
+                                continue
+                            hash_ = _key_to_hash(self._prefix, key)
+                            if hash_ and hash_ in wanted:
+                                found.add(hash_)
+                                # Early exit if we found all we're looking for
+                                if found == wanted:
+                                    break
+                        if found == wanted:
+                            break
+                    return {h: h in found for h in wanted}
+                except botocore_exc.ClientError as e:
+                    if _is_auth_error(e):
+                        raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
+                    raise exceptions.RemoteConnectionError(f"S3 LIST error: {e}") from e
+                except botocore_exc.NoCredentialsError as e:
+                    raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
         tasks = [list_prefix(prefix, wanted) for prefix, wanted in by_prefix.items()]
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -442,18 +482,27 @@ class S3Remote:
 
     async def iter_hashes(self) -> AsyncIterator[str]:
         """Iterate over all cache hashes on remote (memory-efficient streaming)."""
+        from botocore import exceptions as botocore_exc
+
         prefix = f"{self._prefix}files/"
 
-        async with self._session.client("s3", config=_get_s3_config()) as s3:
-            paginator = s3.get_paginator("list_objects_v2")
-            async for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
-                for obj in page.get("Contents", []):
-                    key = obj.get("Key")
-                    if key is None:
-                        continue
-                    hash_ = _key_to_hash(self._prefix, key)
-                    if hash_ is not None:
-                        yield hash_
+        try:
+            async with self._session.client("s3", config=_get_s3_config()) as s3:
+                paginator = s3.get_paginator("list_objects_v2")
+                async for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+                    for obj in page.get("Contents", []):
+                        key = obj.get("Key")
+                        if key is None:
+                            continue
+                        hash_ = _key_to_hash(self._prefix, key)
+                        if hash_ is not None:
+                            yield hash_
+        except botocore_exc.ClientError as e:
+            if _is_auth_error(e):
+                raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
+            raise exceptions.RemoteConnectionError(f"S3 error: {e}") from e
+        except botocore_exc.NoCredentialsError as e:
+            raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
     async def list_hashes(self) -> set[str]:
         """List all cache hashes on remote (collects into memory)."""
@@ -466,25 +515,43 @@ class S3Remote:
 
     async def upload_file(self, local_path: Path, cache_hash: str) -> None:
         """Upload a single file to remote with streaming for large files."""
+        from botocore import exceptions as botocore_exc
+
         _validate_hash(cache_hash)
-        async with self._session.client("s3", config=_get_s3_config()) as s3:
-            await _stream_upload(
-                s3, self._bucket, _hash_to_key(self._prefix, cache_hash), local_path
-            )
+        try:
+            async with self._session.client("s3", config=_get_s3_config()) as s3:
+                await _stream_upload(
+                    s3, self._bucket, _hash_to_key(self._prefix, cache_hash), local_path
+                )
+        except botocore_exc.ClientError as e:
+            if _is_auth_error(e):
+                raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
+            raise
+        except botocore_exc.NoCredentialsError as e:
+            raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
     async def download_file(
         self, cache_hash: str, local_path: Path, *, readonly: bool = False
     ) -> None:
         """Download a single file from remote (atomic write via temp file, streamed)."""
+        from botocore import exceptions as botocore_exc
+
         _validate_hash(cache_hash)
-        async with self._session.client("s3", config=_get_s3_config()) as s3:
-            await _atomic_download(
-                s3,
-                self._bucket,
-                _hash_to_key(self._prefix, cache_hash),
-                local_path,
-                readonly=readonly,
-            )
+        try:
+            async with self._session.client("s3", config=_get_s3_config()) as s3:
+                await _atomic_download(
+                    s3,
+                    self._bucket,
+                    _hash_to_key(self._prefix, cache_hash),
+                    local_path,
+                    readonly=readonly,
+                )
+        except botocore_exc.ClientError as e:
+            if _is_auth_error(e):
+                raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
+            raise
+        except botocore_exc.NoCredentialsError as e:
+            raise exceptions.RemoteConnectionError(_AUTH_ERROR_MESSAGE) from e
 
     async def upload_batch(
         self,

--- a/packages/pivot/tests/cli/test_repro.py
+++ b/packages/pivot/tests/cli/test_repro.py
@@ -8,7 +8,7 @@ import sys
 from typing import TYPE_CHECKING, Annotated, TypedDict
 
 from conftest import isolated_pivot_dir
-from helpers import register_test_stage
+from helpers import create_pipeline_py, register_test_stage
 from pivot import cli, executor, loaders, outputs
 from pivot.storage import cache, track
 
@@ -376,6 +376,32 @@ def test_repro_unknown_stage_errors(
 
     assert result.exit_code != 0
     assert "nonexistent_stage" in result.output
+
+
+def test_repro_pipeline_file_target_registers_stages(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+) -> None:
+    """repro with pipeline.py path registers and resolves stage targets."""
+    with isolated_pivot_dir(runner, tmp_path) as cwd:
+        subdir = cwd / "sub"
+        subdir.mkdir()
+        extra_code = """\
+class _StageAOutputs(TypedDict):
+    output: Annotated[pathlib.Path, outputs.Out(\"a.txt\", loaders.PathOnly())]
+"""
+        pipeline_path = create_pipeline_py(
+            [_helper_stage_a],
+            path=subdir,
+            extra_code=extra_code,
+            names={"_helper_stage_a": "stage_a"},
+        )
+
+        result = runner.invoke(cli.cli, ["repro", "--dry-run", str(pipeline_path)])
+
+        assert result.exit_code == 0, f"repro failed: {result.output}"
+        assert "Would run:" in result.output, "Dry-run output should include plan summary"
+        assert "stage_a" in result.output, "Pipeline file stage should be resolved"
 
 
 # =============================================================================

--- a/packages/pivot/tests/core/test_cli_pipeline_targets.py
+++ b/packages/pivot/tests/core/test_cli_pipeline_targets.py
@@ -1,0 +1,131 @@
+"""Tests for pivot.cli.targets — pipeline file target resolution."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from pivot.cli import targets as cli_targets
+from pivot.pipeline import pipeline as pipeline_mod
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+# =============================================================================
+# resolve_pipeline_file_targets Tests
+# =============================================================================
+
+
+def test_resolve_pipeline_file_targets_pipeline_py(tmp_path: pathlib.Path) -> None:
+    """Pipeline .py file target resolves to its stage names."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("test_pipe")
+
+def _stage_a():
+    pass
+
+def _stage_b():
+    pass
+
+pipeline.register(_stage_a, name="stage_a")
+pipeline.register(_stage_b, name="stage_b")
+"""
+    (sub / "pipeline.py").write_text(pipeline_code)
+
+    target = str(sub / "pipeline.py")
+    resolved, remaining, pipelines = cli_targets.resolve_pipeline_file_targets([target])
+
+    assert resolved == {"stage_a", "stage_b"}, "Should resolve both stages from pipeline file"
+    assert remaining == [], "No targets should remain unresolved"
+    assert pipelines, "Should return loaded pipeline"
+    assert isinstance(pipelines[0], pipeline_mod.Pipeline), "Loaded pipeline should be returned"
+
+
+def test_resolve_pipeline_file_targets_nonexistent_path() -> None:
+    """Non-existent pipeline path falls through (returns empty)."""
+    resolved, remaining, pipelines = cli_targets.resolve_pipeline_file_targets(
+        ["nonexistent/pipeline.py"]
+    )
+
+    assert resolved == set(), "Non-existent path should not resolve any stages"
+    assert remaining == ["nonexistent/pipeline.py"], "Non-existent path should remain unresolved"
+    assert pipelines == [], "Non-existent path should not load pipelines"
+
+
+def test_resolve_pipeline_file_targets_not_pipeline_filename(tmp_path: pathlib.Path) -> None:
+    """File exists but filename doesn't match pipeline patterns — falls through."""
+    other_file = tmp_path / "my_script.py"
+    other_file.write_text("x = 1\n")
+
+    target = str(other_file)
+    resolved, remaining, pipelines = cli_targets.resolve_pipeline_file_targets([target])
+
+    assert resolved == set(), "Non-pipeline filename should not resolve any stages"
+    assert remaining == [target], "Non-pipeline filename should remain unresolved"
+    assert pipelines == [], "Non-pipeline filename should not load pipelines"
+
+
+def test_resolve_pipeline_file_targets_pivot_yaml(tmp_path: pathlib.Path) -> None:
+    """pivot.yaml file target resolves to its stage names."""
+    # Create a real stage module for the YAML to reference
+    stages_code = """\
+def preprocess():
+    pass
+
+def train():
+    pass
+"""
+    (tmp_path / "stages.py").write_text(stages_code)
+
+    yaml_content = """\
+stages:
+  preprocess:
+    python: stages.preprocess
+  train:
+    python: stages.train
+"""
+    (tmp_path / "pivot.yaml").write_text(yaml_content)
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        target = str(tmp_path / "pivot.yaml")
+        resolved, remaining, pipelines = cli_targets.resolve_pipeline_file_targets([target])
+
+        assert "preprocess" in resolved, "Should resolve preprocess stage from pivot.yaml"
+        assert "train" in resolved, "Should resolve train stage from pivot.yaml"
+        assert remaining == [], "No targets should remain unresolved"
+        assert pipelines, "Should return loaded pipeline"
+        assert isinstance(pipelines[0], pipeline_mod.Pipeline), "Loaded pipeline should be returned"
+    finally:
+        sys.path.remove(str(tmp_path))
+        if "stages" in sys.modules:
+            del sys.modules["stages"]
+
+
+def test_resolve_pipeline_file_targets_mixed_targets(tmp_path: pathlib.Path) -> None:
+    """Mix of pipeline file and non-pipeline targets — pipeline resolved, others pass through."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    pipeline_code = """\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("mixed_test")
+
+def _my_stage():
+    pass
+
+pipeline.register(_my_stage, name="my_stage")
+"""
+    (sub / "pipeline.py").write_text(pipeline_code)
+
+    targets = [str(sub / "pipeline.py"), "some_other_target"]
+    resolved, remaining, pipelines = cli_targets.resolve_pipeline_file_targets(targets)
+
+    assert resolved == {"my_stage"}, "Should resolve stages from the pipeline file"
+    assert remaining == ["some_other_target"], "Non-pipeline targets pass through"
+    assert pipelines, "Should return loaded pipeline"

--- a/packages/pivot/tests/core/test_discovery.py
+++ b/packages/pivot/tests/core/test_discovery.py
@@ -1083,6 +1083,38 @@ def test_glob_all_pipelines_finds_multiple_pipelines(
     assert len(result) == 3
 
 
+@pytest.mark.parametrize(
+    "excluded_dir",
+    [
+        pytest.param("site-packages", id="site_packages"),
+        pytest.param("dist-packages", id="dist_packages"),
+        pytest.param(".eggs", id="eggs"),
+    ],
+)
+def test_glob_all_pipelines_excludes_python_package_dirs(
+    set_project_root: pathlib.Path,
+    excluded_dir: str,
+) -> None:
+    """glob_all_pipelines skips site-packages, dist-packages, and .eggs directories."""
+    # Create a pipeline.py inside the excluded directory
+    excluded = set_project_root / excluded_dir / "some_lib"
+    excluded.mkdir(parents=True)
+    (excluded / "pipeline.py").write_text("# should be excluded\n")
+
+    # Create a valid pipeline.py that SHOULD be found
+    valid = set_project_root / "app"
+    valid.mkdir()
+    (valid / "pipeline.py").write_text("# valid pipeline\n")
+
+    result = discovery.glob_all_pipelines(set_project_root)
+
+    result_dirs = [p.parent.name for p in result]
+    assert "app" in result_dirs, "Valid pipeline should be found"
+    assert excluded_dir not in [
+        part for p in result for part in p.relative_to(set_project_root).parts
+    ], f"Pipelines inside {excluded_dir}/ should be excluded"
+
+
 # =============================================================================
 # discover_pipeline(all_pipelines=True) Tests
 # =============================================================================
@@ -1265,6 +1297,60 @@ pipeline.register(_stage, name="consumer")
     # Should log about the unresolved dependency at debug level
     assert any("not produced by any discovered pipeline" in msg for msg in caplog.messages), (
         f"Expected debug message about unresolved deps, got: {caplog.messages}"
+    )
+
+
+def test_discover_all_logs_per_pipeline_details(
+    set_project_root: pathlib.Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """discover_pipeline(all_pipelines=True) logs per-pipeline file path and stage count.
+
+    Each successfully loaded pipeline should log a line containing:
+    - The pipeline name
+    - The file path
+    - The number of stages in that pipeline
+    """
+    # Create two sub-pipelines with different stage counts
+    for name, stage_count in [("alpha", 2), ("beta", 1)]:
+        sub = set_project_root / name
+        sub.mkdir()
+        stages_code = "\n".join(
+            f"""\
+def _stage_{i}():
+    pass
+
+pipeline.register(_stage_{i}, name="stage_{name}_{i}")
+"""
+            for i in range(stage_count)
+        )
+        code = f"""\
+from pivot.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline("{name}", root=__import__("pathlib").Path(__file__).parent)
+
+{stages_code}
+"""
+        (sub / "pipeline.py").write_text(code)
+
+    with caplog.at_level(logging.INFO):
+        result = discovery.discover_pipeline(set_project_root, all_pipelines=True)
+
+    assert result is not None
+    # Verify both pipelines were loaded
+    assert len(result.list_stages()) == 3, "Should have 3 total stages (2 from alpha, 1 from beta)"
+
+    # Check that per-pipeline log lines exist with path and stage count
+    alpha_path = set_project_root / "alpha" / "pipeline.py"
+    beta_path = set_project_root / "beta" / "pipeline.py"
+
+    # Look for log messages containing the pipeline name, path, and stage count
+    log_text = caplog.text
+    assert "alpha" in log_text and str(alpha_path) in log_text and "2 stages" in log_text, (
+        f"Expected log line for alpha pipeline with path and stage count, got: {log_text}"
+    )
+    assert "beta" in log_text and str(beta_path) in log_text and "1 stages" in log_text, (
+        f"Expected log line for beta pipeline with path and stage count, got: {log_text}"
     )
 
 

--- a/packages/pivot/tests/remote/test_s3_remote.py
+++ b/packages/pivot/tests/remote/test_s3_remote.py
@@ -285,6 +285,137 @@ async def test_exists_raises_on_other_error(
         await s3_remote.exists("abcdef1234567890")
 
 
+async def test_s3_exists_auth_error_expired_token(
+    s3_remote: remote_mod.S3Remote, mocker: MockerFixture
+) -> None:
+    """exists raises RemoteConnectionError with friendly message for expired token."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.ClientError(
+        {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}},
+        "HeadObject",
+    )
+    mock_client.head_object = mocker.AsyncMock(side_effect=error)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="aws sso login",
+    ):
+        await s3_remote.exists("abcdef1234567890")
+
+
+async def test_s3_exists_auth_error_no_credentials(
+    s3_remote: remote_mod.S3Remote, mocker: MockerFixture
+) -> None:
+    """exists raises RemoteConnectionError with friendly message for missing credentials."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.NoCredentialsError()
+    mock_client.head_object = mocker.AsyncMock(side_effect=error)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="AWS credentials",
+    ):
+        await s3_remote.exists("abcdef1234567890")
+
+
+async def test_s3_exists_non_auth_error_still_generic(
+    s3_remote: remote_mod.S3Remote, mocker: MockerFixture
+) -> None:
+    """exists raises RemoteConnectionError with generic message for non-auth errors."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.ClientError(
+        {"Error": {"Code": "InternalError", "Message": "Internal server error"}},
+        "HeadObject",
+    )
+    mock_client.head_object = mocker.AsyncMock(side_effect=error)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="S3 error",
+    ):
+        await s3_remote.exists("abcdef1234567890")
+
+
+async def test_s3_iter_hashes_auth_error(
+    s3_remote: remote_mod.S3Remote, mocker: MockerFixture
+) -> None:
+    """iter_hashes raises RemoteConnectionError with friendly message for auth errors."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.ClientError(
+        {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}},
+        "ListObjectsV2",
+    )
+
+    class _FailingAsyncIterator:
+        def __aiter__(self) -> _FailingAsyncIterator:
+            return self
+
+        async def __anext__(self) -> Any:  # noqa: ANN401
+            raise error
+
+    mock_paginator = mocker.MagicMock()
+    mock_paginator.paginate = mocker.MagicMock(return_value=_FailingAsyncIterator())
+    mock_client.get_paginator = mocker.Mock(return_value=mock_paginator)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="aws sso login",
+    ):
+        async for _ in s3_remote.iter_hashes():
+            pass
+
+
+async def test_s3_upload_file_auth_error(
+    s3_remote: remote_mod.S3Remote,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """upload_file raises RemoteConnectionError with friendly message for auth errors."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.ClientError(
+        {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}},
+        "PutObject",
+    )
+    mock_client.put_object = mocker.AsyncMock(side_effect=error)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    test_file = tmp_path / "test.txt"
+    test_file.write_bytes(b"test content")
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="aws sso login",
+    ):
+        await s3_remote.upload_file(test_file, "abc123def4567890")
+
+
+async def test_s3_download_file_auth_error(
+    s3_remote: remote_mod.S3Remote,
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """download_file raises RemoteConnectionError with friendly message for auth errors."""
+    mock_client = mocker.AsyncMock()
+    error = botocore_exc.ClientError(
+        {"Error": {"Code": "ExpiredTokenException", "Message": "Token expired"}},
+        "GetObject",
+    )
+    mock_client.get_object = mocker.AsyncMock(side_effect=error)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    local_path = tmp_path / "downloaded.txt"
+
+    with pytest.raises(
+        exceptions.RemoteConnectionError,
+        match="aws sso login",
+    ):
+        await s3_remote.download_file("abc123def4567890", local_path)
+
+
 async def test_upload_file(
     s3_remote: remote_mod.S3Remote,
     tmp_path: pathlib.Path,


### PR DESCRIPTION
## Summary

Addresses 4 UX issues reported by naterush during [eval-pipeline PR #717](https://github.com/METR/eval-pipeline/pull/717) — his first hands-on session with Pivot.

## Changes

### 1. Discovery excludes `site-packages` from `--all` scans
`glob_all_pipelines()` now skips `site-packages`, `dist-packages`, and `.eggs` directories. Previously, `--all` would find `pipeline.py` files inside installed packages (e.g., `pydantic/experimental/pipeline.py`, `sklearn/pipeline.py`), causing slow startup and confusing warnings.

### 2. Per-pipeline discovery output
`_discover_all_pipelines()` now logs each pipeline's file path and stage count at INFO level, making it clear which pipelines were found and how many stages each has.

### 3. Friendly S3 auth error messages
Auth-related botocore errors (`ExpiredTokenException`, `NoCredentialsError`, etc.) now produce actionable messages like *"AWS credentials are expired or invalid. Run 'aws sso login' to refresh."* instead of raw Python tracebacks. Applied to `exists()`, `iter_hashes()`, `upload_file()`, `download_file()`, and `bulk_exists()`.

`AccessDenied` is intentionally **not** treated as an auth error — a 403 can indicate insufficient IAM permissions with valid credentials, where "run aws sso login" would be misleading.

### 4. `pivot repro path/to/pipeline.py` support
Users can now pass a pipeline config file path as a target. The pipeline is loaded, its stages are registered into the CLI context, and all its stages are run. Works with `pipeline.py`, `pivot.yaml`, and `pivot.yml`.

## Tests
- 3 parametrized exclusion tests (site-packages, dist-packages, .eggs)
- 1 per-pipeline logging test with caplog
- 6 S3 auth error tests (exists, iter_hashes, upload, download, no-credentials, non-auth)
- 5 pipeline-file target resolution tests
- 1 repro integration test for pipeline-file targets
- **16 new tests total, all passing**