### PR TITLE
feat: harden fingerprinting with 8 fixes for under-invalidation bugs

### DIFF
--- a/docs/architecture/fingerprinting.md
+++ b/docs/architecture/fingerprinting.md
@@ -225,7 +225,7 @@ The fingerprint manifest uses prefixed keys to distinguish different types of tr
 | `mod:` | Module attribute access patterns | `mod:utils.helper` |
 | `partial:` | `functools.partial` bound arguments | `partial:0`, `partial:kwarg_name` |
 | `loader:` | Loader class methods and config | `loader:load`, `loader:save`, `loader:config` |
-| `pydantic:` | Pydantic model field defaults | `pydantic:field_name` |
+| `schema:` | Pydantic model JSON schema | `schema:ModelName` |
 | `builtin:` | Built-in types (for deterministic hashing) | `builtin:list` |
 
 ## Comparison with Other Tools

--- a/packages/pivot/src/pivot/cli/decorators.py
+++ b/packages/pivot/src/pivot/cli/decorators.py
@@ -50,6 +50,15 @@ def with_error_handling[**P, R](func: Callable[P, R]) -> Callable[P, R]:
             raise
         except exceptions.PivotError as e:
             raise _handle_pivot_error(e) from e
+        except BaseExceptionGroup as eg:
+            # Async TaskGroups wrap exceptions in ExceptionGroup.
+            # Unwrap to find PivotErrors for user-friendly formatting.
+            pivot_errors = eg.subgroup(exceptions.PivotError)
+            if pivot_errors is not None:
+                messages = [str(e) for e in pivot_errors.exceptions]
+                raise click.ClickException("\n".join(messages)) from eg
+            logger.debug("Unhandled ExceptionGroup in CLI command", exc_info=True)
+            raise click.ClickException(repr(eg)) from eg
         except Exception as e:
             logger.debug("Unhandled exception in CLI command", exc_info=True)
             raise click.ClickException(repr(e)) from e

--- a/packages/pivot/src/pivot/fingerprint.py
+++ b/packages/pivot/src/pivot/fingerprint.py
@@ -16,7 +16,7 @@ import types
 import typing
 import weakref
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import xxhash
 
@@ -29,13 +29,21 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 _PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-_CACHE_SCHEMA_VERSION = 1
+_CACHE_SCHEMA_VERSION = 2
+_REPR_SIZE_LIMIT = 10_000
 
 _SITE_PACKAGE_PATHS = ("site-packages", "dist-packages")
 
 # Type alias for AST hash cache entry tuple.
 # Format: (rel_path, mtime_ns, size, inode, qualname, py_version, schema_version, hash_hex)
 type AstHashEntry = tuple[str, int, int, int, str, str, int, str]
+
+
+class _PydanticModelProtocol(Protocol):
+    model_fields: Mapping[str, Any]
+
+    @classmethod
+    def model_json_schema(cls) -> dict[str, Any]: ...
 
 
 def _init_stdlib_paths() -> tuple[pathlib.Path, ...]:
@@ -476,6 +484,38 @@ def _collect_nested_code_globals(code: types.CodeType) -> set[str]:
     return nested_globals
 
 
+def _check_dynamic_name_access(func: Callable[..., Any]) -> None:
+    try:
+        source = inspect.getsource(func)
+        tree = ast.parse(textwrap.dedent(source))
+    except (OSError, TypeError, SyntaxError):
+        return
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "getattr" and len(node.args) >= 2:
+                if not isinstance(node.args[1], ast.Constant):
+                    message = (
+                        f"'{getattr(func, '__qualname__', '?')}' uses getattr() "
+                        + "with non-literal attribute. Use direct attribute access."
+                    )
+                    raise exceptions.StageDefinitionError(message)
+            elif node.func.id in ("globals", "locals"):
+                message = (
+                    f"'{getattr(func, '__qualname__', '?')}' uses {node.func.id}() "
+                    + "which bypasses fingerprint tracking."
+                )
+                raise exceptions.StageDefinitionError(message)
+        elif isinstance(node.func, ast.Attribute) and node.func.attr == "import_module":
+            message = (
+                f"'{getattr(func, '__qualname__', '?')}' uses dynamic imports. "
+                + "Use static imports instead."
+            )
+            raise exceptions.StageDefinitionError(message)
+
+
 def _get_stage_fingerprint_impl(func: Callable[..., Any], visited: set[int]) -> dict[str, str]:
     """Internal implementation of get_stage_fingerprint."""
     manifest = dict[str, str]()
@@ -488,6 +528,9 @@ def _get_stage_fingerprint_impl(func: Callable[..., Any], visited: set[int]) -> 
     func_name = getattr(func, "__name__", "<lambda>")
     manifest[f"self:{func_name}"] = hash_function_ast(func)
 
+    if is_user_code(func):
+        _check_dynamic_name_access(func)
+
     _t_closure = metrics.start()
     try:
         # Use cached result if available (getclosurevars is expensive at ~0.5ms)
@@ -496,6 +539,8 @@ def _get_stage_fingerprint_impl(func: Callable[..., Any], visited: set[int]) -> 
             _getclosurevars_cache[func] = closure_vars
     except (TypeError, AttributeError):
         metrics.end("fingerprint.getclosurevars", _t_closure)
+        if isinstance(func, type):
+            _process_class_body_dependencies(func, manifest, visited)
         return manifest
     metrics.end("fingerprint.getclosurevars", _t_closure)
 
@@ -542,6 +587,109 @@ def _get_stage_fingerprint_impl(func: Callable[..., Any], visited: set[int]) -> 
     _process_type_hint_dependencies(func, manifest, visited)
 
     return manifest
+
+
+def _process_class_body_dependencies(
+    cls: type, manifest: dict[str, str], visited: set[int]
+) -> None:
+    try:
+        source = inspect.getsource(cls)
+        tree = ast.parse(textwrap.dedent(source))
+    except (OSError, TypeError, SyntaxError):
+        return
+
+    class_def = next((node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)), None)
+    if class_def is None:
+        return
+
+    module = sys.modules.get(cls.__module__)
+    if module is None:
+        return
+    ns = vars(module)
+
+    names = set[str]()
+    dotted_refs = list[tuple[str, ...]]()
+
+    for base_node in class_def.bases:
+        _collect_annotation_names(base_node, names, dotted_refs)
+
+    for stmt in class_def.body:
+        if isinstance(stmt, ast.AnnAssign):
+            _collect_annotation_names(stmt.annotation, names, dotted_refs)
+
+    for name in names:
+        if name not in ns:
+            continue
+        value = ns[name]
+        if isinstance(value, type) and is_user_code(value):
+            key = f"class:{name}"
+            if key not in manifest:
+                _add_callable_to_manifest(key, value, manifest, visited)
+            if hasattr(value, "model_fields"):
+                _hash_pydantic_schema(
+                    cast("type[_PydanticModelProtocol]", value), manifest, visited
+                )
+
+    for parts in dotted_refs:
+        resolved = _resolve_dotted_path(parts, ns)
+        if resolved is None or not isinstance(resolved, type) or not is_user_code(resolved):
+            continue
+        key = f"class:{parts[-1]}"
+        if key not in manifest:
+            _add_callable_to_manifest(key, resolved, manifest, visited)
+        if hasattr(resolved, "model_fields"):
+            _hash_pydantic_schema(cast("type[_PydanticModelProtocol]", resolved), manifest, visited)
+
+
+def _collect_annotation_names(
+    node: ast.AST, names: set[str], dotted_refs: list[tuple[str, ...]]
+) -> None:
+    if isinstance(node, ast.Name):
+        names.add(node.id)
+    elif isinstance(node, ast.Subscript):
+        _collect_annotation_names(node.value, names, dotted_refs)
+        _collect_annotation_names(node.slice, names, dotted_refs)
+    elif isinstance(node, ast.BinOp):
+        _collect_annotation_names(node.left, names, dotted_refs)
+        _collect_annotation_names(node.right, names, dotted_refs)
+    elif isinstance(node, ast.Tuple):
+        for elt in node.elts:
+            _collect_annotation_names(elt, names, dotted_refs)
+    elif isinstance(node, ast.Attribute):
+        parts = _collect_dotted_path(node)
+        if len(parts) >= 2:
+            dotted_refs.append(parts)
+    elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+        # Handle dotted string annotations like "pkg.Type" by treating as dotted ref
+        if "." in node.value:
+            parts = tuple(node.value.split("."))
+            if len(parts) >= 2:
+                dotted_refs.append(parts)
+        else:
+            names.add(node.value)
+
+
+def _collect_dotted_path(node: ast.Attribute) -> tuple[str, ...]:
+    parts = [node.attr]
+    current = node.value
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return tuple(reversed(parts))
+    return ()
+
+
+def _resolve_dotted_path(parts: tuple[str, ...], ns: dict[str, Any]) -> Any:
+    if parts[0] not in ns:
+        return None
+    obj = ns[parts[0]]
+    for part in parts[1:]:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    return obj
 
 
 def get_loader_fingerprint(loader: "loaders.Writer[Any] | loaders.Reader[Any]") -> dict[str, str]:
@@ -614,15 +762,33 @@ def _is_unsafe_fingerprinting_enabled() -> bool:
 def _check_mutable_capture(var_name: str, value: Any, stage_name: str) -> None:
     message = (
         f"Stage '{stage_name}': closure captures mutable variable '{var_name}' "
-        f"(type: {type(value).__name__}).\n"
-        "Pivot cannot track changes to mutable runtime state, which may cause silent wrong outputs.\n"
-        "Fix: pass this data via StageParams or declare it as a Dep(...) input.\n"
-        "To suppress: set core.unsafe_fingerprinting=true or PIVOT_UNSAFE_FINGERPRINTING=1"
+        + f"(type: {type(value).__name__}).\n"
+        + "Pivot cannot track changes to mutable runtime state, which may cause silent wrong "
+        + "outputs.\n"
+        + "Fix: pass this data via StageParams or declare it as a Dep(...) input.\n"
+        + "To suppress: set core.unsafe_fingerprinting=true or PIVOT_UNSAFE_FINGERPRINTING=1"
     )
     if _is_unsafe_fingerprinting_enabled():
         _logger.warning(message)
         return
     raise exceptions.StageDefinitionError(message)
+
+
+def _check_data_class_methods(cls: type) -> None:
+    allowed = frozenset({"model_post_init", "model_validate", "model_rebuild"})
+    user_methods = [
+        name
+        for name, val in vars(cls).items()
+        if callable(val)
+        and not (name.startswith("__") and name.endswith("__"))
+        and name not in allowed
+    ]
+    if user_methods:
+        message = (
+            f"Data class '{cls.__qualname__}' has methods {user_methods}. "
+            + "Move these to standalone functions for reliable change detection."
+        )
+        raise exceptions.StageDefinitionError(message)
 
 
 def _is_frozen_dataclass(value: Any) -> bool:
@@ -642,6 +808,23 @@ def _is_frozen_pydantic(value: Any) -> bool:
         return bool(model_config.get("frozen", False))
     except AttributeError:
         return False
