### PR TITLE
fix: remove symlink resolution from path normalization at registration time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ packages/pivot/src/pivot/
 - Type system (TypedDict, generics, Protocol)
 - Fingerprinting (what triggers re-runs)
 - LMDB/StateDB (prefixes, transactions)
+- Path resolution / symlinks (normpath vs resolve, registration vs execution validation)
 
 ---
 

--- a/docs/solutions/2026-02-02-path-resolution-design-patterns.md
+++ b/docs/solutions/2026-02-02-path-resolution-design-patterns.md
@@ -127,11 +127,25 @@ On Unix, `PurePosixPath("foo\\bar")` has one component `"foo\\bar"`, not two.
 
 **Solution:** Always use `PureWindowsPath` for parsing user input, then `.as_posix()` for internal use.
 
+## Invariant: Registration vs Execution Path Validation
+
+Path validation has two distinct phases with different responsibilities:
+
+| Phase | Validates | May call | Must NOT call |
+|-------|-----------|----------|---------------|
+| **Registration** (loading pipeline.py) | Declared/logical paths — syntax, containment, normalization | `normpath`, `is_relative_to` | `.resolve()`, `.exists()`, `.is_symlink()` |
+| **Execution** (running stages) | Filesystem reality — symlink escape, permissions, actual content | `.resolve()`, `.exists()` | N/A |
+
+**Why this matters:** Output files may be symlinks to the cache directory (created by a previous run with symlink checkout mode). If the cache is on a different filesystem (e.g., cross-filesystem worktrees with shared cache), those symlinks point outside the project root. Registration must not reject them — the declared path `data/output.jsonl` is inside the project regardless of what the file currently symlinks to on disk.
+
+**Execution-time defense-in-depth:** `stage_def.py:_validate_path_not_escaped()` checks symlink targets when writing outputs. This is the correct place for filesystem state validation.
+
 ## Prevention
 
 When designing path resolution:
 1. Decide early: implicit vs explicit prefix
 2. Keep resolution in one layer, don't thread through multiple modules
 3. Use `normpath` not `resolve` if symlinks should be preserved
-4. Test with symlinks pointing outside project root
-5. Test with Windows-style paths if accepting user input
+4. Never call `.resolve()`, `.exists()`, or `.is_symlink()` on artifact paths at registration time — see invariant above
+5. Test with symlinks pointing outside project root (especially cross-filesystem cache scenarios)
+6. Test with Windows-style paths if accepting user input

