### PR TITLE
feat: add @no_fingerprint() decorator for per-stage opt-out of AST fingerprinting

### DIFF
--- a/docs/plans/2026-02-11-no-fingerprint-decorator.md
+++ b/docs/plans/2026-02-11-no-fingerprint-decorator.md
@@ -1,0 +1,189 @@
+# `@pivot.no_fingerprint()` Decorator + Public API Exports
+
+**Date:** 2026-02-11
+**Status:** Ready for implementation
+
+## Problem
+
+Pivot's AST fingerprinting is the most complex part of the system. It walks function closures, hashes transitive dependencies, detects mutable captures, and caches results across multiple tiers. When it works, it's powerful — code changes trigger re-runs automatically. When it has bugs, it's the hardest thing to debug.
+
+A colleague testing the Pivot migration found a "change dependencies, doesn't repro" bug on their first attempt. With the primary author leaving, the team needs a safe fallback that preserves Pivot's benefits (auto-parallelization, warm workers, DAG resolution) while using simpler, more predictable change detection.
+
+## Solution
+
+A `@pivot.no_fingerprint()` decorator that replaces AST-based closure walking with simple `.py` file hashing. Per-stage opt-in, co-located with the stage code.
+
+## API
+
+```python
+import pivot
+
+# Disable AST fingerprinting, use file-level hashing only
+@pivot.no_fingerprint()
+def train(
+    data: Annotated[DataFrame, Dep("input.csv", CSV())],
+) -> Annotated[DataFrame, Out("output.csv", CSV())]:
+    return data.dropna()
+
+# Declare additional code dependency files
+@pivot.no_fingerprint(code_deps=["src/utils.py", "src/model_helpers.py"])
+def train(
+    data: Annotated[DataFrame, Dep("input.csv", CSV())],
+) -> Annotated[DataFrame, Out("output.csv", CSV())]:
+    return data.dropna()
+```
+
+## Behavior
+
+- Hashes the `.py` file containing the stage function (via `inspect.getfile(func)`)
+- Hashes any additional files listed in `code_deps` (resolved relative to project root)
+- Uses existing `cache.hash_file()` with mtime caching via StateDB — no new hashing code
+- Produces a `code_manifest` like `{"file:stages/train.py": "abc123", "file:src/utils.py": "def456"}`
+- All three tiers of skip detection work identically — they compare dict contents, not key formats
+- Decorator always wins regardless of any global config
+
+### What triggers a re-run
+
+| Change | With AST fingerprint | With `@no_fingerprint` |
+|--------|---------------------|----------------------|
+| Input data file changed | Re-run | Re-run |
+| Parameters changed | Re-run | Re-run |
+| Stage source file changed | Re-run | Re-run |
+| Helper function in same file changed | Re-run | Re-run |
+| Helper function in different file changed | Re-run | Re-run only if listed in `code_deps` |
+| Comment/whitespace in stage file changed | Skip (AST ignores) | Re-run (file hash changes) |
+| Unrelated code in stage file changed | Re-run | Re-run |
+
+### Trade-offs vs AST fingerprinting
+
+**Advantages:**
+- No closure walking, no AST parsing — eliminates the entire class of fingerprinting bugs
+- Predictable: "if I edit this file, the stage re-runs"
+- Faster: file hash with mtime cache is O(1), vs AST analysis
+- Simple to reason about and debug
+
+**Disadvantages:**
+- Doesn't detect changes in imported helper files (unless listed in `code_deps`)
+- Comment/whitespace changes trigger unnecessary re-runs
+- Manual maintenance of `code_deps` list
+
+## Implementation
+
+### Files changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `pivot/__init__.py` | Export `no_fingerprint`, `Pipeline`, `StageParams`, `DirectoryOut` | ~8 |
+| `pivot/decorators.py` (new) | Decorator implementation | ~15 |
+| `pivot/registry.py` | Branch in `_compute_fingerprint()`, new `_compute_file_fingerprint()` | ~20 |
+| `tests/test_no_fingerprint.py` (new) | Integration tests | ~150 |
+
+### No changes to
+
+- `worker.py` — skip detection compares dicts, doesn't care about key format
+- `lock.py` — stores whatever dict it gets
+- `engine.py` — calls `ensure_fingerprint()` the same way
+- `types.py` — `LockData.code_manifest` is already `dict[str, str]`
+- StateDB — generation tracking works the same
+
+### Decorator (`pivot/decorators.py`)
+
+```python
+def no_fingerprint(
+    code_deps: list[str] | None = None,
+) -> Callable[[F], F]:
+    """Disable AST fingerprinting for a stage. Use file-level hashing instead."""
+    def decorator(func: F) -> F:
+        func.__pivot_no_fingerprint__ = True
+        func.__pivot_code_deps__ = code_deps or []
+        return func
+    return decorator
+```
+
+### Fingerprint computation (`pivot/registry.py`)
+
+In `_compute_fingerprint()`, add a branch:
+
+```python
+def _compute_fingerprint(stage_name: str, info: RegistryStageInfo) -> dict[str, str]:
+    func = info["func"]
+    if getattr(func, "__pivot_no_fingerprint__", False):
+        return _compute_file_fingerprint(func)
+    # ... existing AST fingerprinting unchanged ...
+```
+
+New helper:
+
+```python
+def _compute_file_fingerprint(func: Callable[..., Any]) -> dict[str, str]:
+    """Compute file-hash fingerprint (no AST analysis)."""
+    result: dict[str, str] = {}
+
+    # Hash the source file containing the stage function
+    source_file = pathlib.Path(inspect.getfile(func))
+    file_hash, _ = cache.hash_file(source_file)
+    rel_path = str(project.relative_path(source_file))
+    result[f"file:{rel_path}"] = file_hash
+
+    # Hash additional code_deps
+    code_deps: list[str] = getattr(func, "__pivot_code_deps__", [])
+    root = project.get_project_root()
+    for dep_path in code_deps:
+        abs_path = root / dep_path
+        dep_hash, _ = cache.hash_file(abs_path)
+        result[f"file:{dep_path}"] = dep_hash
+
+    return result
+```
+
+## Public API Exports
+
+Alongside `no_fingerprint`, expose the key pipeline-authoring classes from the top-level `pivot` package so users don't need deep imports.
+
+### New exports
+
+| Export | Source | Purpose |
+|--------|--------|---------|
+| `Pipeline` | `pivot.pipeline.pipeline` | Main pipeline registration class |
+| `StageParams` | `pivot.stage_def` | Base class for stage parameters |
+| `DirectoryOut` | `pivot.outputs` | Directory output spec |
+| `no_fingerprint` | `pivot.decorators` | Disable AST fingerprinting decorator |
+
+### Already exported
+
+`Out`, `Dep`, `Metric`, `Plot`, `IncrementalOut`, `PlaceholderDep`, `loaders`, `stage_def`
+
+### After
+
+```python
+# Users can write:
+from pivot import Pipeline, StageParams, Out, Dep, DirectoryOut, no_fingerprint
+
+# Instead of:
+from pivot.pipeline.pipeline import Pipeline
+from pivot.stage_def import StageParams
+from pivot.outputs import DirectoryOut
+```
+
+### Implementation
+
+Add entries to both `TYPE_CHECKING` block and `_LAZY_IMPORTS` dict in `pivot/__init__.py`, following the existing lazy-import pattern (~8 lines).
+
+## Tests (integration, `execute_stage` level)
+
+Following the pattern in `test_skip_detection_integration.py`:
+
+1. **Skip when unchanged**: Stage with `@no_fingerprint()` runs, second run skips
+2. **Re-run on source file change**: Compute file-hash manifest, modify `.py` file, recompute — hashes differ, stage re-runs
+3. **Re-run on code_deps change**: Same pattern with a `code_deps` file
+4. **No re-run on unrelated change**: Modify an unrelated file — skip still works
+5. **Mixed pipeline**: One fingerprinted stage + one `@no_fingerprint` stage — both behave correctly
+6. **Missing code_deps file**: Clear error message
+
+## Design decisions
+
+1. **Per-stage decorator, not global config** — YAGNI. If you want all stages to use file hashing, decorate each one. Avoids a second code path.
+2. **Decorator always wins** — No interaction with global config. Simple mental model.
+3. **File hash, not "no tracking"** — We still detect code changes (file-level), just without AST analysis. An empty manifest would mean code changes are invisible, which is dangerous.
+4. **`code_deps` as explicit list** — Users declare what they depend on. No import parsing, no magic. Predictable.
+5. **Same lockfile format** — `code_manifest` is still `dict[str, str]`. Just different keys (`file:` prefix instead of `self:`/`func:`/`class:`).