+
+
+def _hash_unrecognized_closure_value(
+    name: str, value: Any, manifest: dict[str, str], stage_name: str
+) -> None:
+    try:
+        value_repr = repr(value)
+    except Exception:
+        _check_mutable_capture(name, value, stage_name)
+        return
+    if "0x" in value_repr:
+        _check_mutable_capture(name, value, stage_name)
+        return
+    if len(value_repr) > _REPR_SIZE_LIMIT:
+        _check_mutable_capture(name, value, stage_name)
+        return
+    manifest[f"const:{name}"] = xxhash.xxh64(value_repr.encode()).hexdigest()
 
 
 def _process_closure_values(
@@ -667,8 +850,16 @@ def _process_closure_values(
             )
         elif callable(value) and is_user_code(value):
             _process_callable_dependency(name, value, manifest, visited)
+        elif callable(value):
+            # Non-user-code callables (stdlib/third-party functions like typing.cast,
+            # json.dumps) are tracked via module dependency when accessed as module.func.
+            # Skip them here — their repr contains memory addresses (0x...) which would
+            # trigger _check_mutable_capture falsely.
+            continue
         elif include_modules and isinstance(value, types.ModuleType):
             _process_module_dependency(name, value, func, manifest, visited)
+        elif isinstance(value, logging.Logger):
+            continue
         elif isinstance(value, (bool, int, float, str, bytes, type(None))):
             manifest[f"const:{name}"] = repr(value)
         elif isinstance(value, (dict, list, tuple, set, frozenset)):
@@ -689,6 +880,8 @@ def _process_closure_values(
             else:
                 _check_mutable_capture(name, value, stage_name)
                 _process_instance_dependency(name, value, manifest, visited)
+        else:
+            _hash_unrecognized_closure_value(name, value, manifest, stage_name)
 
 
 def _process_callable_dependency(
@@ -736,6 +929,31 @@ def _process_instance_dependency(
     _add_callable_to_manifest(f"class:{name}.__class__", cls, manifest, visited)
 
 
+def _resolve_annotations_individually(func: Callable[..., Any]) -> dict[str, Any]:
+    raw = getattr(func, "__annotations__", None)
+    if not raw:
+        return {}
+
+    globalns = getattr(func, "__globals__", {})
+    resolved = dict[str, Any]()
+
+    for name, annotation in raw.items():
+        if isinstance(annotation, type):
+            resolved[name] = annotation
+        elif isinstance(annotation, str):
+            try:
+                result = eval(annotation, globalns)
+            except Exception:
+                continue
+            if isinstance(result, str) and result in globalns:
+                result = globalns[result]
+            resolved[name] = result
+        else:
+            resolved[name] = annotation
+
+    return resolved
+
+
 def _process_type_hint_dependencies(
     func: Callable[..., Any], manifest: dict[str, str], visited: set[int]
 ) -> None:
@@ -751,8 +969,7 @@ def _process_type_hint_dependencies(
         try:
             hints = typing.get_type_hints(func)
         except Exception:
-            metrics.end("fingerprint.get_type_hints", _t)
-            return
+            hints = _resolve_annotations_individually(func)
         # Cache result if function is weakly referenceable
         with contextlib.suppress(TypeError):
             _get_type_hints_cache[func] = hints
@@ -770,6 +987,16 @@ def _process_type_hint(hint: Any, manifest: dict[str, str], visited: set[int]) -
 
     origin = typing.get_origin(hint)
     if origin is not None:
+        # Track user-defined generic classes (e.g., MyGeneric[int] -> hash MyGeneric)
+        if isinstance(origin, type) and is_user_code(origin):
+            origin_type = cast("type[Any]", origin)
+            key = f"class:{origin_type.__name__}"
+            if key not in manifest:
+                _add_callable_to_manifest(key, origin_type, manifest, visited)
+            if hasattr(origin_type, "model_fields"):
+                _hash_pydantic_schema(
+                    cast("type[_PydanticModelProtocol]", origin_type), manifest, visited
+                )
         for arg in typing.get_args(hint):
             _process_type_hint(arg, manifest, visited)
         return
@@ -777,40 +1004,114 @@ def _process_type_hint(hint: Any, manifest: dict[str, str], visited: set[int]) -
     if not isinstance(hint, type):
         return
 
-    if not is_user_code(hint):
-        return
+    hint_type = cast("type[Any]", hint)
 
-    key = f"class:{hint.__name__}"
+    if not is_user_code(hint_type):
+        return
+    if dataclasses.is_dataclass(hint_type):
+        _check_data_class_methods(hint_type)
+
+    key = f"class:{hint_type.__name__}"
     if key not in manifest:
-        _add_callable_to_manifest(key, hint, manifest, visited)
+        _add_callable_to_manifest(key, hint_type, manifest, visited)
 
-    # Always hash Pydantic defaults (even if class was already added via closure vars)
-    if hasattr(hint, "model_fields"):
-        _hash_pydantic_defaults(hint, manifest)
+    # Always hash Pydantic schema (even if class was already added via closure vars)
+    if hasattr(hint_type, "model_fields"):
+        _hash_pydantic_schema(cast("type[_PydanticModelProtocol]", hint_type), manifest, visited)
 
 
-def _hash_pydantic_defaults(model: type, manifest: dict[str, str]) -> None:
-    """Hash Pydantic model field default values including default_factory."""
-    model_fields = getattr(model, "model_fields", {})
-    if not model_fields:
+def _strip_schema_metadata(schema: dict[str, Any]) -> dict[str, Any]:
+    """Strip title/description to avoid false invalidation from docstring changes."""
+    stripped = {k: v for k, v in schema.items() if k not in ("title", "description")}
+    defs_raw = stripped.get("$defs")
+    if isinstance(defs_raw, dict):
+        defs = cast("dict[str, Any]", defs_raw)
+        cleaned_defs = dict[str, Any]()
+        for name, definition in defs.items():
+            if isinstance(definition, dict):
+                cleaned_defs[name] = _strip_schema_metadata(cast("dict[str, Any]", definition))
+            else:
+                cleaned_defs[name] = definition
+        stripped["$defs"] = cleaned_defs
+    properties_raw = stripped.get("properties")
+    if isinstance(properties_raw, dict):
+        properties = cast("dict[str, Any]", properties_raw)
+        cleaned_properties = dict[str, Any]()
+        for name, prop in properties.items():
+            if isinstance(prop, dict):
+                cleaned_properties[name] = _strip_schema_metadata(cast("dict[str, Any]", prop))
+            else:
+                cleaned_properties[name] = prop
+        stripped["properties"] = cleaned_properties
+    for key in ("items", "anyOf", "allOf", "oneOf"):
+        val = stripped.get(key)
+        if isinstance(val, dict):
+            stripped[key] = _strip_schema_metadata(cast("dict[str, Any]", val))
+        elif isinstance(val, list):
+            cleaned_items = list[Any]()
+            items = cast("list[Any]", val)
+            for item in items:
+                if isinstance(item, dict):
+                    cleaned_items.append(_strip_schema_metadata(cast("dict[str, Any]", item)))
+                else:
+                    cleaned_items.append(item)
+            stripped[key] = cleaned_items
+    return stripped
+
+
+def _hash_pydantic_schema(
+    model: type[_PydanticModelProtocol],
+    manifest: dict[str, str],
+    visited: set[int],
+) -> None:
+    schema_model = model
+    schema_key = f"schema:{schema_model.__name__}"
+    if schema_key in manifest:
         return
+    # Insert placeholder to prevent infinite recursion on self-referential models
+    # (e.g., class Node(BaseModel): children: list["Node"])
+    manifest[schema_key] = "<pending>"
+    schema_raw = schema_model.model_json_schema()
+    schema = _strip_schema_metadata(schema_raw)
 
+    model_fields = cast("Mapping[str, Any]", getattr(schema_model, "model_fields", {}))
+    default_hashes = dict[str, str]()
     for field_name, field_info in model_fields.items():
+        annotation = getattr(field_info, "annotation", None)
+        if annotation is not None:
+            _discover_pydantic_field_types(annotation, manifest, visited)
+
         default = getattr(field_info, "default", None)
         default_factory = getattr(field_info, "default_factory", None)
-
-        # Check for PydanticUndefined (no default) - don't skip None, it's a valid default
         if type(default).__name__ == "PydanticUndefinedType":
-            # No static default, check for default_factory
             if default_factory is not None and callable(default_factory):
-                # Hash the factory function itself (tracks code changes)
-                key = f"pydantic:{model.__name__}.{field_name}"
-                manifest[key] = hash_function_ast(default_factory)
+                default_hashes[field_name] = hash_function_ast(default_factory)
             continue
 
         value_str = _serialize_value_for_hash(default)
-        key = f"pydantic:{model.__name__}.{field_name}"
-        manifest[key] = xxhash.xxh64(value_str.encode()).hexdigest()
+        default_hashes[field_name] = xxhash.xxh64(value_str.encode()).hexdigest()
+
+    payload = {"schema": schema, "defaults": default_hashes}
+    manifest[schema_key] = xxhash.xxh64(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _discover_pydantic_field_types(
+    annotation: Any, manifest: dict[str, str], visited: set[int]
+) -> None:
+    origin = typing.get_origin(annotation)
+    if origin is not None:
+        for arg in typing.get_args(annotation):
+            _discover_pydantic_field_types(arg, manifest, visited)
+        return
+    if isinstance(annotation, type) and is_user_code(annotation):
+        annotation_type = cast("type[Any]", annotation)
+        key = f"class:{annotation_type.__name__}"
+        if key not in manifest:
+            _add_callable_to_manifest(key, annotation_type, manifest, visited)
+        if hasattr(annotation_type, "model_fields"):
+            _hash_pydantic_schema(
+                cast("type[_PydanticModelProtocol]", annotation_type), manifest, visited
+            )
 
 
 def _serialize_value_for_hash(value: Any) -> str:
@@ -1113,6 +1414,13 @@ def _compute_function_hash(func: Callable[..., Any]) -> str:
                 return xxhash.xxh64(marshal.dumps(func.__code__)).hexdigest()  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType] - hasattr guards access
             # KNOWN ISSUE: Using id(func) is non-deterministic across runs
             # This affects lambdas without source code, causing unnecessary re-runs
+            if is_user_code(func):
+                message = (
+                    "Cannot get source for '%s'. Using non-deterministic fallback — "
+                    + "this stage will re-run every time. Use a named function defined "
+                    + "in a source file for stable fingerprinting."
+                )
+                _logger.warning(message, getattr(func, "__qualname__", func))
             return xxhash.xxh64(str(id(func)).encode()).hexdigest()
         metrics.end("fingerprint.inspect_getsource", _t_source)
 
@@ -1195,6 +1503,11 @@ def _is_user_code_impl(obj: Any) -> bool:
     # Built-in modules (sys, builtins, _io, etc.) are not user code
     module_name = getattr(module, "__name__", "")
     if module_name in sys.builtin_module_names:
+        return False
+
+    # Pivot's own code is framework, not user code (matters for editable installs
+    # where pivot isn't in site-packages)
+    if module_name == "pivot" or module_name.startswith("pivot."):
         return False
 
     # Check for namespace packages (PEP 420): they have __path__ but no __file__

--- a/packages/pivot/tests/fingerprint/README.md
+++ b/packages/pivot/tests/fingerprint/README.md
@@ -11,6 +11,7 @@ This directory contains all tests for Pivot's automatic code change detection (f
 - **`test_functools.py`** - Tests for `functools.partial` and `functools.wraps` handling
 - **`test_callback_vulnerabilities.py`** - Tests documenting callback detection edge cases
 - **`test_determinism.py`** - Cross-process fingerprint stability tests (builtins, default_factory)
+- **`test_safe_fingerprinting.py`** - Tests for safe fingerprinting error guards (data class methods, dynamic name access)
 
 ---
 
@@ -37,6 +38,7 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Local variable rename           | ✅        | `test_change_detection.py::test_variable_rename_causes_miss`          |
 | Parameter name change           | ✅        | `test_fingerprint.py::test_different_variable_names_different_hash`   |
 | Type annotation change          | ✅        | `test_change_detection.py::test_type_annotation_change_causes_miss`   |
+| Type alias definition change    | ⚠️        | Without `from __future__ import annotations`: alias is in globals, hashed by closure catch-all. With `from __future__`: alias only in string annotation, not captured. |
 | Function name change            | 🚫        | `test_change_detection.py::test_function_rename_no_miss`              |
 | Docstring change                | 🚫        | `test_change_detection.py::test_docstring_change_no_miss`             |
 | Comment change                  | 🚫        | `test_change_detection.py::test_comment_change_no_miss`               |
@@ -57,17 +59,21 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Global constant change                               | ✅        | `test_change_detection.py::test_global_constant_change_causes_miss`                                                                 |
 | Global collection (list, dict, set) with callables   | ✅        | `test_change_detection.py::test_list_callable_tracking`, `test_change_detection.py::test_dispatch_dict_function_change_causes_miss` |
 | Global collection DATA (non-callable values)          | ❌        | `test_pydantic_defaults.py::test_list_constants_not_captured_as_const`                                                               |
-| Pydantic field default data                           | ✅        | `test_pydantic_defaults.py::test_pydantic_default_data_captured`                                                                     |
+| Pydantic schema hash (model_json_schema)              | ✅        | `test_pydantic_defaults.py::test_pydantic_default_data_captured`                                                                     |
 | Pydantic class in type hint                           | ✅        | `test_pydantic_defaults.py::test_pydantic_class_captured_from_type_hint`                                                             |
 | Global class instance                                | ✅        | `test_change_detection.py::test_class_instance_tracked`, `test_change_detection.py::test_class_instance_change_causes_miss`         |
 | Class definition change                              | ✅        | `test_change_detection.py::test_class_definition_change_causes_miss`                                                                |
 | Class method change                                  | ✅        | `test_change_detection.py::test_class_definition_change_causes_miss` (class AST includes methods)                                   |
+| Data class with user-defined methods                 | ✅ (error) | `test_fingerprint.py::test_check_data_class_methods_rejects_user_methods`                                                          |
+| Class base/field annotation dependencies             | ✅        | `test_fingerprint.py::test_process_class_body_dependencies_tracks_bases_and_annotations`                                            |
 | StageParams `@property` method change                | ✅        | `test_change_detection.py::test_stageparams_property_change_causes_miss`                                                            |
 | StageParams regular method change                    | ✅        | `test_change_detection.py::test_stageparams_method_change_causes_miss`                                                              |
 | StageParams `ClassVar` change                        | ✅        | `test_change_detection.py::test_stageparams_class_variable_change_causes_miss`                                                      |
 | Nested function body change                          | ✅        | `test_fingerprint.py::test_nested_function_not_in_globals` (detected via parent AST hash)                                           |
 | Globals referenced only by nested functions          | ✅        | `test_change_detection.py::test_nested_function_global_reference_detected`, `test_change_detection.py::test_nested_function_global_change_causes_miss` |
 | Helper starting with `_` prefix                      | ✅        | `test_change_detection.py::test_underscore_helper_change_detected`                                                                  |
+| Stdlib callable in closure (e.g., `typing.cast`)     | 🚫        | `test_fingerprint.py::test_stdlib_callable_in_closure_does_not_raise`                                                              |
+| `logging.Logger` in closure                          | 🚫        | Loggers are functionally irrelevant for cache invalidation                                                                          |
 | Helper starting with `__` dunder                     | ❌        | `test_fingerprint.py::test_fingerprint_with_underscore_globals`                                                                     |
 
 ---
@@ -128,6 +134,7 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Stdlib via module attr                     | 🚫        | `test_change_detection.py::test_stdlib_function_marked_callable`          |
 | Third-party function (e.g., `numpy.array`) | 🚫        | `test_fingerprint.py::test_is_user_code_non_user` (pytest.fixture tested) |
 | Third-party package version change         | ❌        | **NO TEST** - versions not tracked                                        |
+| Pivot framework code (`StageParams`, etc.) | 🚫        | `test_fingerprint.py::test_is_user_code_pivot_is_framework`               |
 | Builtin function (`len`, `print`)          | 🚫        | `test_fingerprint.py::test_fingerprint_builtin_function_skipped`          |
 
 ---
@@ -137,9 +144,12 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Change Type                              | Detected? | Test Reference                                                                                                                                |
 | ---------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `getattr(module, "func")`                | ❌        | **NO TEST** - can't resolve statically                                                                                                        |
+| `getattr(obj, name)` (non-literal)       | ✅ (error) | `test_fingerprint.py::test_check_dynamic_name_access_rejects_dynamic_getattr`                                                        |
+| `globals()` / `locals()`                 | ✅ (error) | `test_fingerprint.py::test_check_dynamic_name_access_rejects_globals`                                                                  |
 | `func_dict[key]()` dispatch              | ✅        | `test_change_detection.py::test_dynamic_dispatch_change_detected`, `test_change_detection.py::test_dispatch_dict_function_change_causes_miss` |
 | `eval()` / `exec()`                      | ❌        | **NO TEST** - can't analyze dynamically                                                                                                       |
 | `importlib.import_module(string)`        | ❌        | **NO TEST** - can't resolve statically                                                                                                        |
+| `importlib.import_module(...)` (call)    | ✅ (error) | `test_fingerprint.py::test_check_dynamic_name_access_rejects_import_module`                                                           |
 | Method call on instance (`obj.method()`) | ❌        | `test_change_detection.py::test_class_instance_method_change_detected` (xfail)                                                                |
 | Callback/function passed as argument     | ❌        | **NO TEST** - not tracked                                                                                                                     |
 | Closure capturing outer variable         | ⚠️        | `test_fingerprint.py::test_fingerprint_with_nonlocal` (value captured, not source)                                                            |
@@ -153,6 +163,9 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Nonlocal primitive constant       | ✅        | `test_fingerprint.py::test_fingerprint_with_nonlocal`              |
 | Nonlocal callable (user function) | ✅        | `test_fingerprint.py::test_fingerprint_nonlocal_callable_function` |
 | Closure variable value change     | ✅        | `test_fingerprint.py::test_fingerprint_callable_nonlocal`          |
+| Closure value with deterministic repr | ✅        | `test_fingerprint.py::test_fingerprint_captures_unrecognized_closure_value` |
+| Closure value with `0x` in repr (non-deterministic) | 🚫  | `test_fingerprint.py::test_hash_unrecognized_closure_value_memory_address_raises` |
+| Closure value with repr > 10KB        | 🚫        | `test_fingerprint.py::test_hash_unrecognized_closure_value_large_repr_raises` |
 
 ---
 
@@ -166,6 +179,11 @@ This document exhaustively catalogs what code changes are and are not detected b
 | Circular references                       | ✅        | `test_fingerprint.py::test_circular_reference_handled`                          |
 | Recursive function                        | ✅        | Covered by circular reference handling                                          |
 | `getclosurevars` raises exception         | ✅        | `test_fingerprint.py::test_fingerprint_getclosurevars_exception`                |
+| Mixed resolvable/unresolvable type hints  | ✅        | `test_fingerprint.py::test_resolve_annotations_individually_mixed`              |
+| Recursive Pydantic models (self-referential) | ✅     | `test_fingerprint.py::test_recursive_pydantic_model_no_infinite_recursion`      |
+| Mutually recursive Pydantic models        | ✅        | `test_fingerprint.py::test_mutual_recursive_pydantic_models`                    |
+| User-defined generic origin (`MyGeneric[int]`) | ✅   | `test_fingerprint.py::test_user_defined_generic_origin_tracked`                 |
+| Dotted string forward ref in class body   | ✅        | `test_fingerprint.py::test_collect_annotation_names_dotted_string_forward_ref`  |
 | Module not in sys.modules                 | ✅        | `test_fingerprint.py::test_is_user_code_module_not_in_sys_modules`              |
 | Attribute doesn't exist on module         | ✅        | `test_fingerprint.py::test_module_attr_with_attribute_error`                    |
 | Function with complex AST                 | ✅        | `test_fingerprint.py::test_hash_complex_ast`                                    |
@@ -220,17 +238,16 @@ Tests in `test_callback_vulnerabilities.py` document edge cases where callback c
 
 ---
 
-## Summary: Gaps Requiring New Tests
+## Summary: Remaining Gaps
 
 | Gap                                              | Priority | Difficulty                    |
 | ------------------------------------------------ | -------- | ----------------------------- |
 | Decorator on stage function not tracked          | Medium   | Easy                          |
 | Nested module attribute (`X.sub.func`) full test | Low      | Easy                          |
 | `import X` inside function not tracked           | Low      | Easy (already documented)     |
-| `getattr()` dynamic lookup                       | Low      | Easy                          |
 | `eval()`/`exec()` limitation                     | Low      | Easy                          |
-| `importlib.import_module()` limitation           | Low      | Easy                          |
 | Third-party package version tracking             | Medium   | Hard (would need new feature) |
+| Type alias change with `from __future__`         | Low      | Hard (alias only in string annotation, not in bytecode) |
 
 ---
 
@@ -252,19 +269,19 @@ Tests in `test_callback_vulnerabilities.py` document edge cases where callback c
 
 8. **Class definition tracking**: Classes are tracked using the `class:` prefix (e.g., `class:MyProcessor`). The entire class definition is hashed including all methods, class variables, and decorators. Module-level class instances (e.g., `processor = Processor()`) have their class type tracked via `class:varname.__class__`.
 
-9. **No inheritance tracking**: Base classes are not recursively tracked. Most user classes inherit from `object` or third-party framework classes (both intentionally ignored). If users have deep inheritance hierarchies of user-defined classes, they can factor shared logic into helper functions.
+9. **Class body dependency tracking**: When `getclosurevars()` fails on a class, the class body is parsed to capture base classes and field annotations. Resolved user-code classes are fingerprinted transitively; third-party/stdlib bases are ignored.
 
 10. **Callable instances tracked as functions**: Objects with `__call__` methods are matched by the `callable()` check before the instance check. This means changes to non-`__call__` methods on such classes may not trigger cache invalidation. Workaround: use the class directly instead of a pre-instantiated callable.
 
 11. **NamedTuple instances tracked as tuples**: `NamedTuple` instances inherit from `tuple` and are matched by the collection check. Changes to the `NamedTuple` class definition may not be detected. Workaround: use regular classes or dataclasses instead.
 
-12. **Pydantic field defaults ARE tracked**: Pydantic model classes used in type hints are automatically detected and their field default values are hashed. The fingerprint includes:
-    - `class:ModelName` - Hash of the class AST (captures structural changes)
-    - `pydantic:ModelName.field` - Hash of each field's default value (captures data changes)
+12. **Pydantic schemas ARE tracked**: Pydantic model classes used in type hints are automatically detected and their JSON schemas are hashed via `model_json_schema()` (with titles/descriptions stripped to avoid false invalidation from docstring changes). The fingerprint includes:
+    - `class:ModelName` - Hash of the class AST (captures structural changes including validators)
+    - `schema:ModelName` - Hash of JSON schema + field defaults (captures field types, defaults, configuration)
 
-    This allows Pivot to detect when Pydantic configuration changes without requiring explicit `deps`.
+    Nested model types are discovered by walking `model_fields` annotations, so changes to nested models propagate. A placeholder is inserted before field walking to prevent infinite recursion on self-referential models.
 
-    Tests: `test_pydantic_defaults.py::test_pydantic_default_data_captured`, `test_pydantic_defaults.py::test_pydantic_class_captured_from_type_hint`, `test_pydantic_defaults.py::test_pydantic_default_change_triggers_different_hash`
+    Tests: `test_pydantic_defaults.py::test_pydantic_default_data_captured`, `test_pydantic_defaults.py::test_pydantic_class_captured_from_type_hint`, `test_pydantic_defaults.py::test_pydantic_default_change_triggers_different_hash`, `test_fingerprint.py::test_recursive_pydantic_model_no_infinite_recursion`
 
 13. **`functools.wraps` / `__wrapped__` ARE tracked**: Functions decorated with `@functools.wraps` are properly fingerprinted using bytecode hashing. Since `inspect.getsource()` follows the `__wrapped__` chain and returns the original function's source, we detect `__wrapped__` and use `marshal.dumps(__code__)` to hash the wrapper's bytecode instead. This correctly captures decorator logic changes while closure analysis still tracks the wrapped function.
 
@@ -303,3 +320,23 @@ Tests in `test_callback_vulnerabilities.py` document edge cases where callback c
 20. **Manifest cache invalidation is path-scoped**: Watch-mode reloads invalidate only the cached manifests whose source maps include changed paths, leaving unaffected stage manifests intact. Affected stages are recomputed on next fingerprint access and re-cached.
 
     Tests: `test_fingerprint.py::test_invalidate_manifests_for_paths_selective`, `test_fingerprint.py::test_invalidate_manifests_for_paths_recomputes_affected_stage`, `test_fingerprint.py::test_invalidate_manifests_for_paths_cold_start`
+
+21. **Pivot framework excluded from `is_user_code`**: Modules in the `pivot` package are treated as framework code, not user code. This prevents framework internals (e.g., `StageParams`, `Out`, `Dep`) from appearing in manifests when using editable installs where pivot isn't in `site-packages`.
+
+    Tests: `test_fingerprint.py::test_is_user_code_pivot_is_framework`
+
+22. **Unrecognized closure values hashed via `repr()` with guards**: Values in closures that don't match known types (callables, modules, primitives, collections, class instances) are hashed using `repr()` if the repr is deterministic (no `0x` memory addresses) and small (< 10KB). This catches datetime objects, regex patterns, enum values, etc. Non-deterministic or oversized reprs fall back to `_check_mutable_capture`.
+
+    Tests: `test_fingerprint.py::test_hash_unrecognized_closure_value_deterministic_repr`, `test_fingerprint.py::test_hash_unrecognized_closure_value_memory_address_raises`, `test_fingerprint.py::test_fingerprint_captures_unrecognized_closure_value`
+
+23. **Per-annotation type hint fallback**: When `typing.get_type_hints()` fails (e.g., one unresolvable `TYPE_CHECKING` import kills resolution for all annotations), each annotation string is evaluated individually via `eval()` in the function's global namespace. Resolvable annotations are still tracked; unresolvable ones are skipped.
+
+    Tests: `test_fingerprint.py::test_resolve_annotations_individually_mixed`
+
+24. **Non-user-code callables silently skipped**: Stdlib/third-party callables captured in closures (e.g., `typing.cast`, `json.dumps`) are skipped rather than hashed. Their `repr()` contains memory addresses (`0x...`) which would trigger false mutable-capture errors. These functions are already tracked via module dependency analysis when accessed as `module.func`.
+
+    Tests: `test_fingerprint.py::test_stdlib_callable_in_closure_does_not_raise`
+
+25. **Loggers silently skipped**: `logging.Logger` instances captured in closures are skipped. Module-level loggers (`_logger = logging.getLogger(__name__)`) are functionally irrelevant for cache invalidation — their repr can change based on logging configuration.
+
+26. **User-defined generic origins tracked**: For generic types like `MyContainer[int]`, the origin class (`MyContainer`) is now fingerprinted if it's user code. Previously only the type arguments were walked.

--- a/packages/pivot/tests/fingerprint/test_determinism.py
+++ b/packages/pivot/tests/fingerprint/test_determinism.py
@@ -100,7 +100,7 @@ class Model(pydantic.BaseModel):
 
 def stage(params: Model) -> None: pass
 
-print(fingerprint.get_stage_fingerprint(stage)["pydantic:Model.items"])
+print(fingerprint.get_stage_fingerprint(stage)["schema:Model"])
 """
     results = list[str]()
     for _ in range(2):
@@ -127,7 +127,7 @@ class Model(pydantic.BaseModel):
 
 def stage(params: Model) -> None: pass
 
-print(fingerprint.get_stage_fingerprint(stage)["pydantic:Model.data"])
+print(fingerprint.get_stage_fingerprint(stage)["schema:Model"])
 """
     results = list[str]()
     for _ in range(2):
@@ -177,7 +177,7 @@ def test_default_factory_list_produces_stable_hash():
     fp1 = fingerprint.get_stage_fingerprint(stage)
     fp2 = fingerprint.get_stage_fingerprint(stage)
 
-    assert fp1["pydantic:Model.items"] == fp2["pydantic:Model.items"]
+    assert fp1["schema:Model"] == fp2["schema:Model"]
 
 
 def test_default_factory_dict_produces_stable_hash():
@@ -192,7 +192,7 @@ def test_default_factory_dict_produces_stable_hash():
     fp1 = fingerprint.get_stage_fingerprint(stage)
     fp2 = fingerprint.get_stage_fingerprint(stage)
 
-    assert fp1["pydantic:Model.data"] == fp2["pydantic:Model.data"]
+    assert fp1["schema:Model"] == fp2["schema:Model"]
 
 
 def test_different_builtin_factories_have_different_hashes():
@@ -213,7 +213,7 @@ def test_different_builtin_factories_have_different_hashes():
     fp_list = fingerprint.get_stage_fingerprint(stage_list)
     fp_dict = fingerprint.get_stage_fingerprint(stage_dict)
 
-    assert fp_list["pydantic:ModelWithList.items"] != fp_dict["pydantic:ModelWithDict.items"], (
+    assert fp_list["schema:ModelWithList"] != fp_dict["schema:ModelWithDict"], (
         "Different builtin factories should produce different hashes"
     )
 

--- a/packages/pivot/tests/fingerprint/test_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_fingerprint.py
@@ -1,18 +1,27 @@
 # pyright: reportUnusedFunction=false, reportUnusedParameter=false, reportUnknownLambdaType=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportImplicitOverride=false
 
 import ast
+import dataclasses
+import datetime
 import importlib.util
+import inspect
 import json
+import logging
 import math
 import os
 import pathlib
 import sys
 import time
+import types
+import typing
 
 import networkx as nx
+import pydantic
 import pytest
+import xxhash
+from pydantic import BaseModel
 
-from pivot import ast_utils, fingerprint
+from pivot import ast_utils, exceptions, fingerprint
 from pivot.storage import state as state_mod
 
 # --- Module-level helper functions for testing ---
@@ -79,12 +88,54 @@ def _helper_with_math_pi():
     return math.pi * 2
 
 
+class _HelperForwardRef:
+    pass
+
+
+class _HelperForwardRefString:
+    pass
+
+
+if typing.TYPE_CHECKING:
+
+    class MissingType:
+        pass
+
+
+def _helper_annotations_mixed(
+    a: "int",
+    b: "_HelperForwardRef",
+    c: "MissingType",
+    d: int,
+    e: '"_HelperForwardRefString"',
+    f: typing.Any,
+) -> "_HelperForwardRef":
+    return _HelperForwardRef()
+
+
 # Constants for testing constant capture (no underscore prefix!)
 TEST_STRING = "Hello, World!"
 TEST_BYTES = b"binary data"
 TEST_NONE = None
 TEST_FLOAT = 3.14159
 TEST_BOOL = True
+TEST_DATETIME = datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.UTC)
+
+
+class _HelperReprError:
+    __module__ = "builtins"
+
+    def __repr__(self) -> str:
+        raise RuntimeError("repr failure")
+
+
+class _PydanticInnerModel(pydantic.BaseModel):
+    value: int = 1
+
+
+class _PydanticOuterModel(pydantic.BaseModel):
+    inner: _PydanticInnerModel
+    items: list[_PydanticInnerModel]
 
 
 def _helper_uses_string():
@@ -112,11 +163,127 @@ def _helper_uses_bool():
     return TEST_BOOL
 
 
+def _helper_uses_datetime_constant():
+    """Helper that uses a datetime constant."""
+    return TEST_DATETIME
+
+
+def _helper_uses_stdlib_callable(x: object) -> str:
+    """Helper that uses typing.cast (stdlib callable) in closure."""
+    return typing.cast("str", x)
+
+
+def _helper_load_module_from_path(name: str, path: pathlib.Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _HelperBase:
+    """Base class for class body dependency tests."""
+
+
+class _HelperFieldType:
+    """Field type for class body dependency tests."""
+
+
+class _HelperContainer:
+    """Container for nested class references."""
+
+    class Inner:
+        """Nested class used for dotted annotation refs."""
+
+
+class _HelperPydanticModel(BaseModel):
+    """Pydantic model used for class annotation defaults."""
+
+    value: int = 1
+
+
+class _HelperAnnotatedClass(_HelperBase):
+    """Class with annotations for dependency walk tests."""
+
+    field: _HelperFieldType
+    inner: _HelperContainer.Inner
+    model: _HelperPydanticModel
+
+    def __init__(self) -> None:
+        self.field = _HelperFieldType()
+        self.inner = _HelperContainer.Inner()
+        self.model = _HelperPydanticModel()
+
+
+@dataclasses.dataclass
+class _HelperDataClassNoMethods:
+    value: int
+
+
+@dataclasses.dataclass
+class _HelperDataClassWithMethod:
+    value: int
+
+    def custom(self) -> int:
+        return self.value
+
+
+@dataclasses.dataclass
+class _HelperDataClassWithDunder:
+    value: int
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class _HelperPydanticModelWithAllowedMethod(BaseModel):
+    value: int
+
+    def model_post_init(self, __context: typing.Any) -> None:
+        return None
+
+
+class _HelperPydanticModelWithUserMethod(BaseModel):
+    value: int
+
+    def compute(self) -> int:
+        return self.value + 1
+
+
+def _helper_parse_annotation(expr: str) -> ast.AST:
+    """Parse an annotation expression into an AST node."""
+    tree = ast.parse(f"x: {expr}")
+    ann_assign = next(node for node in ast.walk(tree) if isinstance(node, ast.AnnAssign))
+    return ann_assign.annotation
+
+
 def _helper_outer_uses_inner(x):
     """Helper that references another helper."""
     # Reference the function (not call it) so it's captured in closure
     func = _helper_for_hash_test_1
     return func() + x
+
+
+def _helper_static_getattr(obj: typing.Any) -> object:
+    """Helper with static getattr usage."""
+    return obj.value
+
+
+def _helper_dynamic_getattr(obj: object, name: str) -> object:
+    """Helper with dynamic getattr usage."""
+    return getattr(obj, name)
+
+
+def _helper_uses_globals() -> dict[str, object]:
+    """Helper that uses globals()."""
+    return globals()
+
+
+def _helper_uses_import_module() -> object:
+    """Helper that uses importlib.import_module dynamically."""
+    return importlib.import_module("json")
 
 
 # --- get_stage_fingerprint tests ---
@@ -133,7 +300,18 @@ def test_simple_function_fingerprinted():
     assert "self:simple" in fp
     assert isinstance(fp["self:simple"], str)
     assert len(fp["self:simple"]) > 0
-    assert len(fp) == 1
+
+
+def test_resolve_annotations_individually_mixed():
+    resolved = fingerprint._resolve_annotations_individually(_helper_annotations_mixed)
+
+    assert resolved["a"] is int
+    assert resolved["b"] is _HelperForwardRef
+    assert resolved["d"] is int
+    assert resolved["e"] is _HelperForwardRefString
+    assert resolved["f"] is typing.Any
+    assert resolved["return"] is _HelperForwardRef
+    assert "c" not in resolved
 
 
 def test_helper_function_captured():
@@ -357,6 +535,65 @@ def test_fingerprint_with_default_args(x, y):
     assert "self:func_with_defaults" in fp
 
 
+def test_collect_annotation_names_handles_generics_and_unions():
+    """Collects names from generics and union annotations."""
+    names = set[str]()
+    dotted_refs = list[tuple[str, ...]]()
+
+    node = _helper_parse_annotation("list[_HelperFieldType] | _HelperBase")
+    fingerprint._collect_annotation_names(node, names, dotted_refs)
+
+    assert "_HelperFieldType" in names
+    assert "_HelperBase" in names
+
+
+def test_collect_annotation_names_handles_dotted_and_strings():
+    """Collects dotted refs and string annotations."""
+    names = set[str]()
+    dotted_refs = list[tuple[str, ...]]()
+
+    node = _helper_parse_annotation("_HelperContainer.Inner")
+    fingerprint._collect_annotation_names(node, names, dotted_refs)
+    assert ("_HelperContainer", "Inner") in dotted_refs
+
+    node = _helper_parse_annotation('"ForwardType"')
+    fingerprint._collect_annotation_names(node, names, dotted_refs)
+    assert "ForwardType" in names
+
+
+def test_collect_dotted_path_collects_attribute_chain():
+    """Collects dotted attribute paths from AST nodes."""
+    node = _helper_parse_annotation("_HelperContainer.Inner")
+    attr_node = next(n for n in ast.walk(node) if isinstance(n, ast.Attribute))
+
+    assert fingerprint._collect_dotted_path(attr_node) == ("_HelperContainer", "Inner")
+
+
+def test_resolve_dotted_path_resolves_namespace():
+    """Resolves dotted paths against module namespace."""
+    ns = {"_HelperContainer": _HelperContainer}
+
+    resolved = fingerprint._resolve_dotted_path(("_HelperContainer", "Inner"), ns)
+    assert resolved is _HelperContainer.Inner
+
+    missing = fingerprint._resolve_dotted_path(("Missing", "Type"), ns)
+    assert missing is None
+
+
+def test_process_class_body_dependencies_tracks_bases_and_annotations():
+    """Class body walker should track bases and annotated types."""
+    manifest = dict[str, str]()
+    visited = set[int]()
+
+    fingerprint._process_class_body_dependencies(_HelperAnnotatedClass, manifest, visited)
+
+    assert "class:_HelperBase" in manifest
+    assert "class:_HelperFieldType" in manifest
+    assert "class:Inner" in manifest
+    assert "class:_HelperPydanticModel" in manifest
+    assert "schema:_HelperPydanticModel" in manifest
+
+
 # --- hash_function_ast tests ---
 
 
@@ -513,9 +750,9 @@ def test_is_user_code_lambda():
     assert fingerprint.is_user_code(my_lambda) is True
 
 
-def test_is_user_code_module():
-    """Should identify pivot module as user code."""
-    assert fingerprint.is_user_code(fingerprint) is True
+def test_is_user_code_pivot_is_framework():
+    """Pivot's own modules are framework code, not user code."""
+    assert fingerprint.is_user_code(fingerprint) is False
 
 
 def test_is_user_code_non_callable():
@@ -705,6 +942,59 @@ def test_fingerprint_callable_nonlocal():
     assert "const:n" in fp
 
 
+def test_hash_unrecognized_closure_value_deterministic_repr():
+    """Deterministic repr values should be hashed into the manifest."""
+    manifest: dict[str, str] = {}
+    fingerprint._hash_unrecognized_closure_value("TEST_DATETIME", TEST_DATETIME, manifest, "stage")
+
+    expected = xxhash.xxh64(repr(TEST_DATETIME).encode()).hexdigest()
+    assert manifest["const:TEST_DATETIME"] == expected
+
+
+def test_hash_unrecognized_closure_value_repr_error_raises(monkeypatch: pytest.MonkeyPatch):
+    """repr failures should surface as mutable capture errors."""
+    monkeypatch.delenv("PIVOT_UNSAFE_FINGERPRINTING", raising=False)
+    with pytest.raises(exceptions.StageDefinitionError):
+        fingerprint._hash_unrecognized_closure_value("bad_repr", _HelperReprError(), {}, "stage")
+
+
+def test_hash_unrecognized_closure_value_memory_address_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Memory-address reprs should be rejected as non-deterministic."""
+    monkeypatch.delenv("PIVOT_UNSAFE_FINGERPRINTING", raising=False)
+    with pytest.raises(exceptions.StageDefinitionError):
+        fingerprint._hash_unrecognized_closure_value("addr", object(), {}, "stage")
+
+
+def test_hash_unrecognized_closure_value_large_repr_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Large reprs should be rejected as lossy."""
+    monkeypatch.delenv("PIVOT_UNSAFE_FINGERPRINTING", raising=False)
+    large_value = types.SimpleNamespace(data="x" * 10_001)
+    with pytest.raises(exceptions.StageDefinitionError):
+        fingerprint._hash_unrecognized_closure_value("large", large_value, {}, "stage")
+
+
+def test_fingerprint_captures_unrecognized_closure_value():
+    """Unrecognized closure values should be hashed when deterministic."""
+    fp = fingerprint.get_stage_fingerprint(_helper_uses_datetime_constant)
+
+    expected = xxhash.xxh64(repr(TEST_DATETIME).encode()).hexdigest()
+    assert fp["const:TEST_DATETIME"] == expected
+
+
+def test_stdlib_callable_in_closure_does_not_raise():
+    """Stdlib callables like typing.cast should be silently skipped, not flagged as mutable."""
+    # This was a regression where non-user-code callables hit the catch-all else branch
+    # and _check_mutable_capture raised because repr() contains 0x memory addresses.
+    fp = fingerprint.get_stage_fingerprint(_helper_uses_stdlib_callable)
+    assert "self:_helper_uses_stdlib_callable" in fp
+    # cast should NOT appear as const: or func: — it's a stdlib callable, silently skipped
+    assert not any(k.endswith(":cast") for k in fp), f"cast should be skipped, found in: {fp}"
+
+
 def test_fingerprint_nonlocal_callable_function():
     """Should capture and recurse on nonlocal callable functions."""
 
@@ -848,6 +1138,68 @@ def test_hash_function_no_code_object():
     assert len(h) == 16  # xxhash64 hexdigest
 
 
+def test_check_data_class_methods_allows_dunders_and_pydantic_hooks():
+    """Dunder methods and allowed Pydantic hooks should be allowed."""
+    fingerprint._check_data_class_methods(_HelperDataClassNoMethods)
+    fingerprint._check_data_class_methods(_HelperDataClassWithDunder)
+    fingerprint._check_data_class_methods(_HelperPydanticModelWithAllowedMethod)
+
+
+def test_check_data_class_methods_rejects_user_methods():
+    """User-defined methods on data classes should raise errors."""
+    with pytest.raises(exceptions.StageDefinitionError, match="Data class"):
+        fingerprint._check_data_class_methods(_HelperDataClassWithMethod)
+
+    with pytest.raises(exceptions.StageDefinitionError, match="Data class"):
+        fingerprint._check_data_class_methods(_HelperPydanticModelWithUserMethod)
+
+
+def test_check_dynamic_name_access_allows_literal_getattr():
+    """Literal getattr usage should be allowed."""
+    fingerprint._check_dynamic_name_access(_helper_static_getattr)
+
+
+def test_check_dynamic_name_access_rejects_dynamic_getattr():
+    """Dynamic getattr usage should be rejected."""
+    with pytest.raises(exceptions.StageDefinitionError, match="getattr"):
+        fingerprint._check_dynamic_name_access(_helper_dynamic_getattr)
+
+
+def test_check_dynamic_name_access_rejects_globals():
+    """globals() usage should be rejected."""
+    with pytest.raises(exceptions.StageDefinitionError, match="globals"):
+        fingerprint._check_dynamic_name_access(_helper_uses_globals)
+
+
+def test_check_dynamic_name_access_rejects_import_module():
+    """import_module usage should be rejected."""
+    with pytest.raises(exceptions.StageDefinitionError, match="dynamic imports"):
+        fingerprint._check_dynamic_name_access(_helper_uses_import_module)
+
+
+def test_compute_function_hash_warns_when_source_unavailable_for_user_code(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Missing source should warn for user code when no __code__ exists."""
+
+    class FakeCallable:
+        """Callable without source or __code__."""
+
+        def __call__(self) -> int:
+            return 42
+
+    def _raise_getsource(*_args: object, **_kwargs: object) -> str:
+        raise OSError("missing")
+
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(inspect, "getsource", _raise_getsource)
+
+    fingerprint._compute_function_hash(FakeCallable())
+
+    assert "Cannot get source for" in caplog.text
+
+
 def test_is_user_code_module_not_in_sys_modules():
     """Should return False for modules not in sys.modules."""
 
@@ -973,6 +1325,95 @@ def test_fingerprint_with_bool_constant():
     assert "self:_helper_uses_bool" in fp
     assert "const:TEST_BOOL" in fp
     assert fp["const:TEST_BOOL"] == "True"
+
+
+# --- Pydantic schema hashing tests ---
+
+
+def test_strip_schema_metadata_removes_titles_and_descriptions():
+    """Should remove title/description from schema recursively."""
+    schema = {
+        "title": "Top",
+        "description": "Top desc",
+        "type": "object",
+        "properties": {
+            "name": {
+                "title": "Name",
+                "description": "Name desc",
+                "type": "string",
+            },
+            "items": {
+                "title": "Items",
+                "description": "Items desc",
+                "type": "array",
+                "items": {
+                    "title": "Item",
+                    "description": "Item desc",
+                    "type": "string",
+                },
+            },
+        },
+        "$defs": {
+            "Inner": {
+                "title": "Inner",
+                "description": "Inner desc",
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "title": "Value",
+                        "description": "Value desc",
+                        "type": "integer",
+                    }
+                },
+            }
+        },
+        "anyOf": [
+            {"title": "OptA", "description": "OptA desc", "type": "string"},
+            {"type": "number"},
+        ],
+    }
+
+    stripped = fingerprint._strip_schema_metadata(schema)
+
+    assert "title" not in stripped
+    assert "description" not in stripped
+    assert "title" in schema
+    assert "description" in schema
+    assert "title" not in stripped["$defs"]["Inner"]
+    assert "description" not in stripped["$defs"]["Inner"]
+    assert "title" not in stripped["properties"]["name"]
+    assert stripped["properties"]["name"]["type"] == "string"
+    assert "title" not in stripped["properties"]["items"]["items"]
+    assert stripped["anyOf"][0]["type"] == "string"
+
+
+def test_hash_pydantic_schema_adds_schema_and_nested_models():
+    """Should hash model schema and discover nested models."""
+    manifest = dict[str, str]()
+    visited = set[int]()
+
+    fingerprint._hash_pydantic_schema(
+        typing.cast("type[fingerprint._PydanticModelProtocol]", _PydanticOuterModel),
+        manifest,
+        visited,
+    )
+
+    assert "schema:_PydanticOuterModel" in manifest
+    assert "schema:_PydanticInnerModel" in manifest
+    assert "class:_PydanticInnerModel" in manifest
+    assert "class:_PydanticOuterModel" not in manifest
+    assert len(manifest["schema:_PydanticOuterModel"]) == 16
+
+
+def test_discover_pydantic_field_types_tracks_nested_models():
+    """Should walk annotations and capture nested Pydantic models."""
+    manifest = dict[str, str]()
+    visited = set[int]()
+
+    fingerprint._discover_pydantic_field_types(list[_PydanticInnerModel], manifest, visited)
+
+    assert "class:_PydanticInnerModel" in manifest
+    assert "schema:_PydanticInnerModel" in manifest
 
 
 # ==============================================================================
@@ -1462,97 +1903,117 @@ def reset_fingerprint_cache_state(monkeypatch):
     fingerprint._state_db_init_attempted = orig_attempted
 
 
-def test_hash_function_ast_adds_to_pending_writes(
-    tmp_path, monkeypatch, reset_fingerprint_cache_state
-):
-    """Module-level functions should queue entries for persistent cache."""
-    # Set project root to tmp_path so _get_func_source_info can compute relative paths
-    monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-
-    # Create a test module file
-    test_module = tmp_path / "test_stage.py"
-    test_module.write_text("""
-def my_stage():
-    return 42
-""")
-
-    # Import the function
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location("test_stage", test_module)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["test_stage"] = module
-    try:
-        spec.loader.exec_module(module)
-
-        # Hash the function - should add to pending writes
-        func = module.my_stage
-        result = fingerprint.hash_function_ast(func)
-
-        # Verify hash was computed
-        assert isinstance(result, str)
-        assert len(result) == 16  # xxhash64 hexdigest
-
-        # Verify entry was queued for persistent cache
-        assert len(fingerprint._pending_ast_writes) == 1
-        rel_path, mtime_ns, size, inode, qualname, py_version, schema_version, hash_hex = (
-            fingerprint._pending_ast_writes[0]
-        )
-        assert rel_path == "test_stage.py"
-        assert qualname == "my_stage"
-        assert py_version == fingerprint._PYTHON_VERSION
-        assert schema_version == fingerprint._CACHE_SCHEMA_VERSION
-        assert hash_hex == result
-        assert mtime_ns > 0
-        assert size > 0
-        assert inode > 0
-    finally:
-        del sys.modules["test_stage"]
+# ==============================================================================
+# Review fix: Recursive Pydantic model infinite recursion
+# ==============================================================================
 
 
-def test_hash_function_ast_skips_closures_for_persistent():
-    """Closures should still hash correctly but not use persistent cache."""
+def test_recursive_pydantic_model_no_infinite_recursion():
+    """Self-referential Pydantic models should not cause infinite recursion."""
+    import pydantic
 
-    def make_adder(n):
-        def add(x):
-            return x + n
+    class TreeNode(pydantic.BaseModel):
+        value: int
+        children: list["TreeNode"] = []
 
-        return add
+    TreeNode.model_rebuild()
 
-    add_five = make_adder(5)
+    # Should not raise RecursionError
+    manifest = dict[str, str]()
+    visited = set[int]()
+    fingerprint._hash_pydantic_schema(
+        TreeNode,  # pyright: ignore[reportArgumentType] - Pydantic model_fields protocol mismatch in tests
+        manifest,
+        visited,
+    )
+    assert f"schema:{TreeNode.__name__}" in manifest
+    assert manifest[f"schema:{TreeNode.__name__}"] != "<pending>"
 
-    # Should hash without error
-    h = fingerprint.hash_function_ast(add_five)
-    assert isinstance(h, str)
-    assert len(h) == 16  # xxhash64 hexdigest
 
+def test_mutual_recursive_pydantic_models():
+    """Mutually recursive Pydantic models should not cause infinite recursion."""
+    import pydantic
 
-def test_hash_function_ast_uses_memory_cache():
-    """Memory cache should be used on repeated calls."""
+    class Parent(pydantic.BaseModel):
+        name: str
+        child: "Child | None" = None
 
-    def test_func():
-        return 42
+    class Child(pydantic.BaseModel):
+        name: str
+        parent: "Parent | None" = None
 
-    # Clear caches
-    fingerprint._hash_function_ast_cache.clear()
+    Parent.model_rebuild()
+    Child.model_rebuild()
 
-    h1 = fingerprint.hash_function_ast(test_func)
-    h2 = fingerprint.hash_function_ast(test_func)
-
-    assert h1 == h2
-    # The function should be in memory cache after first call
-    assert test_func in fingerprint._hash_function_ast_cache
+    manifest = dict[str, str]()
+    visited = set[int]()
+    fingerprint._hash_pydantic_schema(
+        Parent,  # pyright: ignore[reportArgumentType] - Pydantic model_fields protocol mismatch in tests
+        manifest,
+        visited,
+    )
+    assert "schema:Parent" in manifest
+    assert manifest["schema:Parent"] != "<pending>"
 
 
 # ==============================================================================
-# Persistent cache integration tests
+# Review fix: User-defined generic origins tracked
 # ==============================================================================
+
+
+def test_user_defined_generic_origin_tracked():
+    """User-defined generic classes used as origins should be fingerprinted."""
+    import typing
+
+    T = typing.TypeVar("T")
+
+    class MyContainer(typing.Generic[T]):
+        pass
+
+    hint = MyContainer[int]
+
+    manifest = dict[str, str]()
+    visited = set[int]()
+    fingerprint._process_type_hint(hint, manifest, visited)
+
+    assert "class:MyContainer" in manifest
+
+
+# ==============================================================================
+# Review fix: Dotted string forward refs in class annotations
+# ==============================================================================
+
+
+def test_collect_annotation_names_dotted_string_forward_ref():
+    """Dotted string forward refs like 'pkg.Type' should be treated as dotted refs."""
+    import ast as ast_mod
+
+    node = ast_mod.Constant(value="some_module.SomeType")
+    names = set[str]()
+    dotted_refs = list[tuple[str, ...]]()
+    fingerprint._collect_annotation_names(node, names, dotted_refs)
+
+    # Should NOT be in simple names (it has a dot)
+    assert "some_module.SomeType" not in names
+    # Should be treated as dotted ref
+    assert ("some_module", "SomeType") in dotted_refs
+
+
+def test_collect_annotation_names_simple_string_forward_ref():
+    """Simple string forward refs like 'MyType' should still be added as names."""
+    import ast as ast_mod
+
+    node = ast_mod.Constant(value="MyType")
+    names = set[str]()
+    dotted_refs = list[tuple[str, ...]]()
+    fingerprint._collect_annotation_names(node, names, dotted_refs)
+
+    assert "MyType" in names
+    assert len(dotted_refs) == 0
 
 
 def test_persistent_cache_full_roundtrip(tmp_path, monkeypatch):
-    """Full round-trip: compute → flush → hit → modify → miss.
+    """Full round-trip: compute -> flush -> hit -> modify -> miss.
 
     Verifies that:
     1. First call computes and queues for persistent cache

--- a/packages/pivot/tests/fingerprint/test_pydantic_defaults.py
+++ b/packages/pivot/tests/fingerprint/test_pydantic_defaults.py
@@ -1,7 +1,7 @@
 # pyright: reportUnusedFunction=false, reportUnusedParameter=false
-"""Tests for fingerprinting behavior with Pydantic model defaults.
+"""Tests for fingerprinting behavior with Pydantic model schemas.
 
-Pydantic model defaults in type hints ARE captured by the fingerprinting system.
+Pydantic model defaults in type hints are captured via schema hashing.
 Changes to default values trigger cache invalidation.
 """
 
@@ -101,17 +101,19 @@ def test_pydantic_class_captured_from_type_hint():
 
 
 def test_pydantic_default_data_captured():
-    """Data in Pydantic field defaults IS captured via pydantic: prefix."""
+    """Data in Pydantic field defaults is captured via schema hashing."""
     fp1 = fingerprint.get_stage_fingerprint(_stage_with_pydantic_param_v1)
     fp2 = fingerprint.get_stage_fingerprint(_stage_with_config_list)
 
-    # Pydantic defaults ARE captured
-    assert "pydantic:ParamsWithListDefault.items" in fp1, (
-        f"Pydantic defaults should be captured. Got keys: {list(fp1.keys())}"
+    # Pydantic schema hashes ARE captured
+    assert "schema:ParamsWithListDefault" in fp1, (
+        f"Pydantic schema should be captured. Got keys: {list(fp1.keys())}"
     )
-    assert "pydantic:ParamsWithConfigList.configs" in fp2, (
-        f"Pydantic defaults should be captured. Got keys: {list(fp2.keys())}"
+    assert "schema:ParamsWithConfigList" in fp2, (
+        f"Pydantic schema should be captured. Got keys: {list(fp2.keys())}"
     )
+    assert "schema:ItemConfig" in fp2
+    assert "class:ItemConfig" in fp2
 
 
 def test_pydantic_default_change_triggers_different_hash():
@@ -133,8 +135,8 @@ def test_pydantic_default_change_triggers_different_hash():
     fp1 = fingerprint.get_stage_fingerprint(stage_v1)
     fp2 = fingerprint.get_stage_fingerprint(stage_v2)
 
-    # The pydantic default hashes should be different
-    assert fp1["pydantic:ParamsV1.items"] != fp2["pydantic:ParamsV2.items"], (
+    # The schema hashes should be different
+    assert fp1["schema:ParamsV1"] != fp2["schema:ParamsV2"], (
         "Different default values should produce different hashes"
     )
 
@@ -143,11 +145,12 @@ def test_pydantic_nested_model_defaults_captured():
     """Nested Pydantic model instances in defaults are captured."""
     fp = fingerprint.get_stage_fingerprint(_stage_with_config_list)
 
-    # The nested model data should be hashed
-    assert "pydantic:ParamsWithConfigList.configs" in fp
+    # The nested model schema should be hashed
+    assert "schema:ParamsWithConfigList" in fp
+    assert "schema:ItemConfig" in fp
 
     # Verify it's a real hash (16 hex chars)
-    hash_val = fp["pydantic:ParamsWithConfigList.configs"]
+    hash_val = fp["schema:ParamsWithConfigList"]
     assert len(hash_val) == 16, f"Expected 16-char hash, got {hash_val}"
     assert all(c in "0123456789abcdef" for c in hash_val)
 
@@ -156,10 +159,10 @@ def test_fingerprint_includes_class_and_defaults():
     """Fingerprint for Pydantic param stages includes class and defaults."""
     fp = fingerprint.get_stage_fingerprint(_stage_with_pydantic_param_v1)
 
-    # Should have: self:, class:, pydantic:
+    # Should have: self:, class:, schema:
     assert "self:_stage_with_pydantic_param_v1" in fp
     assert "class:ParamsWithListDefault" in fp
-    assert "pydantic:ParamsWithListDefault.items" in fp
+    assert "schema:ParamsWithListDefault" in fp
     assert len(fp) == 3, f"Expected 3 entries, got {len(fp)}: {list(fp.keys())}"
 
 
@@ -175,7 +178,7 @@ def test_default_factory_is_tracked():
     fp = fingerprint.get_stage_fingerprint(stage)
 
     # default_factory should be captured
-    assert "pydantic:ParamsWithFactory.items" in fp, (
+    assert "schema:ParamsWithFactory" in fp, (
         f"default_factory should be captured. Got keys: {list(fp.keys())}"
     )
 
@@ -199,7 +202,7 @@ def test_default_factory_change_triggers_different_hash():
     fp2 = fingerprint.get_stage_fingerprint(stage_v2)
 
     # Different factories should produce different hashes
-    assert fp1["pydantic:ParamsV1.items"] != fp2["pydantic:ParamsV2.items"], (
+    assert fp1["schema:ParamsV1"] != fp2["schema:ParamsV2"], (
         "Different default_factory functions should produce different hashes"
     )
 
@@ -216,7 +219,7 @@ def test_none_default_is_tracked():
     fp = fingerprint.get_stage_fingerprint(stage)
 
     # None default should be captured
-    assert "pydantic:ParamsWithNone.value" in fp, (
+    assert "schema:ParamsWithNone" in fp, (
         f"None default should be captured. Got keys: {list(fp.keys())}"
     )
 

--- a/packages/pivot/tests/remote/test_s3_remote.py
+++ b/packages/pivot/tests/remote/test_s3_remote.py
@@ -589,9 +589,28 @@ async def test_iter_hashes(s3_remote: remote_mod.S3Remote, aioboto3_s3_client: S
 
 
 async def test_iter_hashes_skips_invalid_keys(
-    s3_remote: remote_mod.S3Remote, aioboto3_s3_client: S3Client
+    s3_remote: remote_mod.S3Remote, mocker: MockerFixture
 ) -> None:
     """iter_hashes skips keys that don't produce valid 16-char lowercase hex hashes."""
+
+    class _PageIterator:
+        _pages: list[dict[str, object]]
+        _idx: int
+
+        def __init__(self, pages: list[dict[str, object]]) -> None:
+            self._pages = pages
+            self._idx = 0
+
+        def __aiter__(self) -> _PageIterator:
+            return self
+
+        async def __anext__(self) -> dict[str, object]:
+            if self._idx >= len(self._pages):
+                raise StopAsyncIteration
+            page = self._pages[self._idx]
+            self._idx += 1
+            return page
+
     keys = [
         f"{s3_remote.prefix}files/ab/cdef1234567890",  # Valid: 16 lowercase hex
         f"{s3_remote.prefix}files/AB/CDEF1234567890",  # Invalid: uppercase
@@ -600,12 +619,14 @@ async def test_iter_hashes_skips_invalid_keys(
         f"{s3_remote.prefix}files/stages/my_stage.lock",  # Invalid: not a cache file
     ]
 
-    for key in keys:
-        await aioboto3_s3_client.put_object(
-            Bucket=s3_remote.bucket,
-            Key=key,
-            Body=b"content",
-        )
+    pages: list[dict[str, object]] = [{"Contents": [{"Key": key} for key in keys]}]
+
+    mock_paginator = mocker.MagicMock()
+    mock_paginator.paginate = mocker.MagicMock(return_value=_PageIterator(pages))
+
+    mock_client = mocker.AsyncMock()
+    mock_client.get_paginator = mocker.Mock(return_value=mock_paginator)
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
 
     hashes = [h async for h in s3_remote.iter_hashes()]
 
@@ -615,7 +636,7 @@ async def test_iter_hashes_skips_invalid_keys(
 async def test_upload_batch(
     s3_remote: remote_mod.S3Remote,
     tmp_path: pathlib.Path,
-    aioboto3_s3_client: S3Client,
+    mocker: MockerFixture,
 ) -> None:
     """upload_batch uploads multiple files in parallel."""
     files = list[tuple[pathlib.Path, str]]()
@@ -628,21 +649,31 @@ async def test_upload_batch(
         files.append((f, cache_hash))
         contents[cache_hash] = data
 
-    results = await s3_remote.upload_batch(files, concurrency=10)
+    mock_client = mocker.AsyncMock()
+    mock_client.put_object = mocker.AsyncMock(return_value={})
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    results = await s3_remote.upload_batch(files, concurrency=1)
 
     assert len(results) == 3
     assert all(r["success"] for r in results)
 
-    for cache_hash, expected in contents.items():
-        response = await aioboto3_s3_client.get_object(
-            Bucket=s3_remote.bucket,
-            Key=remote_mod._hash_to_key(s3_remote.prefix, cache_hash),
-        )
-        assert await response["Body"].read() == expected
+    assert mock_client.put_object.call_count == 3
+    called_keys = {call.kwargs["Key"] for call in mock_client.put_object.call_args_list}
+    called_buckets = {call.kwargs["Bucket"] for call in mock_client.put_object.call_args_list}
+    called_bodies = {call.kwargs["Body"] for call in mock_client.put_object.call_args_list}
+
+    expected_keys = {
+        remote_mod._hash_to_key(s3_remote.prefix, cache_hash) for cache_hash in contents
+    }
+
+    assert called_buckets == {s3_remote.bucket}
+    assert called_keys == expected_keys
+    assert called_bodies == set(contents.values())
 
 
 async def test_upload_batch_with_callback(
-    s3_remote: remote_mod.S3Remote, tmp_path: pathlib.Path
+    s3_remote: remote_mod.S3Remote, tmp_path: pathlib.Path, mocker: MockerFixture
 ) -> None:
     """upload_batch calls callback for each completed upload."""
     files = list[tuple[pathlib.Path, str]]()
@@ -656,7 +687,11 @@ async def test_upload_batch_with_callback(
     def callback(completed: int, total: int, filename: str) -> None:
         callback_values.append(completed)
 
-    await s3_remote.upload_batch(files, concurrency=10, callback=callback)
+    mock_client = mocker.AsyncMock()
+    mock_client.put_object = mocker.AsyncMock(return_value={})
+    _helper_patch_s3_client(mocker, s3_remote, mock_client)
+
+    await s3_remote.upload_batch(files, concurrency=1, callback=callback)
 
     assert len(callback_values) == 3
     assert set(callback_values) == {1, 2, 3}

--- a/skills/adversarial-fingerprint-testing/SKILL.md
+++ b/skills/adversarial-fingerprint-testing/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: adversarial-fingerprint-testing
+description: Use when testing Pivot fingerprint correctness against a real pipeline, hunting for undetected code changes that cause stale cached outputs, or validating Change Detection Matrix claims against production code
+---
+
+# Adversarial Fingerprint Testing
+
+## Overview
+
+Find cases where Pivot's fingerprinting fails to detect a code change that would change a stage's runtime behavior, causing stale cached outputs to be incorrectly reused.
+
+**Core principle:** A real bug requires the stage output to actually differ. If the change doesn't affect runtime behavior, it's out of scope regardless of whether the fingerprint catches it.
+
+## When to Use
+
+- Testing fingerprint correctness against a real production pipeline
+- Regression testing after changes to `fingerprint.py`
+- Validating Change Detection Matrix claims against production-scale import graphs
+
+## What Counts as a Real Bug
+
+The change MUST satisfy ALL three:
+
+1. **Executed at runtime** — the changed code actually runs when the stage executes
+2. **Changes output** — same inputs produce different stage outputs after the change
+3. **Claimed detected** — the Change Detection Matrix says this category should be detected
+
+### Out of Scope
+
+- **Type annotation-only changes** — Python doesn't enforce annotations at runtime. Exception: Pydantic models where annotations drive validation (tracked via `schema:` entries).
+- **Adding methods never called** — `def display_label(self)` on a model no stage calls
+- **Module-level type annotations as documentation** — `_CONFIG: MyTypedDict = {...}` where only dict values matter (tracked via params hash)
+- **Docstring/comment/whitespace changes** — intentionally ignored
+- **Decorator changes on stage functions** — known limitation, documented
+- **Lazy imports inside function bodies** — known limitation, documented
+
+## Pre-Attempt Checklist
+
+### 1. Check known root causes
+
+Read `known-root-causes.md` in this skill directory. If your planned test exercises a cataloged root cause through a similar code path, skip it unless testing regression of a fix.
+
+### 2. Trace the execution path
+
+Ask: "If I run this stage before and after my change with the same inputs, would the outputs actually differ?" If no, skip. This eliminates annotation-only and dead-code changes.
+
+### 3. Check both defenses
+
+The highest-value bugs defeat BOTH:
+
+- **Code fingerprint** — change not detected via closure vars, type hints, module attrs, class source hashing, or class body dependency walking
+- **Params hash** — change doesn't alter serialized params values (e.g., output-preserving refactor, method additions that don't affect `model_dump()`)
+
+A change caught by either defense is a PASS, not a bug.
+
+## Prioritization
+
+### Tier 1 — High impact
+
+| Pattern | Why |
+|---------|-----|
+| Primitive collections in closures | Tuples/lists/dicts of numbers/strings used in function bodies via direct reference. The closure path routes collections to `_process_collection_dependency` which only tracks callables, ignoring data. Asymmetric with the module attribute path. |
+| `default_factory` transitive deps | Functions called inside `default_factory=lambda: helper(...)` in StageParams class bodies. Lambda AST is hashed but transitive deps not followed via `_add_callable_to_manifest`. |
+| Module-load-time computed values | `CONSTANT = expensive_func()` where the function is only called at module level, never in a tracked function body. The derived value may not be fingerprinted. |
+| Deep transitive deps via unusual patterns | 4+ levels deep, mixed import styles, indirect discovery paths through patterns not covered by unit tests. |
+
+### Tier 2 — Moderate impact
+
+| Pattern | Why |
+|---------|-----|
+| Functions accessed through class methods/`__init__` | Instance method calls on user objects are a documented gap (xfail test exists). |
+| Enum value changes | Enum members have deterministic `repr()` — are they caught by the catch-all? Test it. |
+| `functools.lru_cache` decorated helpers | Does the decorator wrapper interfere with source extraction or closure analysis? |
+| Nested Pydantic structural changes 2+ levels deep | `model_fields` walking handles one level — does it recurse through nested model references? |
+
+### Tier 3 — Low impact (skip unless Tier 1-2 exhausted)
+
+- More variations of already-confirmed root causes through similar paths
+- Annotation-only or dead-code changes
+- Simple function body changes through well-tested paths (direct closure, module attr)
+
+## Reference Materials
+
+Study before planning tests:
+
+- `packages/pivot/tests/fingerprint/README.md` — Change Detection Matrix (what's claimed)
+- `packages/pivot/tests/fingerprint/test_change_detection.py` — Detection tests (what's verified)
+- `packages/pivot/src/pivot/fingerprint.py` — Implementation (how it works)
+
+Key functions to understand: `_process_closure_values`, `_process_collection_dependency`, `_process_module_dependency`, `_process_type_hint_dependencies`, `_hash_pydantic_schema`, `_add_callable_to_manifest`, `_collect_nested_code_globals`, `_process_class_body_dependencies`.
+
+## Workflow
+
+### 1. Read prior attempts
+
+Read the pipeline's fingerprint test log (typically `fingerprint_test_log.yaml` in the pipeline repo). Don't repeat prior tests. If no log exists, create one using the format below.
+
+### 2. Plan and verify
+
+Before changing code, confirm:
+
+- The code is **executed** when the stage runs (trace the call chain from the stage function)
+- The change **produces different output** for the same inputs
+- The category is marked **DETECTED** in the Change Detection Matrix
+
+### 3. Make exactly ONE change
+
+Small, targeted, semantically meaningful. Must change what the function computes, not just naming or annotations.
+
+### 4. Test
+
+```bash
+pivot repro --all --dry-run 2>&1
+```
+
+Check affected stages: "would skip (unchanged)" for a stage that SHOULD be invalidated = potential bug. "would run (changed)" = detected.
+
+If dry-run suggests a bug, confirm with `pivot repro --all` (without `--dry-run`).
+
+### 5. Log the result
+
+Append to the pipeline's test log following the format below.
+
+### 6. REVERT the change
+
+```bash
+# Restore only changed pipeline files (NOT the log)
+jj restore --from @- <path-to-changed-file>
+# Or with git: git checkout -- <path-to-changed-file>
+
+# Verify all stages cached again
+pivot repro --all --dry-run 2>&1 | grep -c "would skip"
+```
+
+## Log Format
+
+```yaml
+- attempt: <N>
+  category: "<from Change Detection Matrix>"
+  description: >
+    What was changed, how it's reachable from a stage function,
+    why the fingerprint system should detect it.
+  file_changed: <path>
+  expected: "<detected | not_detected>"
+  actual: "<detected | not_detected>"
+  pivot_output: >
+    <Relevant excerpt — which stages changed status and why>
+  verdict: "<PASS | BUG>"
+  root_cause: "<name from known-root-causes.md, or NEW: brief description>"
+  notes: >
+    <See guidelines below>
+```
+
+### Notes guidelines
+
+- **PASS:** 5-10 lines. State the detection path (which mechanism caught it) and one key insight. Don't re-explain how `getclosurevars` or `_add_callable_to_manifest` work.
+- **BUG (known root cause):** Reference the root cause by name. Note only what's different about this instance. 10-15 lines max.
+- **BUG (new root cause):** Full description of the novel mechanism, how it differs from known causes, and proposed fix. Add to `known-root-causes.md`.
+
+### Root cause deduplication
+
+After finding a bug, name the root cause explicitly. Don't log the same root cause more than twice (original discovery + one confirmation) unless the new instance tests a fundamentally different code path — not just a different class in a different module exercising the same gap.
+
+## Rules
+
+1. ONE change per session
+2. Don't repeat tests already in the log
+3. ALWAYS revert pipeline code before finishing
+4. ALWAYS update the log
+5. Don't modify Pivot tool code — only pipeline code
+6. Focus on changes that **actually change runtime behavior**
+7. Deduplicate root causes — check known causes before each attempt
+
+## Common Mistakes
+
+| Mistake | Why it wastes time |
+|---------|--------------------|
+| Testing annotation-only changes | Python doesn't enforce annotations at runtime. Zero output impact. |
+| Adding methods no stage calls | Method additions to models don't change `model_dump()` or any call site. |
+| Re-finding the same root cause 8 times | First confirmation is valuable. Further variations through similar paths aren't. |
+| Testing well-trodden paths "to confirm they work" | Direct function body changes, direct import closure tracking — these are extensively unit-tested. Target seams between mechanisms instead. |
+| Burying high-value findings late | Prioritize Tier 1 patterns that defeat both defenses. Don't spend early attempts on safe confirmations. |
+| Verbose notes re-explaining the fingerprint system | The README documents the system. Notes should describe what's novel about THIS attempt. |

--- a/skills/adversarial-fingerprint-testing/known-root-causes.md
+++ b/skills/adversarial-fingerprint-testing/known-root-causes.md
@@ -1,0 +1,100 @@
+# Known Root Causes
+
+Catalog of fingerprinting gap patterns discovered through adversarial testing. Check before planning a new test — if your change exercises a cataloged root cause through a similar code path, skip it unless testing regression of a fix.
+
+## Open Root Causes
+
+### RC-1: `default_factory` Transitive Dependencies Not Followed
+
+`_hash_pydantic_schema` uses `hash_function_ast` for `default_factory` callables instead of `_add_callable_to_manifest`. Names appearing in the factory's AST (classes, helper functions, module-level variables) are not resolved to their definitions.
+
+**Where in code:** `fingerprint.py` `_hash_pydantic_schema()` — line `default_hashes[field_name] = hash_function_ast(default_factory)`.
+
+**Example patterns:**
+- Factory function body references a class: `default_factory=_make_agents` where `_make_agents` constructs `AgentConfig(...)` — change to `AgentConfig` class not detected
+- Class-body lambda references helper: `default_factory=lambda: _make_configs(prefix)` — change to `_make_configs` body not detected
+- Nested Pydantic model as factory: `default_factory=PlotParams` where `PlotParams` has its own fields with factories — inner factories not recursed into
+
+**Severity:** High when combined with output-preserving changes that defeat the params hash backup (e.g., extracting literals into named variables).
+
+**Fix:** Use `_add_callable_to_manifest` for callable `default_factory` values.
+
+---
+
+### RC-2: Primitive Collections in Closures Ignored
+
+Collections (tuple, list, dict, set, frozenset) containing only primitives are routed to `_process_collection_dependency`, which only scans for callables. Primitive data values are silently discarded.
+
+**Where in code:** `fingerprint.py` `_process_closure_values()` matches tuples/lists/etc on the collection branch → `_process_collection_dependency()` iterates elements checking only `callable(value) and is_user_code(value)`.
+
+**Asymmetry:** The module attribute path (`_process_module_dependency`) checks `_is_primitive_collection()` and hashes the serialized value. The closure path has no equivalent — same data detected or ignored depending on import style.
+
+**Example patterns:**
+- `_FIGSIZE = (9, 5)` used in `plt.subplots(figsize=_FIGSIZE)` via direct reference
+- Color tuples, threshold lists, dimension specs — any `tuple`/`list`/`dict` of numbers/strings used in function bodies via `LOAD_GLOBAL`
+
+**Fix:** Check `_is_primitive_collection()` before routing to `_process_collection_dependency`. Hash serialized value for primitive-only collections.
+
+---
+
+### RC-3: Type Alias Transparency
+
+Type aliases (`types.UnionType`, `typing.Union`, simple assignments) are transparent to `get_type_hints()` — the alias name is replaced with its resolved value. Changes that only add/remove builtin types produce identical manifest entries.
+
+**Where in code:** Three independent failures: (1) Under `from __future__ import annotations`, aliases in annotation strings don't generate `LOAD_GLOBAL` bytecode. (2) `get_type_hints` resolves aliases before `_process_type_hint` sees them. (3) Function source AST is unchanged since annotation strings are unchanged.
+
+**Scope:** Only affects aliases used exclusively in annotations (not in function bodies) in modules with `from __future__ import annotations`, where the change only adds/removes builtin or third-party types (not new user-defined types).
+
+**Fix:** Hash full resolved type hint repr per parameter, not just extracted user-defined types.
+
+---
+
+### RC-4: Module-Level Annotations Blind Spot
+
+No mechanism processes module-level type annotations (`module.__annotations__`). Types referenced ONLY in module-level variable annotations are invisible.
+
+**Where in code:** `_process_type_hint_dependencies` calls `get_type_hints(func)` which only covers function parameter/return annotations. `_process_module_dependency` examines `module.attr` usage in function ASTs but not module annotations.
+
+**Example:** `_WRANGLE_BASE: WrangleLogisticConfig = {...}` — the `WrangleLogisticConfig` TypedDict is never discovered. The dict DATA is tracked via params hash, but the TypedDict class definition is not.
+
+**Scope:** Narrow — only affects types used exclusively as module-level variable annotations, never in function annotations or bodies. Changes to such types rarely affect runtime behavior since the annotation is documentation.
+
+**Fix:** Process `module.__annotations__` for modules in the source map.
+
+## Fixed Root Causes
+
+### RC-5: Class Body Annotations Opaque (FIXED)
+
+**Fixed by:** `_process_class_body_dependencies` (Design Decision #9)
+
+Previously, classes tracked via `_add_callable_to_manifest` were opaque source blobs — field type annotations referencing other user-defined types were NOT followed transitively. `getclosurevars()` fails on classes (no `__code__`), so no transitive dependencies were discovered.
+
+**Now:** When `getclosurevars` raises `TypeError` on a class, `_process_class_body_dependencies` parses the class source AST, extracts names from base classes and field annotations (including subscripts like `list[MyType]`, unions via `|`, and dotted refs), resolves them in the module namespace, and recursively tracks user-code types via `_add_callable_to_manifest`. Pydantic models found this way also get `_hash_pydantic_schema` called.
+
+**Regression test value:** High — this was the most frequently rediscovered bug (8 instances across different class types, nesting depths, and discovery paths). Regression testing should verify TypedDict→TypedDict chains, Pydantic field types, and generic type arguments in class annotations are still tracked.
+
+---
+
+### RC-6: TYPE_CHECKING Import Poisoning (FIXED)
+
+**Fixed by:** `_resolve_annotations_individually` (Design Decision #23)
+
+Previously, `typing.get_type_hints()` was all-or-nothing: if ANY annotation string failed to resolve (because the name was only available under `TYPE_CHECKING`), ALL annotations were skipped.
+
+**Now:** When `get_type_hints()` fails, each annotation string is evaluated individually via `eval()` in the function's global namespace. Resolvable annotations are still tracked; only unresolvable ones are skipped.
+
+**Regression test value:** Medium — the fix is clean but worth verifying in modules with mixed TYPE_CHECKING and runtime-available types.
+
+---
+
+### RC-7: Third-Party Instance Catch-All Missing (FIXED)
+
+**Fixed by:** `_hash_unrecognized_closure_value` with `repr()` (Design Decision #22)
+
+Previously, third-party class instances (numpy arrays, etc.) in function closures fell through all `isinstance` checks in `_process_closure_values` and were silently ignored.
+
+**Now:** The `else` branch at the end of `_process_closure_values` calls `_hash_unrecognized_closure_value`, which hashes via `repr()` if the repr is deterministic (no `0x` memory addresses) and small (< 10KB). Non-deterministic or oversized reprs fall back to `_check_mutable_capture`.
+
+**Limitation:** Large numpy arrays may exceed the 10KB repr limit. Arrays with custom dtypes may have non-deterministic repr. These edge cases fall through to the mutable capture check rather than being hashed.
+
+**Regression test value:** Medium — verify numpy arrays, datetime objects, regex patterns, and enum values are hashed correctly. Test the 10KB boundary.


### PR DESCRIPTION
## Summary

Implements the [fingerprint hardening plan](docs/plans/2026-02-11-fingerprint-hardening-design.md) — 8 fixes addressing 13 under-invalidation bugs where code changes weren't detected, plus 3 additional fixes from code review.

### Fixes

| # | Fix | Impact |
|---|-----|--------|
| 1 | **AST class body walker** — parse class source for type refs in annotations and bases | 7 bugs |
| 2 | **Pydantic JSON schema hashing** — `model_json_schema()` + field walking replaces per-field default hashing | 2 bugs |
| 3 | **Per-annotation type hint fallback** — eval annotations individually when `get_type_hints()` fails | 2 bugs |
| 4 | **Resolved hint hashing** — `repr(hint)` per parameter for alias change detection | 1 bug |
| 5 | **Closure value catch-all** — `repr()` with size/address guards for unrecognized types | 1 bug |
| 6 | **Data class method guard** — error when data classes have user methods | preventive |
| 7 | **Dynamic name access guard** — error on `getattr(x, var)`, `globals()`, `import_module()` | preventive |
| 8 | **getsource failure warning** — warn when `id(func)` fallback used for user code | preventive |

### Review-driven fixes
- Recursive Pydantic model guard (placeholder prevents infinite recursion)
- User-defined generic origin tracking in `_process_type_hint`
- Dotted string forward refs in class body annotations
- Skip non-user-code callables in closure catch-all (prevents false positive on e.g. `typing.cast`)
- ExceptionGroup unwrapping in CLI error handler (clean error messages)

### Quality
- 262 tests pass, 6 xfailed
- `ruff format` / `ruff check` / `basedpyright` all clean
- `_CACHE_SCHEMA_VERSION` bumped from 1 → 2