--- a/packages/pivot/src/pivot/registry.py
+++ b/packages/pivot/src/pivot/registry.py
@@ -641,7 +641,13 @@ def _normalize_paths(
     """Normalize paths to canonical absolute form, applying policy-based validation.
 
     Uses canonicalize_artifact_path() for the core normalization, then applies
-    policy checks (project containment, symlink escape detection).
+    policy checks (e.g., project containment for outputs). Symlink resolution is
+    intentionally NOT done here — normalization operates on declared/logical
+    paths, not filesystem state.
+
+    Execution-time symlink escape checks are performed in stage_def.py when
+    writing outputs, as defense-in-depth. Dependency paths may legitimately
+    resolve outside the project root when allowed by the configured policy.
     """
     normalized = list[str]()
     project_root = project.get_project_root()
@@ -653,7 +659,7 @@ def _normalize_paths(
             norm_str = path_utils.canonicalize_artifact_path(path, project_root)
             norm_path = pathlib.Path(norm_str.rstrip("/"))
 
-            # Check if path is within project root
+            # Check if path is within project root (logical path check, no symlink resolution)
             is_within_project = norm_path.is_relative_to(project_root)
 
             if not is_within_project:
@@ -663,23 +669,6 @@ def _normalize_paths(
                         + f"which is outside project root '{project_root}'"
                     )
                 logger.warning(f"Absolute {path_type.value} path may break reproducibility: {path}")
-            else:
-                # Symlink escape check (for paths that exist)
-                if norm_path.exists() and project.contains_symlink_in_path(norm_path, project_root):
-                    resolved = norm_path.resolve()
-                    if not resolved.is_relative_to(project_root.resolve()):
-                        msg = (
-                            f"{path_type.value.capitalize()} path '{path}' resolves outside "
-                            + f"project via symlink: {resolved}"
-                        )
-                        if policy["symlink_escape_action"] == "error":
-                            raise exceptions.InvalidPathError(msg)
-                        logger.warning(msg)
-                    else:
-                        logger.warning(
-                            f"Path '{path}' is inside a symlinked directory. "
-                            + "This may affect portability across environments."
-                        )
 
             normalized.append(norm_str)
         except (ValueError, OSError, exceptions.InvalidPathError):

--- a/packages/pivot/tests/config/test_registry.py
+++ b/packages/pivot/tests/config/test_registry.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic import BaseModel
 
 from helpers import register_test_stage
-from pivot import exceptions, fingerprint, loaders, outputs, registry, stage_def
+from pivot import exceptions, fingerprint, loaders, outputs, path_policy, registry, stage_def
 from pivot.exceptions import ParamsError, ValidationError
 from pivot.pipeline.pipeline import Pipeline
 from pivot.registry import RegistryStageInfo, StageRegistry
@@ -1165,3 +1165,42 @@ def test_get_stage_state_dir_returns_default_when_none(set_project_root: pathlib
     result = registry.get_stage_state_dir(stage_info, default_dir)
 
     assert result == default_dir
+
+
+# =============================================================================
+# Symlink escape: cache checkout symlinks should be allowed
+# =============================================================================
+
+
+def test_normalize_paths_ignores_symlink_targets(
+    set_project_root: pathlib.Path,
+) -> None:
+    """_normalize_paths operates on logical paths, not filesystem state.
+
+    When an output path is a symlink (e.g., from cache checkout), normalization
+    should not resolve it. The declared path 'data/output.jsonl' is within the
+    project root — what it symlinks to on disk is irrelevant at registration time.
+    Symlink escape detection happens at execution time in stage_def.py.
+    """
+    project_root = set_project_root
+
+    # Create output file as symlink to a location outside the project
+    # (simulates cross-filesystem cache checkout with symlink mode)
+    external_target = project_root.parent / "external_cache" / "files" / "5b" / "ef87b62b372eca"
+    external_target.parent.mkdir(parents=True)
+    external_target.write_text("cached content")
+
+    out_dir = project_root / "data"
+    out_dir.mkdir(parents=True)
+    output_file = out_dir / "output.jsonl"
+    output_file.symlink_to(external_target)
+
+    # Should NOT raise — normalization checks the logical path, not the symlink target
+    result = registry._normalize_paths(
+        ["data/output.jsonl"],
+        path_policy.PathType.OUT,
+        registry.ValidationMode.ERROR,
+    )
+    expected = str(project_root / "data" / "output.jsonl")
+    assert len(result) == 1
+    assert result[0] == expected


### PR DESCRIPTION
## Summary

Fixes output path registration failing in cross-filesystem worktree setups with shared cache directories.

## Problem

When `checkout_mode` falls back from hardlink to symlink (e.g., EXDEV across filesystems), Pivot creates symlinks from output files to the cache directory. On re-run, `_normalize_paths()` in `registry.py` was resolving these symlinks, finding they point outside the project root (to the cache on a different mount), and rejecting them with `InvalidPathError`.

## Fix

Removed the symlink escape check from `_normalize_paths()`. This function's job is to canonicalize *declared* paths (e.g., `data/output.jsonl` → `{project_root}/data/output.jsonl`). Whether the file on disk is currently a symlink is irrelevant to path normalization — that's a runtime concern. Symlink escape detection already exists at execution time in `stage_def.py:_validate_path_not_escaped()` as defense-in-depth.

## Changes

- **`registry.py`**: Removed `contains_symlink_in_path` + `resolve()` block from `_normalize_paths()` — normalization now only checks the logical path, not filesystem state
- **`test_registry.py`**: Added regression test verifying output symlinks to external locations don't break registration