--- a/packages/pivot/src/pivot/__init__.py
+++ b/packages/pivot/src/pivot/__init__.py
@@ -10,23 +10,31 @@ __version__ = "0.1.0-dev"
 if TYPE_CHECKING:
     from pivot import loaders as loaders
     from pivot import stage_def as stage_def
+    from pivot.decorators import no_fingerprint as no_fingerprint
     from pivot.outputs import Dep as Dep
+    from pivot.outputs import DirectoryOut as DirectoryOut
     from pivot.outputs import IncrementalOut as IncrementalOut
     from pivot.outputs import Metric as Metric
     from pivot.outputs import Out as Out
     from pivot.outputs import PlaceholderDep as PlaceholderDep
     from pivot.outputs import Plot as Plot
+    from pivot.pipeline.pipeline import Pipeline as Pipeline
+    from pivot.stage_def import StageParams as StageParams
 
 # Lazy import mapping for runtime: (module_path, attr_name or None for module import)
 _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    "no_fingerprint": ("pivot.decorators", "no_fingerprint"),
     "loaders": ("pivot.loaders", None),
     "stage_def": ("pivot.stage_def", None),
+    "DirectoryOut": ("pivot.outputs", "DirectoryOut"),
     "Dep": ("pivot.outputs", "Dep"),
     "IncrementalOut": ("pivot.outputs", "IncrementalOut"),
     "Metric": ("pivot.outputs", "Metric"),
     "Out": ("pivot.outputs", "Out"),
     "PlaceholderDep": ("pivot.outputs", "PlaceholderDep"),
     "Plot": ("pivot.outputs", "Plot"),
+    "Pipeline": ("pivot.pipeline.pipeline", "Pipeline"),
+    "StageParams": ("pivot.stage_def", "StageParams"),
 }
 
 

--- a/packages/pivot/src/pivot/decorators.py
+++ b/packages/pivot/src/pivot/decorators.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def no_fingerprint(code_deps: list[str] | None = None) -> Callable[[F], F]:
+    """Disable AST fingerprinting for a stage. Use file-level hashing instead.
+
+    Must be called with parentheses: ``@no_fingerprint()`` not ``@no_fingerprint``.
+    """
+    if callable(code_deps):
+        raise TypeError("Use @no_fingerprint() with parentheses, not @no_fingerprint")
+
+    def decorator(func: F) -> F:
+        setattr(func, "__pivot_no_fingerprint__", True)  # noqa: B010
+        setattr(func, "__pivot_code_deps__", code_deps or [])  # noqa: B010
+        return func
+
+    return decorator

--- a/packages/pivot/src/pivot/registry.py
+++ b/packages/pivot/src/pivot/registry.py
@@ -25,6 +25,7 @@ from pivot import (
     stage_def,
     trie,
 )
+from pivot.storage import cache
 
 if TYPE_CHECKING:
     from inspect import Signature
@@ -957,7 +958,11 @@ def _resolve_params(
 def _compute_fingerprint(stage_name: str, info: RegistryStageInfo) -> dict[str, str]:
     """Compute and return a stage fingerprint, wrapping errors."""
     try:
-        result = fingerprint.get_stage_fingerprint_cached(stage_name, info["func"])
+        unwrapped = inspect.unwrap(info["func"])
+        if getattr(unwrapped, "__pivot_no_fingerprint__", False):
+            result = _compute_file_fingerprint(info["func"])
+        else:
+            result = fingerprint.get_stage_fingerprint_cached(stage_name, info["func"])
         for spec in info["dep_specs"].values():
             result.update(fingerprint.get_loader_fingerprint(spec.loader))
         for out in info["out_specs"].values():
@@ -965,6 +970,36 @@ def _compute_fingerprint(stage_name: str, info: RegistryStageInfo) -> dict[str, 
         return result
     except Exception as exc:
         raise exceptions.PivotError(f"Stage '{stage_name}': fingerprinting failed: {exc}") from exc
+
+
+def _compute_file_fingerprint(func: Callable[..., Any]) -> dict[str, str]:
+    """Compute file-hash fingerprint (no AST analysis).
+
+    Returns dict with keys like ``file:path/to/module.py`` -> hash.
+    Includes the stage function's source file and any ``code_deps``.
+    Uses ``inspect.unwrap`` to handle stacked decorators.
+    """
+    result = dict[str, str]()
+
+    # Unwrap decorators so inspect.getfile returns the actual stage source
+    unwrapped = inspect.unwrap(func)
+    source_file = pathlib.Path(inspect.getfile(unwrapped))
+    file_hash, _ = cache.hash_file(source_file)
+    rel_path = project.to_relative_path(source_file)
+    result[f"file:{rel_path}"] = file_hash
+
+    code_deps: list[str] = getattr(func, "__pivot_code_deps__", [])
+    root = project.get_project_root()
+    for dep_path in code_deps:
+        abs_path = (root / dep_path).resolve()
+        if not abs_path.exists():
+            raise FileNotFoundError(f"code_deps file not found: {dep_path}")
+        dep_hash, _ = cache.hash_file(abs_path)
+        # Normalize key to project-relative path for stable lockfiles
+        dep_rel = project.to_relative_path(abs_path)
+        result[f"file:{dep_rel}"] = dep_hash
+
+    return result
 
 
 def _flatten_deps(deps: dict[str, outputs.PathType]) -> list[str]:

--- a/packages/pivot/tests/fingerprint/README.md
+++ b/packages/pivot/tests/fingerprint/README.md
@@ -238,6 +238,23 @@ Tests in `test_callback_vulnerabilities.py` document edge cases where callback c
 
 ---
 
+## 13. `@no_fingerprint` Decorator (File-Level Hashing)
+
+When a stage uses `@pivot.no_fingerprint()`, AST fingerprinting is bypassed entirely. Change detection uses whole-file hashing instead.
+
+| Change Type                                    | Detected? | Test Reference                                                                  |
+| ---------------------------------------------- | --------- | ------------------------------------------------------------------------------- |
+| Stage source file content change               | ✅        | `test_no_fingerprint.py::test_no_fingerprint_reruns_on_source_file_change`      |
+| `code_deps` file content change                | ✅        | `test_no_fingerprint.py::test_no_fingerprint_reruns_on_code_deps_change`        |
+| Unrelated file change (no re-run)              | ✅        | `test_no_fingerprint.py::test_no_fingerprint_skip_unrelated_change`             |
+| Comment/whitespace change in source file       | ✅        | Not separately tested — file hash changes on any content change                 |
+| Helper function in different file              | ❌        | Not detected unless listed in `code_deps`                                       |
+| Missing `code_deps` file raises error          | ✅        | `test_no_fingerprint.py::test_no_fingerprint_missing_code_deps_file`            |
+| Mixed pipeline (AST + no_fingerprint)          | ✅        | `test_no_fingerprint.py::test_no_fingerprint_mixed_pipeline`                    |
+| Skip on unchanged (second run)                 | ✅        | `test_no_fingerprint.py::test_no_fingerprint_stage_skips_when_unchanged`        |
+
+---
+
 ## Summary: Remaining Gaps
 
 | Gap                                              | Priority | Difficulty                    |

--- a/packages/pivot/tests/fingerprint/test_no_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_no_fingerprint.py
@@ -1,0 +1,289 @@
+"""Integration tests for @no_fingerprint skip detection behavior."""
+
+from __future__ import annotations
+
+import math
+import pathlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pivot import decorators, executor, fingerprint, loaders, outputs, registry, stage_def
+from pivot.storage import cache, state
+
+if TYPE_CHECKING:
+    import inspect
+    import multiprocessing as mp
+    from collections.abc import Callable
+
+    from pivot.executor import WorkerStageInfo
+    from pivot.types import OutputMessage, StageResult
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+@decorators.no_fingerprint()
+def _helper_no_fingerprint_stage() -> None:
+    pathlib.Path("no_fingerprint_output.txt").write_text("output")
+
+
+@decorators.no_fingerprint(code_deps=["helper.py"])
+def _helper_no_fingerprint_with_code_dep() -> None:
+    pathlib.Path("code_dep_output.txt").write_text("output")
+
+
+@decorators.no_fingerprint(code_deps=["nonexistent.py"])
+def _helper_no_fingerprint_missing_dep() -> None:
+    pathlib.Path("missing_dep_output.txt").write_text("output")
+
+
+def _helper_ast_fingerprint_stage() -> None:
+    value = math.pi
+    pathlib.Path("ast_output.txt").write_text(str(value))
+
+
+def _make_stage_info(
+    func: Callable[..., object],
+    tmp_path: pathlib.Path,
+    *,
+    fingerprint: dict[str, str] | None = None,
+    deps: list[str] | None = None,
+    outs: list[outputs.BaseOut] | None = None,
+    params: stage_def.StageParams | None = None,
+    signature: inspect.Signature | None = None,
+    checkout_modes: list[cache.CheckoutMode] | None = None,
+    run_id: str = "test_run",
+    force: bool = False,
+    no_commit: bool = False,
+    dep_specs: dict[str, stage_def.FuncDepSpec] | None = None,
+    out_specs: dict[str, outputs.BaseOut] | None = None,
+    params_arg_name: str | None = None,
+) -> WorkerStageInfo:
+    expanded_outs = [outputs.require_expanded(out) for out in outs] if outs else []
+    expanded_out_specs = out_specs or {}
+    return {
+        "func": func,
+        "fingerprint": fingerprint or {"self:test": "abc123"},
+        "deps": deps or [],
+        "signature": signature,
+        "outs": expanded_outs,
+        "params": params,
+        "variant": None,
+        "overrides": {},
+        "checkout_modes": checkout_modes
+        or [cache.CheckoutMode.HARDLINK, cache.CheckoutMode.SYMLINK, cache.CheckoutMode.COPY],
+        "run_id": run_id,
+        "force": force,
+        "no_commit": no_commit,
+        "dep_specs": dep_specs or {},
+        "out_specs": expanded_out_specs,
+        "params_arg_name": params_arg_name,
+        "project_root": tmp_path,
+        "state_dir": tmp_path / ".pivot",
+    }
+
+
+def _apply_deferred_writes(
+    stage_name: str,
+    stage_info: WorkerStageInfo,
+    result: StageResult,
+) -> None:
+    if "deferred_writes" not in result:
+        return
+    deferred = result["deferred_writes"]
+    state_dir = stage_info["state_dir"]
+    out_paths = [str(out.path) for out in stage_info["outs"]]
+
+    with state.StateDB(state_dir / "state.db") as state_db:
+        state_db.apply_deferred_writes(stage_name, out_paths, deferred)
+
+
+def test_no_fingerprint_stage_skips_when_unchanged(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", _REPO_ROOT)
+    fingerprint_map = registry._compute_file_fingerprint(_helper_no_fingerprint_stage)
+    out = outputs.Out("no_fingerprint_output.txt", loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        _helper_no_fingerprint_stage,
+        tmp_path,
+        fingerprint=fingerprint_map,
+        outs=[out],
+    )
+
+    result1 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran", f"Expected ran, got: {result1}"
+    _apply_deferred_writes("no_fp", stage_info, result1)
+
+    result2 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
+    assert result2["status"] == "skipped", f"Expected skip, got: {result2}"
+
+
+def test_no_fingerprint_reruns_on_source_file_change(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+
+    stage_file = tmp_path / "stages.py"
+    stage_file.write_text(
+        "import pathlib\ndef stage_func():\n    pathlib.Path('source_output.txt').write_text('v1')\n"
+    )
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("stages", stage_file)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    decorators.no_fingerprint()(mod.stage_func)
+
+    fp1 = registry._compute_file_fingerprint(mod.stage_func)
+    assert any(k.startswith("file:") for k in fp1), "Fingerprint should include file: keys"
+
+    out = outputs.Out("source_output.txt", loader=loaders.PathOnly())
+    stage_info = _make_stage_info(mod.stage_func, tmp_path, fingerprint=fp1, outs=[out])
+
+    result1 = executor.execute_stage("src_fp", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran", f"Expected ran, got: {result1}"
+    _apply_deferred_writes("src_fp", stage_info, result1)
+
+    stage_file.write_text(
+        "import pathlib\ndef stage_func():\n    pathlib.Path('source_output.txt').write_text('v2')\n"
+    )
+    spec2 = importlib.util.spec_from_file_location("stages", stage_file)
+    assert spec2 is not None and spec2.loader is not None
+    mod2 = importlib.util.module_from_spec(spec2)
+    spec2.loader.exec_module(mod2)
+    decorators.no_fingerprint()(mod2.stage_func)
+
+    fp2 = registry._compute_file_fingerprint(mod2.stage_func)
+    assert fp1 != fp2, "Fingerprint should change when source file is modified"
+
+    stage_info_changed = _make_stage_info(mod2.stage_func, tmp_path, fingerprint=fp2, outs=[out])
+
+    result2 = executor.execute_stage("src_fp", stage_info_changed, worker_env, output_queue)
+    assert result2["status"] == "ran", f"Expected re-run, got: {result2}"
+    assert result2["reason"] == "Code changed", "Expected Code changed reason"
+
+
+def test_no_fingerprint_reruns_on_code_deps_change(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    (tmp_path / "helper.py").write_text("value = 1\n")
+
+    fingerprint_map = registry._compute_file_fingerprint(_helper_no_fingerprint_with_code_dep)
+    assert "file:helper.py" in fingerprint_map, "Fingerprint should include helper.py"
+
+    out = outputs.Out("code_dep_output.txt", loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        _helper_no_fingerprint_with_code_dep,
+        tmp_path,
+        fingerprint=fingerprint_map,
+        outs=[out],
+    )
+
+    result1 = executor.execute_stage("no_fp_dep", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran", f"Expected ran, got: {result1}"
+    _apply_deferred_writes("no_fp_dep", stage_info, result1)
+
+    (tmp_path / "helper.py").write_text("value = 2\n")
+    fingerprint_changed = registry._compute_file_fingerprint(_helper_no_fingerprint_with_code_dep)
+    stage_info_changed = _make_stage_info(
+        _helper_no_fingerprint_with_code_dep,
+        tmp_path,
+        fingerprint=fingerprint_changed,
+        outs=[out],
+    )
+
+    result2 = executor.execute_stage("no_fp_dep", stage_info_changed, worker_env, output_queue)
+    assert result2["status"] == "ran", f"Expected re-run, got: {result2}"
+    assert result2["reason"] == "Code changed", "Expected Code changed reason"
+
+
+def test_no_fingerprint_skip_unrelated_change(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", _REPO_ROOT)
+    fingerprint_map = registry._compute_file_fingerprint(_helper_no_fingerprint_stage)
+
+    out = outputs.Out("no_fingerprint_output.txt", loader=loaders.PathOnly())
+    stage_info = _make_stage_info(
+        _helper_no_fingerprint_stage,
+        tmp_path,
+        fingerprint=fingerprint_map,
+        outs=[out],
+    )
+
+    result1 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
+    assert result1["status"] == "ran", f"Expected ran, got: {result1}"
+    _apply_deferred_writes("no_fp", stage_info, result1)
+
+    (tmp_path / "unrelated.txt").write_text("unrelated")
+    result2 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
+    assert result2["status"] == "skipped", f"Expected skip, got: {result2}"
+
+
+def test_no_fingerprint_mixed_pipeline(
+    worker_env: pathlib.Path,
+    output_queue: mp.Queue[OutputMessage],
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", _REPO_ROOT)
+    ast_fingerprint = fingerprint.get_stage_fingerprint_cached(
+        "ast_stage", _helper_ast_fingerprint_stage
+    )
+    no_fp_fingerprint = registry._compute_file_fingerprint(_helper_no_fingerprint_stage)
+
+    ast_out = outputs.Out("ast_output.txt", loader=loaders.PathOnly())
+    no_fp_out = outputs.Out("no_fingerprint_output.txt", loader=loaders.PathOnly())
+
+    ast_info = _make_stage_info(
+        _helper_ast_fingerprint_stage,
+        tmp_path,
+        fingerprint=ast_fingerprint,
+        outs=[ast_out],
+    )
+    no_fp_info = _make_stage_info(
+        _helper_no_fingerprint_stage,
+        tmp_path,
+        fingerprint=no_fp_fingerprint,
+        outs=[no_fp_out],
+    )
+
+    result1_ast = executor.execute_stage("ast_stage", ast_info, worker_env, output_queue)
+    assert result1_ast["status"] == "ran", f"Expected ran, got: {result1_ast}"
+    _apply_deferred_writes("ast_stage", ast_info, result1_ast)
+
+    result1_no_fp = executor.execute_stage("no_fp", no_fp_info, worker_env, output_queue)
+    assert result1_no_fp["status"] == "ran", f"Expected ran, got: {result1_no_fp}"
+    _apply_deferred_writes("no_fp", no_fp_info, result1_no_fp)
+
+    result2_ast = executor.execute_stage("ast_stage", ast_info, worker_env, output_queue)
+    assert result2_ast["status"] == "skipped", f"Expected skip, got: {result2_ast}"
+
+    result2_no_fp = executor.execute_stage("no_fp", no_fp_info, worker_env, output_queue)
+    assert result2_no_fp["status"] == "skipped", f"Expected skip, got: {result2_no_fp}"
+
+
+def test_no_fingerprint_missing_code_deps_file(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
+    with pytest.raises(FileNotFoundError, match="nonexistent.py"):
+        registry._compute_file_fingerprint(_helper_no_fingerprint_missing_dep)

--- a/skills/writing-pivot-stages/SKILL.md
+++ b/skills/writing-pivot-stages/SKILL.md
@@ -239,13 +239,36 @@ class NPY(Loader[np.ndarray, np.ndarray]):
 - Loaders must be module-level classes (not closures)
 - Implement `empty()` only if the loader will be used with `IncrementalOut`
 
+## StageParams Defaults
+
+Pydantic deep-copies all defaults (lists, dicts, nested models, TypedDicts). **Never use `default_factory`** for mutable defaults — use plain values:
+
+```python
+# WRONG — unnecessary complexity
+class MyParams(StageParams):
+    exclude: list[str] = pydantic.Field(default_factory=list)
+    styling: dict[str, Any] = pydantic.Field(default_factory=dict)
+    percents: list[int] = pydantic.Field(default_factory=lambda: [50, 80])
+    plots: PlotParams = pydantic.Field(default_factory=PlotParams)
+
+# CORRECT — Pydantic handles all of these safely
+class MyParams(StageParams):
+    exclude: list[str] = []
+    styling: dict[str, Any] = {}
+    percents: list[int] = [50, 80]
+    plots: PlotParams = PlotParams()
+```
+
+Only use `pydantic.Field()` when you need its features (`alias`, `description`, `ge`, etc.), not just for defaults.
+
 ## Critical Rules
 
 1. **All paths relative to project root** — not relative to stage file
 2. **No manual file I/O** — no `pd.read_csv()`, `to_csv()`, `open()` in stage body
 3. **File paths in annotations, not params** — `StageParams` for config only
-4. **Stages must be module-level functions** — lambdas/closures fail pickling
-5. **TypedDict outputs must be module-level** — not defined inside functions
+4. **No `default_factory` for mutable defaults** — Pydantic deep-copies; use `= []`, `= {}`, `= Model()` directly
+5. **Stages must be module-level functions** — lambdas/closures fail pickling
+6. **TypedDict outputs must be module-level** — not defined inside functions
 
 ## Running Stages
 
@@ -318,6 +341,7 @@ def test_my_stage():
 
 - [ ] No manual file I/O in stage function
 - [ ] No file paths in `StageParams`
+- [ ] No `default_factory` in `StageParams` (use plain defaults: `= []`, `= {}`, `= Model()`)
 - [ ] All Dep/Out paths relative to project root
 - [ ] Stage is module-level function (not closure)
 - [ ] TypedDict outputs defined at module level


### PR DESCRIPTION
## Summary

Adds a `@pivot.no_fingerprint()` decorator that replaces AST-based code fingerprinting with simple `.py` file hashing per-stage. This gives teams a safe fallback that preserves Pivot's benefits (auto-parallelization, warm workers, DAG resolution) while using simpler, more predictable change detection.

## Changes

- **`pivot/decorators.py`** (new): `no_fingerprint(code_deps=)` decorator that attaches metadata to stage functions
- **`pivot/registry.py`**: `_compute_file_fingerprint()` helper that hashes source files instead of AST-walking; loader fingerprints are still included
- **`pivot/__init__.py`**: Exports `no_fingerprint`, `Pipeline`, `StageParams`, `DirectoryOut` from top-level package
- **Integration tests**: 6 tests covering skip detection, re-run on code change, code_deps, mixed pipelines, error handling

## Usage

```python
import pivot

@pivot.no_fingerprint()
def train(data: Annotated[DataFrame, Dep("input.csv", CSV())]):
    ...

# With additional code dependency tracking
@pivot.no_fingerprint(code_deps=["src/utils.py"])
def train(data: Annotated[DataFrame, Dep("input.csv", CSV())]):
    ...
```

## Safety features

- `inspect.unwrap()` handles stacked decorators correctly
- `code_deps` paths are normalized to project-relative for stable lockfiles
- Guard against `@no_fingerprint` without parentheses (clear TypeError)
- Missing `code_deps` files raise `FileNotFoundError` with the path
- Loader fingerprints are still included (Reader/Writer changes trigger re-runs)

## Design doc

`docs/plans/2026-02-11-no-fingerprint-decorator.md`