### PR TITLE
refactor: split StageStatus.SKIPPED into semantic statuses + redesign console output

### DIFF
--- a/docs/plans/2026-02-13-cli-output-redesign-plan.md
+++ b/docs/plans/2026-02-13-cli-output-redesign-plan.md
@@ -1,0 +1,899 @@
+# CLI Output Redesign — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace noisy `ConsoleSink` with two auto-detected sinks: `StaticConsoleSink` (pipes/CI) and `LiveConsoleSink` (TTY with Rich Live).
+
+**Architecture:** Both sinks implement `EventSink` protocol. Shared formatting helpers handle alignment, color, symbols, and skip collapsing. The call site (`configure_output_sink`) picks sink based on `console.is_terminal`. The "waiting for artifact lock" message is dropped entirely.
+
+**Tech Stack:** Rich Console, Rich Live, Rich Progress, anyio (for 1Hz tick in Live sink)
+
+**Design:** See `docs/plans/2026-02-13-cli-output-redesign.md`
+
+---
+
+## Task 1: Shared Formatting Helpers
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/engine/sinks.py`
+- Test: `packages/pivot/tests/engine/test_sinks.py`
+
+These are pure functions used by both sinks. Build and test them in isolation first.
+
+**Step 1: Write the failing tests**
+
+Add to `packages/pivot/tests/engine/test_sinks.py` — new section after the existing ConsoleSink tests. All imports at module level per project test rules.
+
+```python
+# =============================================================================
+# Formatting Helper Tests
+# =============================================================================
+
+
+def test_format_stage_line_ran() -> None:
+    """Completed (RAN) stage produces aligned line with green checkmark and duration."""
+    from pivot.engine.sinks import _format_stage_line
+
+    line = _format_stage_line(
+        index=5, total=175, stage="train_model", status=StageStatus.RAN, duration_ms=3400.0, name_width=30,
+    )
+    # Should contain: progress counter, checkmark, stage name, "done", duration
+    assert "[  6/175]" in line, "Progress counter should be 1-indexed and right-aligned"
+    assert "✓" in line, "RAN status should show checkmark"
+    assert "train_model" in line, "Stage name should appear"
+    assert "done" in line, "Status word for RAN should be 'done'"
+    assert "3.4s" in line, "Duration should be formatted as seconds"
+
+
+def test_format_stage_line_skipped() -> None:
+    """Skipped stage shows circle symbol, no duration."""
+    from pivot.engine.sinks import _format_stage_line
+
+    line = _format_stage_line(
+        index=0, total=10, stage="fetch_data", status=StageStatus.SKIPPED, duration_ms=5.0, name_width=30,
+    )
+    assert "○" in line, "SKIPPED status should show circle"
+    assert "skipped" in line, "Status word for SKIPPED should be 'skipped'"
+    assert "0.0s" not in line, "Duration should NOT appear for skipped stages"
+
+
+def test_format_stage_line_failed() -> None:
+    """Failed stage shows X symbol."""
+    from pivot.engine.sinks import _format_stage_line
+
+    line = _format_stage_line(
+        index=2, total=5, stage="export", status=StageStatus.FAILED, duration_ms=100.0, name_width=30,
+    )
+    assert "✗" in line, "FAILED status should show X"
+    assert "FAILED" in line, "Status word for FAILED should be 'FAILED'"
+
+
+def test_format_stage_line_truncates_long_name() -> None:
+    """Stage names exceeding name_width are truncated with ellipsis."""
+    from pivot.engine.sinks import _format_stage_line
+
+    line = _format_stage_line(
+        index=0, total=10, stage="a" * 60, status=StageStatus.RAN, duration_ms=1000.0, name_width=50,
+    )
+    assert "…" in line, "Long names should be truncated with ellipsis"
+    assert "a" * 60 not in line, "Full long name should not appear"
+
+
+def test_format_skip_group_line() -> None:
+    """Collapsed skip group shows range and count."""
+    from pivot.engine.sinks import _format_skip_group_line
+
+    line = _format_skip_group_line(start_index=2, end_index=154, total=175, count=152)
+    assert "152" in line, "Skip count should appear"
+    assert "skipped" in line, "Should say 'skipped'"
+    assert "○" in line, "Should use skip symbol"
+
+
+def test_format_error_detail() -> None:
+    """Error detail lines are indented and each line preserved."""
+    from pivot.engine.sinks import _format_error_detail
+
+    lines = _format_error_detail("Traceback:\n  File test.py\nValueError: bad", name_width=30)
+    assert len(lines) == 3, "Should produce one output line per input line"
+    assert all("  " in l for l in lines), "Each line should be indented"
+    assert "Traceback" in lines[0]
+    assert "ValueError" in lines[2]
+
+
+def test_format_summary() -> None:
+    """Summary line contains counts and total duration."""
+    from pivot.engine.sinks import _format_summary
+
+    line = _format_summary(ran=3, skipped=152, failed=1, total_ms=14200.0)
+    assert "3 ran" in line
+    assert "152 skipped" in line
+    assert "1 failed" in line
+    assert "14.2s" in line
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "format_stage_line or format_skip_group or format_error_detail or format_summary" -v`
+Expected: FAIL — `_format_stage_line` doesn't exist yet
+
+**Step 3: Implement the formatting helpers**
+
+Add to `packages/pivot/src/pivot/engine/sinks.py`, above the class definitions. These are module-level functions prefixed with `_` since they're internal to the module.
+
+Key decisions:
+- Functions return plain strings (no Rich markup) — callers wrap in `console.print()` with markup enabled.
+  Actually, return strings WITH Rich markup tags. The console handles rendering.
+- `_format_stage_line` returns a single Rich-markup string.
+- `_format_error_detail` returns a list of Rich-markup strings (one per error line).
+- `_format_summary` returns a single Rich-markup string.
+- `_format_skip_group_line` returns a single Rich-markup string.
+- `name_width` parameter controls stage name column width. Callers track `max_name_seen`.
+
+```python
+import rich.markup
+
+# These constants are used by both sinks
+_STATUS_SYMBOL: dict[StageStatus, str] = {
+    StageStatus.RAN: "[green]✓[/green]",
+    StageStatus.SKIPPED: "[dim]○[/dim]",
+    StageStatus.FAILED: "[bold red]✗[/bold red]",
+}
+
+_STATUS_WORD: dict[StageStatus, str] = {
+    StageStatus.RAN: "[green]done[/green]",
+    StageStatus.SKIPPED: "[dim]skipped[/dim]",
+    StageStatus.FAILED: "[bold red]FAILED[/bold red]",
+}
+
+_MAX_NAME_WIDTH = 50
+
+
+def _format_stage_line(
+    *,
+    index: int,
+    total: int,
+    stage: str,
+    status: StageStatus,
+    duration_ms: float,
+    name_width: int,
+) -> str:
+    """Format a single stage completion line with alignment and color."""
+    counter_width = len(str(total))
+    counter = f"[{index + 1:>{counter_width}}/{total}]"
+
+    display_name = stage
+    capped_width = min(name_width, _MAX_NAME_WIDTH)
+    if len(display_name) > capped_width:
+        display_name = display_name[: capped_width - 1] + "…"
+
+    symbol = _STATUS_SYMBOL[status]
+    word = _STATUS_WORD[status]
+    duration = f"  {duration_ms / 1000:.1f}s" if status == StageStatus.RAN else ""
+
+    return f"  {counter} {symbol} [bold]{display_name:<{capped_width}}[/bold]  {word}{duration}"
+
+
+def _format_skip_group_line(
+    *, start_index: int, end_index: int, total: int, count: int,
+) -> str:
+    """Format a collapsed skip group line."""
+    counter_width = len(str(total))
+    counter = f"[{start_index + 1}–{end_index + 1}/{total}]"
+    # Pad counter to roughly match individual line counters
+    padded = f"{counter:>{counter_width * 2 + 4}}"
+    return f"  {padded} [dim]○[/dim] [dim]{count} stages skipped[/dim]"
+
+
+def _format_error_detail(reason: str, *, name_width: int) -> list[str]:
+    """Format multi-line error detail, indented under the stage line."""
+    # Indent to align with stage name column (counter + symbol + padding)
+    indent = " " * 12  # Approximate alignment
+    lines = []
+    for line in reason.rstrip().split("\n"):
+        escaped = rich.markup.escape(line)
+        lines.append(f"{indent}[dim red]{escaped}[/dim red]")
+    return lines
+
+
+def _format_summary(*, ran: int, skipped: int, failed: int, total_ms: float) -> str:
+    """Format the end-of-run summary line."""
+    parts = []
+    if ran:
+        parts.append(f"[green]{ran} ran[/green]")
+    if skipped:
+        parts.append(f"[dim]{skipped} skipped[/dim]")
+    if failed:
+        parts.append(f"[bold red]{failed} failed[/bold red]")
+    duration = f"{total_ms / 1000:.1f}s"
+    return f"  Done: {', '.join(parts)} ({duration} total)"
+```
+
+**Step 4: Run the formatting tests**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "format_stage_line or format_skip_group or format_error_detail or format_summary" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(cli): add shared formatting helpers for console sinks"
+```
+
+---
+
+## Task 2: StaticConsoleSink
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/engine/sinks.py`
+- Test: `packages/pivot/tests/engine/test_sinks.py`
+
+The simpler sink: line-by-line output with skip collapsing. No cursor manipulation. Works in CI/pipes.
+
+**Step 1: Write the failing tests**
+
+Add a new section to `test_sinks.py`:
+
+```python
+# =============================================================================
+# StaticConsoleSink Tests
+# =============================================================================
+
+
+async def test_static_sink_prints_ran_stage() -> None:
+    """StaticConsoleSink prints a formatted line for a completed RAN stage."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageStarted(type="stage_started", stage="train", index=0, total=5))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="train", status=StageStatus.RAN,
+        reason="", duration_ms=1500.0, index=0, total=5, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "1/5" in result, "Progress counter should appear"
+    assert "train" in result, "Stage name should appear"
+    assert "done" in result, "Status word should appear"
+    assert "1.5s" in result, "Duration should appear"
+
+
+async def test_static_sink_prints_skipped_stage() -> None:
+    """StaticConsoleSink prints skipped stages individually when count is low."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="fetch", status=StageStatus.SKIPPED,
+        reason="up-to-date", duration_ms=5.0, index=0, total=5, input_hash=None,
+    ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="train", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=1, total=5, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "fetch" in result, "Skipped stage should appear individually"
+    assert "skipped" in result
+
+
+async def test_static_sink_collapses_many_skips() -> None:
+    """StaticConsoleSink collapses >20 consecutive skips into a summary line."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    # Send 25 skipped stages followed by one RAN stage to flush buffer
+    for i in range(25):
+        await sink.handle(StageCompleted(
+            type="stage_completed", stage=f"stage_{i}", status=StageStatus.SKIPPED,
+            reason="up-to-date", duration_ms=5.0, index=i, total=30, input_hash=None,
+        ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="final", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=25, total=30, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    # Should NOT list all 25 individually
+    assert "stage_12" not in result, "Individual skip names should not appear when collapsed"
+    assert "25" in result, "Skip count should appear"
+    assert "skipped" in result, "Should say 'skipped'"
+
+
+async def test_static_sink_does_not_collapse_few_skips() -> None:
+    """StaticConsoleSink lists skips individually when <=20."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    for i in range(5):
+        await sink.handle(StageCompleted(
+            type="stage_completed", stage=f"stage_{i}", status=StageStatus.SKIPPED,
+            reason="up-to-date", duration_ms=5.0, index=i, total=10, input_hash=None,
+        ))
+    # Flush with a ran stage
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="final", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=5, total=10, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    for i in range(5):
+        assert f"stage_{i}" in result, f"stage_{i} should appear individually"
+
+
+async def test_static_sink_ignores_waiting_on_lock() -> None:
+    """StaticConsoleSink does NOT print 'waiting for artifact lock'."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageStateChanged(
+        type="stage_state_changed", stage="train",
+        state=StageExecutionState.WAITING_ON_LOCK,
+        previous_state=StageExecutionState.PREPARING,
+    ))
+    await sink.close()
+
+    assert output.getvalue() == "", "Should not print anything for WAITING_ON_LOCK"
+
+
+async def test_static_sink_prints_failed_with_reason() -> None:
+    """StaticConsoleSink prints FAILED stage with indented error detail."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="export", status=StageStatus.FAILED,
+        reason="KeyError: 'score'", duration_ms=100.0, index=0, total=5, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "FAILED" in result, "Should show FAILED status"
+    assert "KeyError" in result, "Error reason should appear"
+
+
+async def test_static_sink_ignores_stage_started() -> None:
+    """StaticConsoleSink does not print anything for stage_started events."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageStarted(type="stage_started", stage="train", index=0, total=5))
+
+    assert output.getvalue() == "", "Should not print for stage_started"
+
+
+async def test_static_sink_prints_summary_on_close() -> None:
+    """StaticConsoleSink prints summary line when closed."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="a", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=0, total=3, input_hash=None,
+    ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="b", status=StageStatus.SKIPPED,
+        reason="up-to-date", duration_ms=5.0, index=1, total=3, input_hash=None,
+    ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="c", status=StageStatus.FAILED,
+        reason="err", duration_ms=50.0, index=2, total=3, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "1 ran" in result, "Summary should count ran"
+    assert "1 skipped" in result, "Summary should count skipped"
+    assert "1 failed" in result, "Summary should count failed"
+
+
+async def test_static_sink_show_output_prints_log_lines() -> None:
+    """StaticConsoleSink prints log lines in dim when show_output=True."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console, show_output=True)
+
+    await sink.handle(LogLine(
+        type="log_line", stage="train", line="Epoch 1/10", is_stderr=False,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "train" in result, "Stage name prefix should appear"
+    assert "Epoch 1/10" in result, "Log content should appear"
+
+
+async def test_static_sink_hides_log_lines_by_default() -> None:
+    """StaticConsoleSink ignores log lines when show_output=False."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console)
+
+    await sink.handle(LogLine(
+        type="log_line", stage="train", line="Epoch 1/10", is_stderr=False,
+    ))
+
+    assert output.getvalue() == "", "Should not print log lines by default"
+
+
+async def test_static_sink_log_line_flushes_skip_buffer() -> None:
+    """Log lines arriving mid-skip-buffer flush pending skips first."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = StaticConsoleSink(console=console, show_output=True)
+
+    # 3 skips then a log line
+    for i in range(3):
+        await sink.handle(StageCompleted(
+            type="stage_completed", stage=f"s{i}", status=StageStatus.SKIPPED,
+            reason="", duration_ms=5.0, index=i, total=10, input_hash=None,
+        ))
+    await sink.handle(LogLine(
+        type="log_line", stage="train", line="hello", is_stderr=False,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    lines = result.strip().split("\n")
+    # Skipped stages should appear before the log line
+    skip_line_indices = [i for i, l in enumerate(lines) if "skipped" in l]
+    log_line_indices = [i for i, l in enumerate(lines) if "hello" in l]
+    assert skip_line_indices, "Skipped lines should appear"
+    assert log_line_indices, "Log line should appear"
+    assert max(skip_line_indices) < min(log_line_indices), "Skips should flush before log line"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "static_sink" -v`
+Expected: FAIL — `StaticConsoleSink` doesn't exist yet
+
+**Step 3: Implement StaticConsoleSink**
+
+Add to `packages/pivot/src/pivot/engine/sinks.py`. Key implementation details:
+
+- Tracks: `_completed_count`, `_ran_count`, `_skipped_count`, `_failed_count`, `_total_duration_ms`, `_max_name_width`, `_skip_buffer` (list of `StageCompleted` events).
+- `_skip_buffer` holds consecutive skipped stages. Flushed when a non-skip completion, log line (if `show_output`), or `close()` is called.
+- Flush logic: if `len(buffer) <= 20`, print each individually; if `> 20`, print one collapsed line.
+- On `close()`: flush remaining skip buffer, then print summary line.
+- `stage_started`: ignored (no output).
+- `stage_state_changed`: ignored entirely (no "waiting for lock").
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "static_sink" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(cli): add StaticConsoleSink with skip collapsing and aligned output"
+```
+
+---
+
+## Task 3: LiveConsoleSink
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/engine/sinks.py`
+- Test: `packages/pivot/tests/engine/test_sinks.py`
+
+The complex sink: Rich `Live` pinned section with running stages, progress bar, and summary counts. Scrollback via `console.print()`.
+
+**Step 1: Write the failing tests**
+
+Testing `Live` is tricky — you can't easily capture Live output in a `StringIO`. Focus on testing:
+1. State management (running set, completion tracking)
+2. Scrollback output (completions and log lines printed via `console.print()`)
+3. The pinned renderable content
+
+Strategy: use `no_color=True` console to capture what `console.print()` emits (scrollback). For the Live renderable, test the `_build_live_renderable()` method directly.
+
+```python
+# =============================================================================
+# LiveConsoleSink Tests
+# =============================================================================
+
+
+async def test_live_sink_prints_completion_to_scrollback() -> None:
+    """LiveConsoleSink prints completed stage lines via console.print() (scrollback)."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console)
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="train", status=StageStatus.RAN,
+        reason="", duration_ms=1500.0, index=0, total=5, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "train" in result, "Stage name should appear in scrollback"
+    assert "done" in result, "Status should appear in scrollback"
+
+
+async def test_live_sink_tracks_running_stages() -> None:
+    """LiveConsoleSink adds stages to running set on stage_started."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console)
+
+    await sink.handle(StageStarted(type="stage_started", stage="train", index=0, total=5))
+
+    assert "train" in sink._running, "Stage should be in running set after stage_started"
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="train", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=0, total=5, input_hash=None,
+    ))
+
+    assert "train" not in sink._running, "Stage should be removed from running set after completion"
+    await sink.close()
+
+
+async def test_live_sink_ignores_waiting_on_lock() -> None:
+    """LiveConsoleSink does NOT print 'waiting for artifact lock'."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console)
+
+    await sink.handle(StageStateChanged(
+        type="stage_state_changed", stage="train",
+        state=StageExecutionState.WAITING_ON_LOCK,
+        previous_state=StageExecutionState.PREPARING,
+    ))
+    await sink.close()
+
+    assert output.getvalue() == "", "Should not print anything for WAITING_ON_LOCK"
+
+
+async def test_live_sink_collapses_many_skips_in_scrollback() -> None:
+    """LiveConsoleSink uses same skip collapsing in scrollback as StaticConsoleSink."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console)
+
+    for i in range(25):
+        await sink.handle(StageCompleted(
+            type="stage_completed", stage=f"stage_{i}", status=StageStatus.SKIPPED,
+            reason="up-to-date", duration_ms=5.0, index=i, total=30, input_hash=None,
+        ))
+    # Flush with a ran stage
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="final", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=25, total=30, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "stage_12" not in result, "Individual skip names should not appear when collapsed"
+    assert "25" in result, "Skip count should appear"
+
+
+async def test_live_sink_summary_counts() -> None:
+    """LiveConsoleSink tracks ran/skipped/failed counts for summary."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console)
+
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="a", status=StageStatus.RAN,
+        reason="", duration_ms=1000.0, index=0, total=3, input_hash=None,
+    ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="b", status=StageStatus.SKIPPED,
+        reason="", duration_ms=5.0, index=1, total=3, input_hash=None,
+    ))
+    await sink.handle(StageCompleted(
+        type="stage_completed", stage="c", status=StageStatus.FAILED,
+        reason="err", duration_ms=50.0, index=2, total=3, input_hash=None,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "1 ran" in result
+    assert "1 skipped" in result
+    assert "1 failed" in result
+
+
+async def test_live_sink_show_output_prints_log_lines() -> None:
+    """LiveConsoleSink prints log lines to scrollback when show_output=True."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = LiveConsoleSink(console=console, show_output=True)
+
+    await sink.handle(LogLine(
+        type="log_line", stage="train", line="Epoch 1", is_stderr=False,
+    ))
+    await sink.close()
+
+    result = output.getvalue()
+    assert "train" in result
+    assert "Epoch 1" in result
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "live_sink" -v`
+Expected: FAIL — `LiveConsoleSink` doesn't exist
+
+**Step 3: Implement LiveConsoleSink**
+
+Add to `packages/pivot/src/pivot/engine/sinks.py`. Key implementation details:
+
+**State:**
+- `_running: dict[str, float]` — stage name → start timestamp (for elapsed timers)
+- `_completed_count`, `_ran_count`, `_skipped_count`, `_failed_count`, `_total_duration_ms`
+- `_total: int` — total stage count (set from first event's `total` field)
+- `_max_name_width: int` — max stage name length seen so far
+- `_skip_buffer: list[StageCompleted]` — same collapsing logic as StaticConsoleSink
+- `_live: rich.live.Live | None` — the Rich Live context, created lazily on first event
+- `_tick_scope: anyio.CancelScope | None` — scope for the 1Hz tick task
+
+**Event handling:**
+- `stage_started`: add to `_running` dict with `time.monotonic()` timestamp. Update Live.
+- `stage_completed`: remove from `_running`. Buffer skips or flush+print. Update Live.
+- `stage_state_changed`: ignored entirely.
+- `log_line` (if `show_output`): flush skip buffer, `console.print()` dim line. Update Live.
+- `engine_diagnostic`: flush skip buffer, `console.print()` warning. Update Live.
+
+**Live renderable (`_build_live_renderable`):**
+Return a `rich.console.Group` containing:
+1. Running stage lines: `▶ stage_name    running…  3.2s` (green, with elapsed time from `_running` dict)
+2. Progress bar: `rich.progress_bar.ProgressBar` or a formatted string
+3. Summary line: `3 ran · 152 skipped · 1 failed`
+
+**1Hz tick:**
+- Started in `handle()` on the first event (not in `__init__`, to avoid needing an event loop at construction).
+- Uses `anyio.CancelScope` + `anyio.sleep(1)` loop.
+- Each tick calls `_live.update(self._build_live_renderable())`.
+- **Important:** The sink's `handle()` is called from the engine's async dispatch loop, so we can't start a background task from `handle()` directly. Instead, the tick task must be started by the engine or passed in. **Alternative:** Since `Live` itself can set `refresh_per_second=1`, we might not need a manual tick at all — just call `_live.update()` on every event, and Rich's Live will re-render at 1Hz automatically, picking up the updated elapsed times from `_running` dict by calling `_build_live_renderable` as the Live's `get_renderable`.
+
+**Simpler approach for ticking:** Pass `_build_live_renderable` as the Live's renderable (a callable). Rich Live calls `get_renderable()` on every refresh. Set `refresh_per_second=1`. Then:
+- On each event, update internal state. Live re-renders at 1Hz automatically.
+- Call `_live.update(self._build_live_renderable())` on events for immediate feedback too.
+
+This eliminates the need for a separate anyio tick task entirely.
+
+**`close()`:**
+- Flush remaining skip buffer via `console.print()`.
+- Print summary line via `console.print()`.
+- Stop Live context (`_live.stop()` / `__exit__`).
+
+**Note on testing:** Since `Live` uses terminal control codes, tests use `force_terminal=False` consoles where `Live` degrades gracefully (no live updates). The scrollback output (`console.print()` calls) is still captured and testable. The live renderable building logic can be tested separately by calling `_build_live_renderable()` directly.
+
+**Step 4: Run the tests**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py -k "live_sink" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(cli): add LiveConsoleSink with Rich Live pinned section"
+```
+
+---
+
+## Task 4: Wire Up Call Sites
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/cli/_run_common.py:262-283`
+- Modify: `packages/pivot/src/pivot/cli/repro.py:519-522`
+- Modify: `packages/pivot/src/pivot/engine/sinks.py` (`__all__`)
+- Test: `packages/pivot/tests/cli/test_cli_run_common.py:523-539`
+
+**Step 1: Write the failing tests**
+
+Update the existing test in `test_cli_run_common.py`:
+
+```python
+def test_configure_output_sink_console_mode_picks_static_for_non_terminal(
+    mocker: MockerFixture,
+) -> None:
+    """configure_output_sink adds StaticConsoleSink when console is not a terminal."""
+    mock_engine = mocker.MagicMock(spec=engine.Engine)
+    # Patch Console to report non-terminal
+    mock_console = mocker.patch("pivot.cli._run_common.rich.console.Console")
+    mock_console.return_value.is_terminal = False
+
+    _run_common.configure_output_sink(
+        mock_engine, quiet=False, as_json=False, use_console=True, jsonl_callback=None,
+    )
+
+    mock_engine.add_sink.assert_called_once()
+    added_sink = mock_engine.add_sink.call_args[0][0]
+    assert isinstance(added_sink, sinks.StaticConsoleSink)
+
+
+def test_configure_output_sink_console_mode_picks_live_for_terminal(
+    mocker: MockerFixture,
+) -> None:
+    """configure_output_sink adds LiveConsoleSink when console is a terminal."""
+    mock_engine = mocker.MagicMock(spec=engine.Engine)
+    mock_console = mocker.patch("pivot.cli._run_common.rich.console.Console")
+    mock_console.return_value.is_terminal = True
+
+    _run_common.configure_output_sink(
+        mock_engine, quiet=False, as_json=False, use_console=True, jsonl_callback=None,
+    )
+
+    mock_engine.add_sink.assert_called_once()
+    added_sink = mock_engine.add_sink.call_args[0][0]
+    assert isinstance(added_sink, sinks.LiveConsoleSink)
+```
+
+**Step 2: Run to verify failure**
+
+Run: `uv run pytest packages/pivot/tests/cli/test_cli_run_common.py -k "picks_static or picks_live" -v`
+Expected: FAIL
+
+**Step 3: Update configure_output_sink**
+
+In `_run_common.py`, change `configure_output_sink()`:
+
+```python
+def configure_output_sink(
+    eng: engine.Engine,
+    *,
+    quiet: bool,
+    as_json: bool,
+    use_console: bool,
+    jsonl_callback: Callable[[dict[str, object]], None] | None,
+    show_output: bool = False,
+) -> None:
+    """Configure output sinks based on display mode."""
+    import rich.console
+
+    if as_json and jsonl_callback:
+        eng.add_sink(JsonlSink(callback=jsonl_callback))
+        return
+
+    if quiet:
+        return
+
+    if use_console:
+        console = rich.console.Console()
+        if console.is_terminal:
+            eng.add_sink(sinks.LiveConsoleSink(console=console, show_output=show_output))
+        else:
+            eng.add_sink(sinks.StaticConsoleSink(console=console, show_output=show_output))
+```
+
+In `repro.py`, update the `--serve` mode sink setup similarly:
+
+```python
+if not quiet:
+    serve_console = rich.console.Console()
+    if serve_console.is_terminal:
+        eng.add_sink(sinks.LiveConsoleSink(console=serve_console, show_output=show_output))
+    else:
+        eng.add_sink(sinks.StaticConsoleSink(console=serve_console, show_output=show_output))
+```
+
+Update `sinks.py` `__all__` to export the new classes:
+
+```python
+__all__ = [
+    "LiveConsoleSink",
+    "ResultCollectorSink",
+    "StaticConsoleSink",
+]
+```
+
+**Step 4: Run all affected tests**
+
+Run: `uv run pytest packages/pivot/tests/cli/test_cli_run_common.py packages/pivot/tests/engine/test_sinks.py -v`
+Expected: PASS (new tests pass, but existing ConsoleSink tests will fail — addressed in Task 5)
+
+**Step 5: Commit**
+
+```bash
+jj desc -m "feat(cli): auto-detect TTY for Live vs Static console sink"
+```
+
+---
+
+## Task 5: Remove Old ConsoleSink and Update Tests
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/engine/sinks.py` (remove `ConsoleSink`)
+- Modify: `packages/pivot/tests/engine/test_sinks.py` (update/remove old tests)
+- Modify: `packages/pivot/tests/engine/test_lock_state.py` (update tests)
+- Modify: `packages/pivot/tests/cli/test_cli_run_common.py` (update isinstance checks)
+
+**Step 1: Remove ConsoleSink class from sinks.py**
+
+Delete the `ConsoleSink` class entirely. It's replaced by `StaticConsoleSink` and `LiveConsoleSink`. Remove from `__all__`.
+
+**Step 2: Update test_sinks.py**
+
+The old `ConsoleSink` tests (`test_console_sink_*`) need to be either:
+- **Deleted** if covered by the new `StaticConsoleSink`/`LiveConsoleSink` tests (most are).
+- **Migrated** if they test behavior still relevant (Rich markup escaping, etc.).
+
+Tests to migrate to `StaticConsoleSink` equivalents:
+- `test_console_sink_escapes_rich_markup_in_log_lines` → test that `StaticConsoleSink` escapes markup in log lines
+- `test_console_sink_handles_special_characters` → test special chars in `StaticConsoleSink`
+
+Tests to delete (covered by new tests):
+- `test_console_sink_handles_stage_started` (Static ignores; Live tracks running set)
+- `test_console_sink_handles_stage_completed_ran` → `test_static_sink_prints_ran_stage`
+- `test_console_sink_handles_stage_completed_skipped` → `test_static_sink_prints_skipped_stage`
+- `test_console_sink_handles_stage_completed_failed` → `test_static_sink_prints_failed_with_reason`
+- `test_console_sink_handles_multiline_reason` → covered by `_format_error_detail` test
+- `test_console_sink_ignores_other_events` → implicit (sinks only handle known events)
+- `test_console_sink_formats_duration_correctly` → `test_format_stage_line_ran`
+- `test_console_sink_running_message_format` → deleted (no more "Running..." line)
+- `test_console_sink_handles_log_line_when_show_output_enabled` → `test_static_sink_show_output_prints_log_lines`
+- `test_console_sink_stderr_line_contains_content` → add stderr test for new sinks
+- `test_console_sink_ignores_log_line_when_show_output_disabled` → `test_static_sink_hides_log_lines_by_default`
+- `test_console_sink_handles_empty_log_line` → add for new sinks if needed
+- `test_console_sink_handles_multiline_log_output` → add for new sinks if needed
+
+**Step 3: Update test_lock_state.py**
+
+- `test_console_sink_displays_waiting_on_lock` → **Invert the assertion**: both new sinks should NOT print waiting-on-lock messages. Replace with tests for both sinks asserting empty output for WAITING_ON_LOCK events. Or simply rename the test to `test_static_sink_ignores_waiting_on_lock` and `test_live_sink_ignores_waiting_on_lock` (already in Task 2 and 3 tests).
+- `test_console_sink_ignores_other_state_changes` → already covered by new tests.
+
+**Step 4: Update test_cli_run_common.py**
+
+- `test_configure_output_sink_console_mode` → Replace with the TTY/non-TTY tests from Task 4.
+
+**Step 5: Run full test suite for sinks**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_sinks.py packages/pivot/tests/engine/test_lock_state.py packages/pivot/tests/cli/test_cli_run_common.py -v`
+Expected: PASS
+
+**Step 6: Run quality checks**
+
+Run: `uv run ruff format packages/pivot/src/pivot/engine/sinks.py packages/pivot/tests/engine/test_sinks.py && uv run ruff check packages/pivot/src/pivot/engine/sinks.py packages/pivot/tests/engine/test_sinks.py && uv run basedpyright packages/pivot/src/pivot/engine/sinks.py`
+Expected: Clean
+
+**Step 7: Commit**
+
+```bash
+jj desc -m "refactor(cli): remove old ConsoleSink, migrate tests to new sinks"
+```
+
+---
+
+## Task 6: Full Test Suite and Polish
+
+**Files:**
+- All modified files from Tasks 1-5
+
+**Step 1: Run the full test suite**
+
+Run: `uv run pytest packages/pivot/tests packages/pivot-tui/tests -n auto`
+Expected: PASS (or only pre-existing failures unrelated to this change)
+
+**Step 2: Run quality checks**
+
+Run: `uv run ruff format . && uv run ruff check . && uv run basedpyright`
+Expected: Clean
+
+**Step 3: Manual verification**
+
+If possible, run `pivot repro` on a real pipeline to visually verify:
+1. Static mode (pipe): `pivot repro 2>&1 | cat` — should show aligned, collapsed output
+2. Live mode (TTY): `pivot repro` — should show pinned running stages + progress bar
+3. Quiet mode: `pivot repro --quiet` — should show nothing
+4. Show output: `pivot repro --show-output` — should show dim log lines in scrollback
+
+**Step 4: Final commit**
+
+```bash
+jj desc -m "feat(cli): redesign CLI output with auto-detected Live/Static console sinks"
+```

--- a/docs/plans/2026-02-13-cli-output-redesign.md
+++ b/docs/plans/2026-02-13-cli-output-redesign.md
@@ -1,0 +1,133 @@
+# CLI Output Redesign
+
+**Goal:** Replace the noisy, unformatted `ConsoleSink` with clean, aligned, colored output that auto-detects TTY vs pipe mode.
+
+**Problem:** With large pipelines (175 stages), CLI output is a wall of unstyled text. Every stage emits multiple lines ("waiting for artifact lock", "skipped"), nothing aligns, there's no color, no progress indicator, and no way to tell what's running vs finished at a glance.
+
+**Scope:** `ConsoleSink` replacement only. No changes to the event system, engine, TUI, or JSON output.
+
+---
+
+## Design
+
+### Two sinks, one interface
+
+The current `ConsoleSink` is replaced by two classes. The call site picks based on `console.is_terminal`:
+
+- **`LiveConsoleSink`** — TTY: Rich `Live` pinned section + scrollback
+- **`StaticConsoleSink`** — Pipes/CI: one line per stage completion
+
+Both implement the existing `EventSink` protocol (`handle()` / `close()`). Shared formatting logic (alignment, colors, symbols) lives in helper functions within `sinks.py`.
+
+### Event handling
+
+| Event | Static sink | Live sink |
+|-------|-------------|-----------|
+| `stage_started` | ignore | add to running set, re-render |
+| `stage_completed` | print completion line | move to completed, `console.print()` above pinned, re-render |
+| `stage_state_changed` (`WAITING_ON_LOCK`) | **ignore** | **ignore** |
+| `log_line` (if `--show-output`) | print dim line | `console.print()` dim line above pinned |
+| `engine_diagnostic` | print warning | `console.print()` warning above pinned |
+
+The "waiting for artifact lock" message is dropped by both sinks.
+
+### Completion line format
+
+```
+  [ 3/175] ✓ base_download_data               done      3.4s
+  [2–154/175] ○ 152 stages skipped
+  [155/175] ✓ final_aggregate                  done      2.1s
+  [156/175] ✗ export_results                   FAILED
+             KeyError: 'score_normalized'...
+```
+
+**Columns:**
+1. **Progress counter** `[N/TOTAL]` — right-aligned, fixed width
+2. **Status symbol** — `✓` (green), `○` (dim), `✗` (bold red)
+3. **Stage name** — left-padded to `min(max_name_seen, 50)`, truncated with `…` if longer
+4. **Status word** — `done`, `skipped`, `FAILED`, colored to match
+5. **Duration** — only for `done` stages
+
+Error detail lines are indented below the failed stage in `dim red`.
+
+### Skip collapsing
+
+Skipped stages are buffered. The buffer flushes when a non-skip event arrives or the run ends:
+
+- **≤20 buffered skips:** print each individually
+- **>20 buffered skips:** collapse to `[N–M/TOTAL] ○ K stages skipped`
+
+DAG execution naturally clusters skips (upstream skips → dependents skip), so collapsing works well in practice. Interleaved skip clusters are handled independently.
+
+### Visual hierarchy (completion lines vs log lines)
+
+When `--show-output` is on, completion lines and log lines are interleaved in scrollback. They're visually distinct:
+
+- **Completion lines:** colored symbol, bold stage name, progress counter
+- **Log lines:** `dim` text, `[stage_name]` prefix, no counter
+
+### Live sink: pinned section
+
+A Rich `Live` block pinned to the bottom of the terminal. Contains only:
+
+```
+  ▶ base_transform_data          running…  3.2s
+  ▶ difficulty_compute_scores    running…  1.1s
+  ━━━━━━━━━━━━━━━━━━━━━━━━  155/175 (88%)  3 ran · 152 skipped · 1 failed
+```
+
+- **Running stages** with elapsed timers, green `▶` prefix
+- **Progress bar** (Rich `Progress`)
+- **Summary counts** — updated on every completion
+
+Height is `(currently running stages) + 2`. Bounded by `--jobs` (default 4), not total stages. Shrinks to just summary + progress when nothing's running between batches.
+
+### Live sink: 1Hz timer tick
+
+Running stage elapsed timers need to update even when no events arrive (long-running stages). An `anyio` background task sends a tick every second, triggering a `Live.update()` re-render. Cancelled on `close()`.
+
+### Live sink: run end
+
+When execution finishes, the running section empties, the progress bar fills, and `Live` exits. Clean scrollback remains — identical to what static mode would have produced, plus the final summary line.
+
+### Static sink
+
+Pure line-by-line output. No `Live`, no cursor manipulation. Works in CI, pipes, log files. Same completion line format and skip collapsing as the live sink's scrollback. Ends with:
+
+```
+  Done: 3 ran, 152 skipped, 1 failed (14.2s total)
+```
+
+### Flags
+
+- **`--quiet`**: no output from either sink (unchanged from today)
+- **`--json`**: `JsonlSink` handles it, `configure_output_sink()` returns early (unchanged)
+- **`--show-output`**: log lines appear in scrollback (both sinks)
+
+---
+
+## Implementation
+
+### Files changed
+
+**`packages/pivot/src/pivot/engine/sinks.py`** — replace `ConsoleSink` with:
+- `_format_stage_line()` — shared alignment, color, symbols
+- `_format_error_detail()` — shared indented error lines
+- `_format_summary()` — shared end summary
+- `StaticConsoleSink` — buffered skip collapsing, line-by-line
+- `LiveConsoleSink` — Rich `Live`, running set, 1Hz tick, `console.print()` for scrollback
+- `ResultCollectorSink` — unchanged
+
+**`packages/pivot/src/pivot/cli/_run_common.py`** — `configure_output_sink()` picks `LiveConsoleSink` or `StaticConsoleSink` based on `console.is_terminal`.
+
+**`packages/pivot/src/pivot/cli/repro.py`** — same change for `--serve` mode sink setup.
+
+### Files unchanged
+
+- `engine/types.py` — all needed event types already exist
+- `engine/engine.py` — event emission unchanged
+- `pivot-tui/` — TUI is a separate code path
+
+### Testing
+
+Unit tests for formatting helpers (alignment, collapsing thresholds, color). Integration tests for both sinks: feed `OutputEvent` TypedDicts, assert output via `StringIO`-backed `Console`. Follow the existing `ResultCollectorSink` test pattern.

--- a/docs/plans/2026-02-13-split-skipped-status.md
+++ b/docs/plans/2026-02-13-split-skipped-status.md
@@ -1,0 +1,409 @@
+# Split StageStatus.SKIPPED Into Semantic Statuses — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the ambiguous `StageStatus.SKIPPED` with three specific statuses (`CACHED`, `BLOCKED`, `CANCELLED`) so every consumer gets the correct semantic status without calling `categorize_stage_result()`.
+
+**Architecture:** Add `CACHED`, `BLOCKED`, `CANCELLED` to `StageStatus`. Remove `SKIPPED`. Update all 6 creation sites (4 in worker, 2 in engine) to set the correct status. Simplify `categorize_stage_result()` to a trivial 1:1 mapping. Update all consumers.
+
+**Tech Stack:** Python 3.13+ StrEnum, TypedDict, Literal types
+
+---
+
+## Scope
+
+**Source files:** 10 files, ~18 references to update
+**Test files:** ~25 files, ~50 references to update
+**Breaking change:** Yes — `StageStatus.SKIPPED` removed, lock files with `"skipped"` won't load. Pre-alpha, acceptable per AGENTS.md.
+
+---
+
+### Task 1: Update StageStatus Enum and Type Aliases
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/types.py`
+- Test: `packages/pivot/tests/test_types.py`
+
+**Step 1: Write the failing test**
+
+Update `test_completion_type_includes_skipped` → rename to `test_completion_type_includes_all_terminal_statuses`:
+
+```python
+def test_completion_type_includes_all_terminal_statuses() -> None:
+    """CompletionType includes all terminal status values."""
+    assert StageStatus.RAN in get_args(CompletionType)
+    assert StageStatus.CACHED in get_args(CompletionType)
+    assert StageStatus.BLOCKED in get_args(CompletionType)
+    assert StageStatus.CANCELLED in get_args(CompletionType)
+    assert StageStatus.FAILED in get_args(CompletionType)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/pivot/tests/test_types.py -k "completion_type" -v`
+Expected: FAIL — `StageStatus.CACHED` doesn't exist
+
+**Step 3: Update the enum and type aliases**
+
+In `types.py`:
+
+```python
+class StageStatus(enum.StrEnum):
+    READY = "ready"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CACHED = "cached"         # Was SKIPPED — stage up-to-date, outputs restored from cache
+    BLOCKED = "blocked"       # Was SKIPPED — upstream dependency failed
+    CANCELLED = "cancelled"   # Was SKIPPED — run cancelled by user
+    FAILED = "failed"
+    RAN = "ran"
+    UNKNOWN = "unknown"
+
+CompletionType = Literal[
+    StageStatus.RAN, StageStatus.CACHED, StageStatus.BLOCKED,
+    StageStatus.CANCELLED, StageStatus.FAILED,
+]
+```
+
+Update `categorize_stage_result` — it no longer needs reason-parsing for SKIPPED:
+
+```python
+def categorize_stage_result(status: StageStatus, reason: str) -> DisplayCategory:
+    """Map status to display category for consistent UI."""
+    match status:
+        case StageStatus.READY:
+            return DisplayCategory.PENDING
+        case StageStatus.IN_PROGRESS:
+            return DisplayCategory.RUNNING
+        case StageStatus.COMPLETED | StageStatus.RAN:
+            return DisplayCategory.SUCCESS
+        case StageStatus.FAILED:
+            return DisplayCategory.FAILED
+        case StageStatus.CACHED:
+            return DisplayCategory.CACHED
+        case StageStatus.BLOCKED:
+            return DisplayCategory.BLOCKED
+        case StageStatus.CANCELLED:
+            return DisplayCategory.CANCELLED
+        case StageStatus.UNKNOWN:
+            return DisplayCategory.UNKNOWN
+```
+
+Note: `categorize_stage_result` is now trivial (1:1 mapping). It can stay for backward compatibility with existing call sites — removing all callers is a separate cleanup. The important thing is it no longer parses `reason` strings.
+
+Update `StageRunRecord` type annotation (line ~736):
+```python
+status: Literal[StageStatus.RAN, StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED, StageStatus.FAILED]
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/pivot/tests/test_types.py -k "completion_type" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+---
+
+### Task 2: Update Worker — All SKIPPED Returns → CACHED
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/executor/worker.py`
+- Test: `packages/pivot/tests/execution/test_executor_worker.py`
+
+Workers only return SKIPPED when a stage is up-to-date (cache hit). All 4 sites become CACHED.
+
+**Step 1: Update `_make_result` type annotation (line 157)**
+
+```python
+status: Literal[StageStatus.RAN, StageStatus.CACHED, StageStatus.FAILED],
+```
+
+**Step 2: Replace all 4 SKIPPED returns**
+
+- Line 276: `StageStatus.SKIPPED` → `StageStatus.CACHED` (generation-based skip)
+- Line 329: `StageStatus.SKIPPED` → `StageStatus.CACHED` (lock-based skip)
+- Line 350: `StageStatus.SKIPPED` → `StageStatus.CACHED` (run cache, no-commit mode)
+- Line 372: `StageStatus.SKIPPED` → `StageStatus.CACHED` (run cache, with deferred writes)
+
+**Step 3: Run worker tests**
+
+Run: `uv run pytest packages/pivot/tests/execution/test_executor_worker.py -x --tb=short`
+
+Many tests will fail because they assert `status == "skipped"`. Update all assertions:
+- Grep for `== "skipped"` in `test_executor_worker.py` (~12 locations)
+- All should become `== "cached"` (workers only produce cache-hit skips)
+
+**Step 4: Run full worker test suite**
+
+Run: `uv run pytest packages/pivot/tests/execution/test_executor_worker.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+---
+
+### Task 3: Update Engine — Blocked and Cancelled Stages
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/engine/engine.py`
+- Test: `packages/pivot/tests/engine/test_engine.py`
+
+The engine creates SKIPPED events for three distinct scenarios:
+- Cached (worker returned skip) — already CACHED from Task 2
+- Blocked (upstream failed) — needs BLOCKED
+- Cancelled (user cancelled) — needs CANCELLED
+
+**Step 1: Rename `_emit_skipped_stage` → `_emit_terminal_stage`**
+
+Update the method to accept a `status` parameter instead of always using SKIPPED:
+
+```python
+async def _emit_terminal_stage(
+    self,
+    stage_name: str,
+    status: StageStatus,
+    reason: str,
+    results: dict[str, executor_core.ExecutionSummary],
+    run_id: str = "",
+) -> None:
+    """Record and emit a non-executed stage completion (cached/blocked/cancelled)."""
+    results[stage_name] = executor_core.ExecutionSummary(
+        status=status,
+        reason=reason,
+        input_hash=None,
+    )
+    stage_index, total_stages = self._get_stage_index(stage_name)
+    await self.emit(
+        StageCompleted(
+            type="stage_completed",
+            stage=stage_name,
+            status=status,
+            reason=reason,
+            duration_ms=0.0,
+            index=stage_index,
+            total=total_stages,
+            run_id=run_id,
+            input_hash=None,
+            output_summary=None,
+        )
+    )
+```
+
+**Step 2: Update all 3 call sites**
+
+- Line 1047 (blocked by failed upstream):
+  ```python
+  await self._emit_terminal_stage(name, StageStatus.BLOCKED, f"upstream '{first_failed}' failed", results, run_id=run_id)
+  ```
+
+- Line 1066 (cancelled):
+  ```python
+  await self._emit_terminal_stage(name, StageStatus.CANCELLED, "cancelled", results, run_id=run_id)
+  ```
+
+- Line 1109 (blocked by failed upstream, post-loop cleanup):
+  ```python
+  await self._emit_terminal_stage(name, StageStatus.BLOCKED, f"upstream '{failed_upstream}' failed", results, run_id=run_id)
+  ```
+
+**Step 3: Update line 973 — deferred writes check**
+
+```python
+# Before:
+result["status"] in (StageStatus.RAN, StageStatus.SKIPPED)
+# After:
+result["status"] in (StageStatus.RAN, StageStatus.CACHED)
+```
+
+Only CACHED stages have deferred writes (blocked/cancelled don't execute at all).
+
+**Step 4: Update `_record_skipped_stage` (line ~1660)**
+
+This method handles worker-returned skips (all CACHED). Rename to `_record_cached_stage` and use `StageStatus.CACHED`.
+
+**Step 5: Run engine tests**
+
+Run: `uv run pytest packages/pivot/tests/engine/test_engine.py -x --tb=short`
+
+Update assertions: grep for `"skipped"` (~3 locations). Determine whether each should become `"cached"`, `"blocked"`, or `"cancelled"` based on the test scenario.
+
+**Step 6: Commit**
+
+---
+
+### Task 4: Update Type Annotations
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/executor/core.py` (line 120)
+- Modify: `packages/pivot/src/pivot/engine/types.py` (StageCompleted TypedDict)
+
+**Step 1: Update ExecutionSummary**
+
+```python
+status: Literal[StageStatus.RAN, StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED, StageStatus.FAILED, StageStatus.UNKNOWN]
+```
+
+**Step 2: Update `count_results` in executor/core.py**
+
+The function currently uses `categorize_stage_result`. Now it can match directly:
+
+```python
+match result["status"]:
+    case StageStatus.RAN:
+        ran += 1
+    case StageStatus.FAILED:
+        failed += 1
+    case StageStatus.BLOCKED:
+        blocked += 1
+    case StageStatus.CACHED | StageStatus.CANCELLED:
+        cached += 1
+    case _:
+        pass
+```
+
+**Step 3: Run affected tests**
+
+Run: `uv run pytest packages/pivot/tests/execution/ packages/pivot/tests/engine/test_types.py -x --tb=short`
+
+**Step 4: Commit**
+
+---
+
+### Task 5: Update CLI Consumers
+
+**Files:**
+- Modify: `packages/pivot/src/pivot/cli/repro.py`
+- Modify: `packages/pivot/src/pivot/cli/run.py`
+- Modify: `packages/pivot/src/pivot/cli/history.py`
+- Modify: `packages/pivot/src/pivot/cli/console.py`
+- Modify: `packages/pivot/src/pivot/engine/sinks.py`
+
+**Step 1: Update repro.py and run.py — SKIPPED count**
+
+Both have `sum(1 for r in results.values() if r["status"] == StageStatus.SKIPPED)`. Replace:
+
+```python
+skipped = sum(1 for r in results.values() if r["status"] in (StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED))
+```
+
+Or better — use `count_results()` which already handles this.
+
+**Step 2: Update history.py**
+
+- Line 54: Replace `StageStatus.SKIPPED` count with CACHED + BLOCKED + CANCELLED
+- Line 127: Update match case:
+  ```python
+  case StageStatus.CACHED | StageStatus.BLOCKED | StageStatus.CANCELLED:
+      icon = "•"
+  ```
+
+**Step 3: Update console.py**
+
+The `stage_result` method (line 149) already calls `categorize_stage_result()` which now does a trivial mapping. No changes needed — it still works. Optionally, replace with direct status matching later (cleanup task, not blocking).
+
+**Step 4: Update sinks.py**
+
+The sinks already use `DisplayCategory` via `_categorize()`. Since `categorize_stage_result()` still works (trivial mapping now), the sinks work as-is. But clean up:
+- The `_SKIP_CATEGORIES` set and `_categorize()` helper can match on `StageStatus` directly instead of going through `DisplayCategory`
+- The `_CATEGORY_SYMBOL` and `_CATEGORY_WORD` dicts can be keyed on `StageStatus` instead of `DisplayCategory`
+
+This is optional cleanup — sinks work correctly either way since `categorize_stage_result()` is now a trivial 1:1 mapping.
+
+**Step 5: Run CLI tests**
+
+Run: `uv run pytest packages/pivot/tests/cli/ -x --tb=short`
+
+Update failing tests that check for `"skipped"` string in output:
+- `test_cli.py` line 791
+- `test_cli_commit.py` line 263
+- Various keep-going tests (already updated for "blocked")
+
+**Step 6: Commit**
+
+---
+
+### Task 6: Update TUI
+
+**Files:**
+- Modify: `packages/pivot-tui/src/pivot_tui/run.py`
+- Modify: `packages/pivot-tui/src/pivot_tui/widgets/status.py`
+- Modify: `packages/pivot-tui/src/pivot_tui/widgets/logs.py`
+
+**Step 1: Update run.py**
+
+- Line 550: Replace `StageStatus.SKIPPED` with all three new statuses in the completion check tuple
+- Line 572: Same — update progress counting
+- Line 666: Replace `status == StageStatus.SKIPPED` with `status in (StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED)`
+
+**Step 2: Update widgets/status.py**
+
+The status widget functions already use `categorize_stage_result()` which still works. No changes required — `categorize_stage_result(StageStatus.CACHED, "")` returns `DisplayCategory.CACHED` just like before. 
+
+Optionally, switch to matching `StageStatus` directly (cleanup task).
+
+**Step 3: Update widgets/logs.py**
+
+- Line 109: Replace SKIPPED match:
+  ```python
+  case StageStatus.CACHED | StageStatus.BLOCKED | StageStatus.CANCELLED:
+      self.write("[dim]Stage was skipped[/]")
+  ```
+
+**Step 4: Run TUI tests**
+
+Run: `uv run pytest packages/pivot-tui/tests/ -x --tb=short`
+
+Update: `test_status.py` parametrized tests to use `StageStatus.CACHED` (with "cache hit" reason) and `StageStatus.BLOCKED` (with "upstream failed" reason) instead of `StageStatus.SKIPPED`.
+
+**Step 5: Commit**
+
+---
+
+### Task 7: Update Remaining Test Files
+
+**Files:** ~15 test files with `== "skipped"` assertions
+
+This is the mechanical bulk of the work. Each `"skipped"` assertion needs to become `"cached"`, `"blocked"`, or `"cancelled"` depending on the test scenario.
+
+**Pattern:**
+- Tests where a stage is unchanged/up-to-date: `"skipped"` → `"cached"`
+- Tests where a stage is blocked by upstream failure: `"skipped"` → `"blocked"`
+- Tests where a run is cancelled: `"skipped"` → `"cancelled"`
+
+**Files to update (by expected new status):**
+
+| File | Assertions | Expected new status |
+|------|-----------|---------------------|
+| `test_executor_worker.py` | 12 | `"cached"` (all cache-hit scenarios) |
+| `test_executor.py` | 7 | `"cached"` (most), `"blocked"` (upstream failure tests) |
+| `test_skip_detection_integration.py` | 5 | `"cached"` |
+| `test_run_cache_lock_update.py` | 4 | `"cached"` |
+| `test_no_fingerprint.py` | 4 | `"cached"` |
+| `test_engine.py` | 3 | `"cached"` or `"blocked"` depending on test |
+| `test_incremental_out.py` | 2 | `"cached"` |
+| `test_execution_modes.py` | 1 | `"cached"` |
+| `test_executor_pvt.py` | 1 | `"cached"` |
+| `test_cli_commit.py` | 1 | `"cached"` |
+| `test_cli.py` | 1 | `"cached"` |
+| `test_run_history.py` | 2 | `"cached"` |
+| `test_jsonl_sink.py` | 1 | `"cached"` |
+| `test_cli_run_common.py` | 2 | `"cached"` |
+| `test_engine_shutdown.py` | 1 | Add CACHED, BLOCKED, CANCELLED to acceptable statuses |
+| `test_unified_execution.py` | 1 | Add CACHED, BLOCKED, CANCELLED to acceptable statuses |
+
+**Note:** `test_sync.py` and `test_transfer.py` use `result["skipped"]` for sync operation counts — NOT stage status. Leave these unchanged.
+
+**Step 1: Update each test file** (can be done in batches by directory)
+
+**Step 2: Run full test suite**
+
+Run: `uv run pytest packages/pivot/tests packages/pivot-tui/tests -n auto`
+Expected: PASS
+
+**Step 3: Run quality checks**
+
+Run: `uv run ruff format . && uv run ruff check . && uv run basedpyright`
+Expected: Clean
+
+**Step 4: Commit**

--- a/packages/pivot-tui/src/pivot_tui/run.py
+++ b/packages/pivot-tui/src/pivot_tui/run.py
@@ -547,7 +547,9 @@ class PivotApp(textual.app.App[None]):
             elif status in (
                 StageStatus.RAN,
                 StageStatus.COMPLETED,
-                StageStatus.SKIPPED,
+                StageStatus.CACHED,
+                StageStatus.BLOCKED,
+                StageStatus.CANCELLED,
                 StageStatus.FAILED,
             ):
                 self._finalize_history_entry(stage, status, msg["reason"], msg["elapsed"], run_id)
@@ -569,7 +571,14 @@ class PivotApp(textual.app.App[None]):
                 1
                 for s in self._stages.values()
                 if s.status
-                in (StageStatus.COMPLETED, StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED)
+                in (
+                    StageStatus.COMPLETED,
+                    StageStatus.RAN,
+                    StageStatus.CACHED,
+                    StageStatus.BLOCKED,
+                    StageStatus.CANCELLED,
+                    StageStatus.FAILED,
+                )
             )
             self.title = f"pivot run ({completed}/{len(self._stages)})"
 
@@ -663,7 +672,10 @@ class PivotApp(textual.app.App[None]):
         pending = self._pending_history.pop(stage_name, None)
 
         if pending is None:
-            if status == StageStatus.SKIPPED and run_id:
+            if (
+                status in (StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED)
+                and run_id
+            ):
                 entry = ExecutionHistoryEntry(
                     run_id=run_id,
                     stage_name=stage_name,

--- a/packages/pivot-tui/src/pivot_tui/widgets/logs.py
+++ b/packages/pivot-tui/src/pivot_tui/widgets/logs.py
@@ -106,7 +106,7 @@ class StageLogPanel(textual.widgets.RichLog):
         else:
             # Show status-appropriate message when no logs
             match stage.status:
-                case StageStatus.SKIPPED:
+                case StageStatus.CACHED | StageStatus.BLOCKED | StageStatus.CANCELLED:
                     self.write("[dim]Stage was skipped[/]")
                 case StageStatus.COMPLETED | StageStatus.RAN | StageStatus.FAILED:
                     self.write("[dim]No logs recorded[/]")

--- a/packages/pivot-tui/src/pivot_tui/widgets/status.py
+++ b/packages/pivot-tui/src/pivot_tui/widgets/status.py
@@ -22,9 +22,9 @@ def format_elapsed(elapsed: float | None) -> str:
     return f"({mins}:{secs:02d})"
 
 
-def get_status_symbol(status: StageStatus, reason: str = "") -> tuple[str, str]:
+def get_status_symbol(status: StageStatus, _reason: str = "") -> tuple[str, str]:
     """Get compact symbol and style for a status (for row display)."""
-    category = categorize_stage_result(status, reason)
+    category = categorize_stage_result(status)
     match category:
         case DisplayCategory.PENDING:
             return ("○", "dim")
@@ -46,9 +46,9 @@ def get_status_symbol(status: StageStatus, reason: str = "") -> tuple[str, str]:
             return ("?", "dim")
 
 
-def get_status_label(status: StageStatus, reason: str = "") -> tuple[str, str]:
+def get_status_label(status: StageStatus, _reason: str = "") -> tuple[str, str]:
     """Get verbose label and style for a status (for detail panel)."""
-    category = categorize_stage_result(status, reason)
+    category = categorize_stage_result(status)
     match category:
         case DisplayCategory.PENDING:
             return ("PENDING", "dim")
@@ -70,9 +70,9 @@ def get_status_label(status: StageStatus, reason: str = "") -> tuple[str, str]:
             return ("UNKNOWN", "dim")
 
 
-def get_status_icon(status: StageStatus, reason: str = "") -> str:
+def get_status_icon(status: StageStatus, _reason: str = "") -> str:
     """Get status icon with Rich markup (for inline display in headers/history)."""
-    category = categorize_stage_result(status, reason)
+    category = categorize_stage_result(status)
     match category:
         case DisplayCategory.SUCCESS:
             return "[green]✓[/]"
@@ -103,15 +103,15 @@ _STATUS_ICON_PLAIN: dict[DisplayCategory, str] = {
 }
 
 
-def get_status_icon_plain(status: StageStatus, reason: str = "") -> str:
+def get_status_icon_plain(status: StageStatus, _reason: str = "") -> str:
     """Get status icon without Rich markup (for length calculations)."""
-    category = categorize_stage_result(status, reason)
+    category = categorize_stage_result(status)
     return _STATUS_ICON_PLAIN.get(category, "")
 
 
-def get_status_table_cell(status: StageStatus, reason: str) -> str:
+def get_status_table_cell(status: StageStatus, _reason: str) -> str:
     """Get fixed-width status cell for table display (8 chars visible)."""
-    category = categorize_stage_result(status, reason)
+    category = categorize_stage_result(status)
     match category:
         case DisplayCategory.SUCCESS:
             return "[green]✓ ran[/]  "
@@ -154,6 +154,12 @@ def count_statuses(stages: Iterable[StageInfo]) -> StatusCounts:
                 completed += 1
             case StageStatus.FAILED:
                 failed += 1
-            case StageStatus.READY | StageStatus.SKIPPED | StageStatus.UNKNOWN:
+            case (
+                StageStatus.READY
+                | StageStatus.CACHED
+                | StageStatus.BLOCKED
+                | StageStatus.CANCELLED
+                | StageStatus.UNKNOWN
+            ):
                 pass  # Not counted
     return StatusCounts(running=running, completed=completed, failed=failed)

--- a/packages/pivot-tui/tests/test_console.py
+++ b/packages/pivot-tui/tests/test_console.py
@@ -128,7 +128,7 @@ def test_console_stage_result_cached() -> None:
     stream = io.StringIO()
     con = console.Console(stream=stream, color=False)
 
-    con.stage_result("my_stage", index=1, total=5, status=StageStatus.SKIPPED, reason="unchanged")
+    con.stage_result("my_stage", index=1, total=5, status=StageStatus.CACHED, reason="unchanged")
 
     output = stream.getvalue()
     assert "cached" in output
@@ -140,7 +140,7 @@ def test_console_stage_result_blocked() -> None:
     con = console.Console(stream=stream, color=False)
 
     con.stage_result(
-        "my_stage", index=1, total=5, status=StageStatus.SKIPPED, reason="upstream 'other' failed"
+        "my_stage", index=1, total=5, status=StageStatus.BLOCKED, reason="upstream 'other' failed"
     )
 
     output = stream.getvalue()
@@ -191,7 +191,7 @@ def test_console_summary() -> None:
     stream = io.StringIO()
     con = console.Console(stream=stream, color=False)
 
-    con.summary(ran=5, cached=2, blocked=1, failed=1, total_duration=10.5)
+    con.summary(ran=5, cached=2, blocked=1, cancelled=0, failed=1, total_duration=10.5)
 
     output = stream.getvalue()
     assert "5" in output  # ran

--- a/packages/pivot-tui/tests/test_history.py
+++ b/packages/pivot-tui/tests/test_history.py
@@ -249,7 +249,7 @@ def test_finalize_history_skipped_without_pending_creates_entry() -> None:
     # Call _finalize_history_entry for a SKIPPED stage with no pending state
     app._finalize_history_entry(
         stage_name="downstream_stage",
-        status=StageStatus.SKIPPED,
+        status=StageStatus.BLOCKED,
         reason="upstream 'stage_a' failed",
         elapsed=None,
         run_id="test_run_123",
@@ -259,7 +259,7 @@ def test_finalize_history_skipped_without_pending_creates_entry() -> None:
     assert len(app._stages["downstream_stage"].history) == 1
     entry = app._stages["downstream_stage"].history[0]
     assert entry.run_id == "test_run_123"
-    assert entry.status == StageStatus.SKIPPED
+    assert entry.status == StageStatus.BLOCKED
     assert "upstream 'stage_a' failed" in entry.reason
     assert entry.duration is None
     assert entry.logs == []
@@ -272,7 +272,7 @@ def test_finalize_history_skipped_without_run_id_does_not_create_entry() -> None
     # Call without run_id - should not create entry
     app._finalize_history_entry(
         stage_name="downstream_stage",
-        status=StageStatus.SKIPPED,
+        status=StageStatus.BLOCKED,
         reason="upstream failed",
         elapsed=None,
         run_id=None,  # No run_id
@@ -442,7 +442,7 @@ def test_finalize_history_with_empty_logs() -> None:
     # Finalize with SKIPPED status (special case that creates entry without pending)
     app._finalize_history_entry(
         stage_name="silent_stage",
-        status=StageStatus.SKIPPED,
+        status=StageStatus.BLOCKED,
         reason="upstream failed",
         elapsed=None,
         run_id="test_run",
@@ -452,7 +452,7 @@ def test_finalize_history_with_empty_logs() -> None:
     assert len(app._stages["silent_stage"].history) == 1
     entry = app._stages["silent_stage"].history[0]
     assert len(entry.logs) == 0
-    assert entry.status == StageStatus.SKIPPED
+    assert entry.status == StageStatus.BLOCKED
 
 
 def test_get_current_stage_history_with_no_stages() -> None:

--- a/packages/pivot-tui/tests/widgets/test_status.py
+++ b/packages/pivot-tui/tests/widgets/test_status.py
@@ -18,8 +18,8 @@ from pivot_tui.widgets import status
         pytest.param(StageStatus.IN_PROGRESS, "", "\u25b6", "blue bold", id="running"),
         pytest.param(StageStatus.RAN, "", "\u25cf", "green bold", id="success"),
         pytest.param(StageStatus.FAILED, "error", "\u2717", "red bold", id="failed"),
-        pytest.param(StageStatus.SKIPPED, "cache hit", "\u21ba", "yellow", id="cached"),
-        pytest.param(StageStatus.SKIPPED, "upstream failed", "\u25c7", "red", id="blocked"),
+        pytest.param(StageStatus.CACHED, "cache hit", "\u21ba", "yellow", id="cached"),
+        pytest.param(StageStatus.BLOCKED, "upstream failed", "\u25c7", "red", id="blocked"),
     ],
 )
 def test_get_status_symbol(
@@ -41,8 +41,8 @@ def test_get_status_symbol(
     [
         pytest.param(StageStatus.RAN, "", "[green]\u2713[/]", id="success"),
         pytest.param(StageStatus.FAILED, "error", "[red]\u2717[/]", id="failed"),
-        pytest.param(StageStatus.SKIPPED, "cache hit", "[yellow]\u21ba[/]", id="cached"),
-        pytest.param(StageStatus.SKIPPED, "upstream failed", "[red]\u25c7[/]", id="blocked"),
+        pytest.param(StageStatus.CACHED, "cache hit", "[yellow]\u21ba[/]", id="cached"),
+        pytest.param(StageStatus.BLOCKED, "upstream failed", "[red]\u25c7[/]", id="blocked"),
         pytest.param(StageStatus.READY, "", "", id="pending_no_icon"),
         pytest.param(StageStatus.IN_PROGRESS, "", "", id="running_no_icon"),
     ],
@@ -57,8 +57,8 @@ def test_get_status_icon(status_val: StageStatus, reason: str, expected_icon: st
     [
         pytest.param(StageStatus.RAN, "", "\u2713", id="success"),
         pytest.param(StageStatus.FAILED, "error", "\u2717", id="failed"),
-        pytest.param(StageStatus.SKIPPED, "cache hit", "\u21ba", id="cached"),
-        pytest.param(StageStatus.SKIPPED, "upstream failed", "\u25c7", id="blocked"),
+        pytest.param(StageStatus.CACHED, "cache hit", "\u21ba", id="cached"),
+        pytest.param(StageStatus.BLOCKED, "upstream failed", "\u25c7", id="blocked"),
         pytest.param(StageStatus.READY, "", "", id="pending_no_icon"),
     ],
 )
@@ -77,8 +77,8 @@ def test_get_status_icon_plain(status_val: StageStatus, reason: str, expected_pl
     [
         pytest.param(StageStatus.RAN, "", ["\u2713", "ran"], id="success"),
         pytest.param(StageStatus.FAILED, "error", ["\u2717", "fail"], id="failed"),
-        pytest.param(StageStatus.SKIPPED, "cache hit", ["\u21ba", "cache"], id="cached"),
-        pytest.param(StageStatus.SKIPPED, "upstream failed", ["\u25c7", "block"], id="blocked"),
+        pytest.param(StageStatus.CACHED, "cache hit", ["\u21ba", "cache"], id="cached"),
+        pytest.param(StageStatus.BLOCKED, "upstream failed", ["\u25c7", "block"], id="blocked"),
         pytest.param(StageStatus.READY, "", ["PENDING"], id="pending"),
         pytest.param(StageStatus.IN_PROGRESS, "", ["RUNNING"], id="running"),
     ],
@@ -134,8 +134,8 @@ def test_format_elapsed(elapsed: float | None, expected: str) -> None:
         pytest.param(StageStatus.RAN, "", "SUCCESS", id="success"),
         pytest.param(StageStatus.COMPLETED, "", "SUCCESS", id="completed_as_success"),
         pytest.param(StageStatus.FAILED, "error", "FAILED", id="failed"),
-        pytest.param(StageStatus.SKIPPED, "cache hit", "CACHED", id="cached"),
-        pytest.param(StageStatus.SKIPPED, "upstream failed", "BLOCKED", id="blocked"),
+        pytest.param(StageStatus.CACHED, "cache hit", "CACHED", id="cached"),
+        pytest.param(StageStatus.BLOCKED, "upstream failed", "BLOCKED", id="blocked"),
         pytest.param(StageStatus.UNKNOWN, "", "UNKNOWN", id="unknown"),
     ],
 )
@@ -165,7 +165,7 @@ def test_count_statuses_mixed_stages() -> None:
     stages[1].status = StageStatus.RAN
     stages[2].status = StageStatus.COMPLETED
     stages[3].status = StageStatus.FAILED
-    stages[4].status = StageStatus.SKIPPED  # Not counted
+    stages[4].status = StageStatus.CACHED  # Not counted
 
     counts = status.count_statuses(stages)
     assert counts == {"running": 1, "completed": 2, "failed": 1}
@@ -175,7 +175,7 @@ def test_count_statuses_ignores_non_terminal_statuses() -> None:
     """count_statuses does not count READY, SKIPPED, or UNKNOWN."""
     stages = [StageInfo(f"s{i}", i, 3) for i in range(1, 4)]
     stages[0].status = StageStatus.READY
-    stages[1].status = StageStatus.SKIPPED
+    stages[1].status = StageStatus.CACHED
     stages[2].status = StageStatus.UNKNOWN
 
     counts = status.count_statuses(stages)

--- a/packages/pivot/src/pivot/cli/_run_common.py
+++ b/packages/pivot/src/pivot/cli/_run_common.py
@@ -280,7 +280,11 @@ def configure_output_sink(
         return
 
     if use_console:
-        eng.add_sink(sinks.ConsoleSink(console=rich.console.Console(), show_output=show_output))
+        console = rich.console.Console()
+        if console.is_terminal:
+            eng.add_sink(sinks.LiveConsoleSink(console=console, show_output=show_output))
+        else:
+            eng.add_sink(sinks.StaticConsoleSink(console=console, show_output=show_output))
 
 
 def convert_results(

--- a/packages/pivot/src/pivot/cli/console.py
+++ b/packages/pivot/src/pivot/cli/console.py
@@ -146,7 +146,7 @@ class Console:
         progress = self._color(f"[{index}/{total}]", "dim")
 
         # Determine display status and text based on status and reason
-        category = categorize_stage_result(status, reason)
+        category = categorize_stage_result(status)
         match category:
             case DisplayCategory.SUCCESS:
                 status_text = self._color("ran", "green", "bold")
@@ -190,6 +190,7 @@ class Console:
         ran: int,
         cached: int,
         blocked: int,
+        cancelled: int,
         failed: int,
         total_duration: float,
     ) -> None:
@@ -202,9 +203,14 @@ class Console:
         ran_text = self._color(str(ran), "green") if ran > 0 else str(ran)
         cached_text = self._color(str(cached), "yellow") if cached > 0 else str(cached)
         blocked_text = self._color(str(blocked), "red") if blocked > 0 else str(blocked)
+        cancelled_text = self._color(str(cancelled), "yellow") if cancelled > 0 else str(cancelled)
         failed_text = self._color(str(failed), "red", "bold") if failed > 0 else str(failed)
 
-        summary = f"Summary: {ran_text} ran, {cached_text} cached, {blocked_text} blocked, {failed_text} failed"
+        parts = [f"{ran_text} ran", f"{cached_text} cached", f"{blocked_text} blocked"]
+        if cancelled > 0:
+            parts.append(f"{cancelled_text} cancelled")
+        parts.append(f"{failed_text} failed")
+        summary = "Summary: " + ", ".join(parts)
         duration = self._color(f"[{total_duration:.2f}s total]", "dim")
 
         self._echo(f"{summary} {duration}")

--- a/packages/pivot/src/pivot/cli/history.py
+++ b/packages/pivot/src/pivot/cli/history.py
@@ -51,7 +51,11 @@ def _print_run_summary(run: RunManifest) -> None:
     """Print single-line summary of a run as table row."""
     stages = run["stages"]
     ran = sum(1 for s in stages.values() if s["status"] == StageStatus.RAN)
-    skipped = sum(1 for s in stages.values() if s["status"] == StageStatus.SKIPPED)
+    skipped = sum(
+        1
+        for s in stages.values()
+        if s["status"] in (StageStatus.CACHED, StageStatus.BLOCKED, StageStatus.CANCELLED)
+    )
     failed = sum(1 for s in stages.values() if s["status"] == StageStatus.FAILED)
 
     total_duration_ms = sum(s["duration_ms"] for s in stages.values())
@@ -124,12 +128,10 @@ def _print_run_detail(run: RunManifest) -> None:
         match status:
             case StageStatus.RAN:
                 icon = "\u2713"
-            case StageStatus.SKIPPED:
+            case StageStatus.CACHED | StageStatus.BLOCKED | StageStatus.CANCELLED:
                 icon = "\u2022"
             case StageStatus.FAILED:
                 icon = "\u2717"
-            case _:
-                icon = "?"
 
         click.echo(f"  {icon} {name:<24} {status:<8} {duration_str:>8}  {reason}")
 

--- a/packages/pivot/src/pivot/cli/repro.py
+++ b/packages/pivot/src/pivot/cli/repro.py
@@ -36,7 +36,6 @@ from pivot.types import (
     OnError,
     RunEventType,
     SchemaVersionEvent,
-    StageStatus,
     categorize_stage_result,
 )
 
@@ -51,7 +50,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # JSONL schema version for forward compatibility
-_JSONL_SCHEMA_VERSION = 1
+_JSONL_SCHEMA_VERSION = 2
 
 
 def _configure_watch_sources(
@@ -672,15 +671,14 @@ def _run_oneshot_mode(
     # Emit JSONL final result
     if as_json:
         total_duration_ms = (time.perf_counter() - start_time) * 1000
-        ran = sum(1 for r in results.values() if r["status"] == StageStatus.RAN)
-        skipped = sum(1 for r in results.values() if r["status"] == StageStatus.SKIPPED)
-        failed = sum(1 for r in results.values() if r["status"] == StageStatus.FAILED)
+        ran, cached, blocked, cancelled, failed = executor_core.count_results(results)
+        skipped = cached + blocked + cancelled
 
         # Compute failed stage names for JSONL output
         failed_stage_names = sorted(
             name
             for name, r in results.items()
-            if categorize_stage_result(r["status"], r["reason"]) == DisplayCategory.FAILED
+            if categorize_stage_result(r["status"]) == DisplayCategory.FAILED
         )
 
         cli_helpers.emit_jsonl(
@@ -697,14 +695,14 @@ def _run_oneshot_mode(
 
     # Print summary for plain mode
     if console and results:
-        ran, cached, blocked, failed = executor_core.count_results(results)
+        ran, cached, blocked, cancelled, failed = executor_core.count_results(results)
         total_duration = time.perf_counter() - start_time
-        console.summary(ran, cached, blocked, failed, total_duration)
+        console.summary(ran, cached, blocked, cancelled, failed, total_duration)
         # Print failed stage names after summary
         failed_stage_names = sorted(
             name
             for name, r in results.items()
-            if categorize_stage_result(r["status"], r["reason"]) == DisplayCategory.FAILED
+            if categorize_stage_result(r["status"]) == DisplayCategory.FAILED
         )
         console.failed_stages(failed_stage_names)
 

--- a/packages/pivot/src/pivot/cli/repro.py
+++ b/packages/pivot/src/pivot/cli/repro.py
@@ -519,7 +519,14 @@ def _run_serve_mode(
             # Add sinks
             if not quiet:
                 serve_console = rich.console.Console()
-                eng.add_sink(sinks.ConsoleSink(console=serve_console, show_output=show_output))
+                if serve_console.is_terminal:
+                    eng.add_sink(
+                        sinks.LiveConsoleSink(console=serve_console, show_output=show_output)
+                    )
+                else:
+                    eng.add_sink(
+                        sinks.StaticConsoleSink(console=serve_console, show_output=show_output)
+                    )
             eng.add_sink(sinks.ResultCollectorSink())
             eng.add_sink(BroadcastEventSink())  # Broadcast events to connected agents
 

--- a/packages/pivot/src/pivot/cli/run.py
+++ b/packages/pivot/src/pivot/cli/run.py
@@ -30,7 +30,6 @@ from pivot.types import (
     OnError,
     RunEventType,
     SchemaVersionEvent,
-    StageStatus,
     categorize_stage_result,
 )
 
@@ -41,7 +40,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # JSONL schema version for forward compatibility
-_JSONL_SCHEMA_VERSION = 1
+_JSONL_SCHEMA_VERSION = 2
 
 
 def _configure_oneshot_source(
@@ -212,15 +211,14 @@ def _run_json_mode(
 
     # Emit execution result
     total_duration_ms = (time.perf_counter() - start_time) * 1000
-    ran = sum(1 for r in results.values() if r["status"] == StageStatus.RAN)
-    skipped = sum(1 for r in results.values() if r["status"] == StageStatus.SKIPPED)
-    failed = sum(1 for r in results.values() if r["status"] == StageStatus.FAILED)
+    ran, cached, blocked, cancelled, failed = executor_core.count_results(results)
+    skipped = cached + blocked + cancelled
 
     # Compute failed stage names for JSONL output
     failed_stage_names = sorted(
         name
         for name, r in results.items()
-        if categorize_stage_result(r["status"], r["reason"]) == DisplayCategory.FAILED
+        if categorize_stage_result(r["status"]) == DisplayCategory.FAILED
     )
 
     cli_helpers.emit_jsonl(
@@ -287,14 +285,14 @@ def _run_plain_mode(
     results = anyio.run(plain_main)
 
     if console and results:
-        ran, cached, blocked, failed = executor_core.count_results(results)
+        ran, cached, blocked, cancelled, failed = executor_core.count_results(results)
         total_duration = time.perf_counter() - start_time
-        console.summary(ran, cached, blocked, failed, total_duration)
+        console.summary(ran, cached, blocked, cancelled, failed, total_duration)
         # Print failed stage names after summary
         failed_stage_names = sorted(
             name
             for name, r in results.items()
-            if categorize_stage_result(r["status"], r["reason"]) == DisplayCategory.FAILED
+            if categorize_stage_result(r["status"]) == DisplayCategory.FAILED
         )
         console.failed_stages(failed_stage_names)
 

--- a/packages/pivot/src/pivot/engine/engine.py
+++ b/packages/pivot/src/pivot/engine/engine.py
@@ -50,6 +50,7 @@ from pivot.executor import core as executor_core
 from pivot.executor import worker
 from pivot.storage import state as state_mod
 from pivot.types import (
+    CompletionType,
     DepEntry,
     HashInfo,
     LockData,
@@ -59,6 +60,7 @@ from pivot.types import (
     StageExplanation,
     StageResult,
     StageStatus,
+    ensure_completion_type,
 )
 
 if TYPE_CHECKING:
@@ -968,9 +970,9 @@ class Engine:
                                     )
                                     stage_durations[stage_name] = duration_ms
 
-                                    # Apply deferred writes for RAN and SKIPPED stages
+                                    # Apply deferred writes for RAN and CACHED stages
                                     if (
-                                        result["status"] in (StageStatus.RAN, StageStatus.SKIPPED)
+                                        result["status"] in (StageStatus.RAN, StageStatus.CACHED)
                                         and not no_commit
                                     ):
                                         stage_info = self._get_stage(stage_name)
@@ -1038,14 +1040,15 @@ class Engine:
                                                 previous_state=old_state,
                                             )
                                         )
-                                    # Emit skipped for all blocked stages not yet in results
+                                    # Emit terminal events for blocked stages not yet in results
                                     for name, state in self._scheduler.stage_states.items():
                                         if (
                                             state == StageExecutionState.BLOCKED
                                             and name not in results
                                         ):
-                                            await self._emit_skipped_stage(
+                                            await self._emit_terminal_stage(
                                                 name,
+                                                StageStatus.BLOCKED,
                                                 f"upstream '{first_failed}' failed",
                                                 results,
                                                 run_id=run_id,
@@ -1063,8 +1066,12 @@ class Engine:
                                             previous_state=old_state,
                                         )
                                     )
-                                    await self._emit_skipped_stage(
-                                        name, "cancelled", results, run_id=run_id
+                                    await self._emit_terminal_stage(
+                                        name,
+                                        StageStatus.CANCELLED,
+                                        "cancelled",
+                                        results,
+                                        run_id=run_id,
                                     )
 
                             # Start more stages if slots available
@@ -1106,8 +1113,9 @@ class Engine:
                                     ),
                                     "unknown",
                                 )
-                                await self._emit_skipped_stage(
+                                await self._emit_terminal_stage(
                                     name,
+                                    StageStatus.BLOCKED,
                                     f"upstream '{failed_upstream}' failed",
                                     results,
                                     run_id=run_id,
@@ -1581,7 +1589,7 @@ class Engine:
 
         skipped, generation_input_hash = await anyio.to_thread.run_sync(_try_generation_skip)
         if skipped:
-            await self._record_skipped_stage(
+            await self._record_cached_stage(
                 stage_name,
                 "unchanged (generation)",
                 generation_input_hash,
@@ -1646,7 +1654,7 @@ class Engine:
         if not restored:
             return False
 
-        await self._record_skipped_stage(
+        await self._record_cached_stage(
             stage_name,
             "unchanged",
             input_hash,
@@ -1656,7 +1664,7 @@ class Engine:
         )
         return True
 
-    async def _record_skipped_stage(
+    async def _record_cached_stage(
         self,
         stage_name: str,
         reason: str,
@@ -1667,7 +1675,7 @@ class Engine:
         run_id: str,
     ) -> None:
         result = StageResult(
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason=reason,
             input_hash=input_hash,
             output_lines=[],
@@ -1854,16 +1862,17 @@ class Engine:
 
         return duration_ms
 
-    async def _emit_skipped_stage(
+    async def _emit_terminal_stage(
         self,
         stage_name: str,
+        status: CompletionType,
         reason: str,
         results: dict[str, executor_core.ExecutionSummary],
         run_id: str = "",
     ) -> None:
-        """Record and emit a skipped/blocked stage completion."""
+        """Record and emit a non-executed stage completion (cached/blocked/cancelled)."""
         results[stage_name] = executor_core.ExecutionSummary(
-            status=StageStatus.SKIPPED,
+            status=status,
             reason=reason,
             input_hash=None,
         )
@@ -1872,7 +1881,7 @@ class Engine:
             StageCompleted(
                 type="stage_completed",
                 stage=stage_name,
-                status=StageStatus.SKIPPED,
+                status=status,
                 reason=reason,
                 duration_ms=0.0,
                 index=stage_index,
@@ -1904,7 +1913,7 @@ class Engine:
 
             stages_records[name] = run_history.StageRunRecord(
                 input_hash=input_hash,
-                status=summary["status"],
+                status=ensure_completion_type(summary["status"]),
                 reason=summary["reason"],
                 duration_ms=duration_ms,
             )

--- a/packages/pivot/src/pivot/engine/sinks.py
+++ b/packages/pivot/src/pivot/engine/sinks.py
@@ -10,7 +10,7 @@ import rich.markup
 import rich.text
 
 from pivot.engine.types import StageCompleted
-from pivot.types import DisplayCategory, StageStatus, categorize_stage_result
+from pivot.types import DisplayCategory, categorize_stage_result
 
 if TYPE_CHECKING:
     from pivot.engine.types import OutputEvent
@@ -51,8 +51,7 @@ def _format_stage_line(
     name_width: int,
 ) -> str:
     total_digits = len(str(total))
-    current = index + 1
-    counter = f"[{current:>{total_digits}}/{total}]"
+    counter = f"[{index:>{total_digits}}/{total}]"
     display_width = max(1, min(name_width, _MAX_NAME_WIDTH))
     stage_name = f"{stage[: display_width - 1]}…" if len(stage) > display_width else stage
     padded_name = stage_name.ljust(display_width)
@@ -66,10 +65,8 @@ def _format_stage_line(
 
 def _format_skip_group_line(*, start_index: int, end_index: int, total: int, count: int) -> str:
     total_digits = len(str(total))
-    start = start_index + 1
-    end = end_index + 1
-    range_text = f"{start:>{total_digits}}–{end:>{total_digits}}/{total}"
-    return f"[dim]  [{range_text}] ○ {count} stages skipped[/dim]"
+    range_text = f"{start_index:>{total_digits}}–{end_index:>{total_digits}}/{total}"
+    return f"[dim]  [{range_text}] ○ {count} stages not run[/dim]"
 
 
 def _format_error_detail(reason: str, *, total: int) -> list[str]:
@@ -80,7 +77,7 @@ def _format_error_detail(reason: str, *, total: int) -> list[str]:
 
 
 def _categorize(event: StageCompleted) -> DisplayCategory:
-    return categorize_stage_result(event["status"], event["reason"])
+    return categorize_stage_result(event["status"])
 
 
 def _print_completions(
@@ -244,7 +241,7 @@ class LiveConsoleSink:
     _total: int
     _live: rich.live.Live | None
 
-    _RECENT_COMPLETIONS_LIMIT = 5
+    _RECENT_COMPLETIONS_LIMIT: int = 5
 
     def __init__(self, *, console: rich.console.Console, show_output: bool = False) -> None:
         self._console = console
@@ -300,6 +297,7 @@ class LiveConsoleSink:
         ran = counts.get(DisplayCategory.SUCCESS, 0)
         cached = counts.get(DisplayCategory.CACHED, 0)
         blocked = counts.get(DisplayCategory.BLOCKED, 0)
+        cancelled = counts.get(DisplayCategory.CANCELLED, 0)
         failed = counts.get(DisplayCategory.FAILED, 0)
         parts: list[tuple[str, str]] = []
         if ran:
@@ -308,6 +306,8 @@ class LiveConsoleSink:
             parts.append((f"{cached} cached", "yellow"))
         if blocked:
             parts.append((f"{blocked} blocked", "red"))
+        if cancelled:
+            parts.append((f"{cancelled} cancelled", "yellow"))
         if failed:
             parts.append((f"{failed} failed", "bold red"))
         for i, (text, style) in enumerate(parts):
@@ -346,13 +346,8 @@ class LiveConsoleSink:
                 self._total = event["total"]
                 self._max_name_width = max(self._max_name_width, len(event["stage"]))
                 self._completed_count += 1
-                match event["status"]:
-                    case StageStatus.SKIPPED:
-                        self._skipped_count += 1
-                    case StageStatus.RAN:
-                        self._ran_count += 1
-                    case StageStatus.FAILED:
-                        self._failed_count += 1
+                category = _categorize(event)
+                self._category_counts[category] = self._category_counts.get(category, 0) + 1
                 self._completion_buffer.append(event)
                 self._update_live()
             case "log_line":

--- a/packages/pivot/src/pivot/engine/sinks.py
+++ b/packages/pivot/src/pivot/engine/sinks.py
@@ -1,63 +1,201 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import anyio
 import rich.console
+import rich.live
 import rich.markup
+import rich.text
 
-from pivot.engine.types import StageCompleted, StageExecutionState
-from pivot.types import StageStatus
+from pivot.engine.types import StageCompleted
+from pivot.types import DisplayCategory, StageStatus, categorize_stage_result
 
 if TYPE_CHECKING:
     from pivot.engine.types import OutputEvent
 
 __all__ = [
-    "ConsoleSink",
+    "StaticConsoleSink",
+    "LiveConsoleSink",
     "ResultCollectorSink",
 ]
 
 
-class ConsoleSink:
-    """Async sink that prints stage events to console."""
+_CATEGORY_SYMBOL: dict[DisplayCategory, str] = {
+    DisplayCategory.SUCCESS: "[green]✓[/green]",
+    DisplayCategory.CACHED: "[yellow]○[/yellow]",
+    DisplayCategory.BLOCKED: "[red]○[/red]",
+    DisplayCategory.CANCELLED: "[dim yellow]○[/dim yellow]",
+    DisplayCategory.FAILED: "[bold red]✗[/bold red]",
+}
+_CATEGORY_WORD: dict[DisplayCategory, str] = {
+    DisplayCategory.SUCCESS: "[green]done[/green]",
+    DisplayCategory.CACHED: "[yellow]cached[/yellow]",
+    DisplayCategory.BLOCKED: "[red]blocked[/red]",
+    DisplayCategory.CANCELLED: "[dim yellow]cancelled[/dim yellow]",
+    DisplayCategory.FAILED: "[bold red]FAILED[/bold red]",
+}
+_SKIP_CATEGORIES = {DisplayCategory.CACHED, DisplayCategory.BLOCKED, DisplayCategory.CANCELLED}
+_MAX_NAME_WIDTH = 50
+_SKIP_COLLAPSE_THRESHOLD = 20
+
+
+def _format_stage_line(
+    *,
+    index: int,
+    total: int,
+    stage: str,
+    category: DisplayCategory,
+    duration_ms: float,
+    name_width: int,
+) -> str:
+    total_digits = len(str(total))
+    current = index + 1
+    counter = f"[{current:>{total_digits}}/{total}]"
+    display_width = max(1, min(name_width, _MAX_NAME_WIDTH))
+    stage_name = f"{stage[: display_width - 1]}…" if len(stage) > display_width else stage
+    padded_name = stage_name.ljust(display_width)
+    symbol = _CATEGORY_SYMBOL.get(category, "[dim]?[/dim]")
+    word = _CATEGORY_WORD.get(category, f"[dim]{category.value}[/dim]")
+    if category == DisplayCategory.SUCCESS:
+        duration_s = duration_ms / 1000
+        return f"  {counter} {symbol} [bold]{padded_name}[/bold] {word} {duration_s:.1f}s"
+    return f"  {counter} {symbol} [bold]{padded_name}[/bold] {word}"
+
+
+def _format_skip_group_line(*, start_index: int, end_index: int, total: int, count: int) -> str:
+    total_digits = len(str(total))
+    start = start_index + 1
+    end = end_index + 1
+    range_text = f"{start:>{total_digits}}–{end:>{total_digits}}/{total}"
+    return f"[dim]  [{range_text}] ○ {count} stages skipped[/dim]"
+
+
+def _format_error_detail(reason: str, *, total: int) -> list[str]:
+    total_digits = len(str(total))
+    counter_sample = f"[{1:>{total_digits}}/{total}]"
+    indent = " " * (2 + len(counter_sample) + 3)
+    return [f"{indent}[dim red]{rich.markup.escape(line)}[/dim red]" for line in reason.split("\n")]
+
+
+def _categorize(event: StageCompleted) -> DisplayCategory:
+    return categorize_stage_result(event["status"], event["reason"])
+
+
+def _print_completions(
+    console: rich.console.Console,
+    events: list[StageCompleted],
+    *,
+    total: int,
+    max_name_width: int,
+    stage_logs: dict[str, list[str]] | None = None,
+) -> None:
+    """Print buffered completions sorted by index with skip collapsing."""
+    if not events:
+        return
+
+    sorted_events = sorted(events, key=lambda e: e["index"])
+    logs = stage_logs or {}
+
+    i = 0
+    while i < len(sorted_events):
+        event = sorted_events[i]
+        category = _categorize(event)
+        if category in _SKIP_CATEGORIES:
+            # Collect consecutive skips (cached/blocked/cancelled)
+            skip_group = [event]
+            j = i + 1
+            while j < len(sorted_events) and _categorize(sorted_events[j]) in _SKIP_CATEGORIES:
+                skip_group.append(sorted_events[j])
+                j += 1
+
+            if len(skip_group) > _SKIP_COLLAPSE_THRESHOLD:
+                line = _format_skip_group_line(
+                    start_index=skip_group[0]["index"],
+                    end_index=skip_group[-1]["index"],
+                    total=total,
+                    count=len(skip_group),
+                )
+                console.print(line)
+            else:
+                for ev in skip_group:
+                    line = _format_stage_line(
+                        index=ev["index"],
+                        total=total,
+                        stage=ev["stage"],
+                        category=_categorize(ev),
+                        duration_ms=ev["duration_ms"],
+                        name_width=max_name_width,
+                    )
+                    console.print(line)
+            i = j
+        else:
+            line = _format_stage_line(
+                index=event["index"],
+                total=total,
+                stage=event["stage"],
+                category=category,
+                duration_ms=event["duration_ms"],
+                name_width=max_name_width,
+            )
+            console.print(line)
+            if category == DisplayCategory.FAILED:
+                # Show captured stage output for failed stages
+                stage_log = logs.get(event["stage"], [])
+                if stage_log:
+                    for log_line in stage_log:
+                        escaped = rich.markup.escape(log_line)
+                        console.print(f"          [dim]{escaped}[/dim]")
+                if event["reason"]:
+                    for detail in _format_error_detail(event["reason"], total=total):
+                        console.print(detail)
+            i += 1
+
+
+_MAX_LOG_LINES_PER_STAGE = 50
+
+
+class StaticConsoleSink:
+    """Pipe/CI sink: buffers completions, prints sorted report on close."""
 
     _console: rich.console.Console
     _show_output: bool
+    _max_name_width: int
+    _completion_buffer: list[StageCompleted]
+    _stage_logs: dict[str, list[str]]
+    _total: int
 
     def __init__(self, *, console: rich.console.Console, show_output: bool = False) -> None:
         self._console = console
         self._show_output = show_output
+        self._max_name_width = 0
+        self._completion_buffer = list[StageCompleted]()
+        self._stage_logs = dict[str, list[str]]()
+        self._total = 0
 
     async def handle(self, event: OutputEvent) -> None:
-        """Handle output event by printing to console."""
+        """Handle output event."""
         match event["type"]:
             case "stage_started":
-                self._console.print(f"Running {event['stage']}...")
+                self._total = event["total"]
+                self._max_name_width = max(self._max_name_width, len(event["stage"]))
             case "stage_completed":
+                self._total = event["total"]
+                self._max_name_width = max(self._max_name_width, len(event["stage"]))
+                self._completion_buffer.append(event)
+            case "log_line":
+                # Always buffer for failed-stage output; stream if --show-output
                 stage = event["stage"]
-                duration = event["duration_ms"] / 1000
-                match event["status"]:
-                    case StageStatus.SKIPPED:
-                        self._console.print(f"  {stage}: skipped")
-                    case StageStatus.RAN:
-                        self._console.print(f"  {stage}: done ({duration:.1f}s)")
-                    case StageStatus.FAILED:
-                        self._console.print(f"  {stage}: [red]FAILED[/red]")
-                        if event["reason"]:
-                            # Indent each line of the error for readability
-                            # Escape to prevent Rich markup injection from error messages
-                            for line in event["reason"].rstrip().split("\n"):
-                                self._console.print(f"    [dim]{rich.markup.escape(line)}[/dim]")
-            case "stage_state_changed" if event["state"] == StageExecutionState.WAITING_ON_LOCK:
-                self._console.print(f"  ⏳ {event['stage']}: waiting for artifact lock...")
-            case "log_line" if self._show_output:
-                stage = event["stage"]
-                # Escape line content to prevent Rich markup injection from stage output
-                line = rich.markup.escape(event["line"])
-                if event["is_stderr"]:
-                    self._console.print(f"[red]\\[{stage}][/red] [red]{line}[/red]")
-                else:
-                    self._console.print(f"\\[{stage}] {line}")
+                buf = self._stage_logs.setdefault(stage, [])
+                if len(buf) < _MAX_LOG_LINES_PER_STAGE:
+                    buf.append(event["line"])
+                if self._show_output:
+                    line = rich.markup.escape(event["line"])
+                    if event["is_stderr"]:
+                        self._console.print(f"[dim red]\\[{stage}] {line}[/dim red]")
+                    else:
+                        self._console.print(f"[dim]\\[{stage}] {line}[/dim]")
             case "engine_diagnostic":
                 msg = rich.markup.escape(event["message"])
                 detail = rich.markup.escape(event["detail"]) if event["detail"] else ""
@@ -65,10 +203,189 @@ class ConsoleSink:
                 if detail:
                     self._console.print(f"  [dim]{detail}[/dim]")
             case _:
-                pass  # Ignore other events
+                pass
 
     async def close(self) -> None:
-        """No cleanup needed."""
+        """Print sorted completion report."""
+        _print_completions(
+            self._console,
+            self._completion_buffer,
+            total=self._total,
+            max_name_width=self._max_name_width,
+            stage_logs=self._stage_logs,
+        )
+
+
+class _LiveRenderable:
+    _sink: LiveConsoleSink
+
+    def __init__(self, sink: LiveConsoleSink) -> None:
+        self._sink = sink
+
+    def __rich_console__(
+        self,
+        console: rich.console.Console,
+        options: rich.console.ConsoleOptions,
+    ) -> rich.console.RenderResult:
+        yield self._sink._build_live_group()  # pyright: ignore[reportPrivateUsage] - internal helper class
+
+
+class LiveConsoleSink:
+    """TTY sink with live pinned status area. Completions print on close."""
+
+    _console: rich.console.Console
+    _show_output: bool
+    _running: dict[str, float]
+    _completed_count: int
+    _category_counts: dict[DisplayCategory, int]
+    _max_name_width: int
+    _completion_buffer: list[StageCompleted]
+    _stage_logs: dict[str, list[str]]
+    _total: int
+    _live: rich.live.Live | None
+
+    _RECENT_COMPLETIONS_LIMIT = 5
+
+    def __init__(self, *, console: rich.console.Console, show_output: bool = False) -> None:
+        self._console = console
+        self._show_output = show_output
+        self._running = dict[str, float]()
+        self._completed_count = 0
+        self._category_counts = dict[DisplayCategory, int]()
+        self._max_name_width = 0
+        self._completion_buffer = list[StageCompleted]()
+        self._stage_logs = dict[str, list[str]]()
+        self._total = 0
+        self._live = None
+
+    def _build_live_renderable(self) -> rich.console.RenderableType:
+        return _LiveRenderable(self)
+
+    def _build_live_group(self) -> rich.console.Group:
+        renderables: list[rich.console.RenderableType] = []
+        display_width = max(1, min(self._max_name_width, _MAX_NAME_WIDTH))
+
+        # Recent completions (last N)
+        recent = self._completion_buffer[-self._RECENT_COMPLETIONS_LIMIT :]
+        for event in recent:
+            category = _categorize(event)
+            symbol = _CATEGORY_SYMBOL.get(category, "[dim]?[/dim]")
+            word = _CATEGORY_WORD.get(category, f"[dim]{category.value}[/dim]")
+            stage_name = event["stage"]
+            if len(stage_name) > display_width:
+                stage_name = stage_name[: display_width - 1] + "…"
+            padded = stage_name.ljust(display_width)
+            renderables.append(f"  {symbol} {padded}  {word}")
+
+        # Currently running stages
+        running_sorted = sorted(self._running.items(), key=lambda item: item[1])
+        for stage, started_at in running_sorted:
+            stage_name = f"{stage[: display_width - 1]}…" if len(stage) > display_width else stage
+            padded_name = stage_name.ljust(display_width)
+            elapsed_s = time.monotonic() - started_at
+            renderables.append(f"  [green]▶[/green] {padded_name}  running…  {elapsed_s:.0f}s")
+
+        # Progress bar
+        total = self._total
+        completed = self._completed_count
+        fraction = min(1.0, completed / total) if total > 0 else 0.0
+        bar_width = 40
+        filled = int(bar_width * fraction)
+        bar = "━" * filled + "─" * (bar_width - filled)
+        renderables.append(f"  {bar} {completed}/{total} ({fraction * 100:.0f}%)")
+
+        # Summary counts using display categories
+        counts = self._category_counts
+        summary = rich.text.Text("  ")
+        ran = counts.get(DisplayCategory.SUCCESS, 0)
+        cached = counts.get(DisplayCategory.CACHED, 0)
+        blocked = counts.get(DisplayCategory.BLOCKED, 0)
+        failed = counts.get(DisplayCategory.FAILED, 0)
+        parts: list[tuple[str, str]] = []
+        if ran:
+            parts.append((f"{ran} ran", "green"))
+        if cached:
+            parts.append((f"{cached} cached", "yellow"))
+        if blocked:
+            parts.append((f"{blocked} blocked", "red"))
+        if failed:
+            parts.append((f"{failed} failed", "bold red"))
+        for i, (text, style) in enumerate(parts):
+            if i > 0:
+                summary.append(" · ")
+            summary.append(text, style=style)
+        if parts:
+            renderables.append(summary)
+        return rich.console.Group(*renderables)
+
+    def _ensure_live(self) -> None:
+        if self._live is not None:
+            return
+        self._live = rich.live.Live(
+            self._build_live_renderable(),
+            console=self._console,
+            refresh_per_second=1,
+        )
+        self._live.start()
+
+    def _update_live(self) -> None:
+        if self._live is None:
+            return
+        self._live.update(self._build_live_renderable())
+
+    async def handle(self, event: OutputEvent) -> None:
+        match event["type"]:
+            case "stage_started":
+                self._running[event["stage"]] = time.monotonic()
+                self._total = event["total"]
+                self._max_name_width = max(self._max_name_width, len(event["stage"]))
+                self._ensure_live()
+                self._update_live()
+            case "stage_completed":
+                _ = self._running.pop(event["stage"], None)
+                self._total = event["total"]
+                self._max_name_width = max(self._max_name_width, len(event["stage"]))
+                self._completed_count += 1
+                match event["status"]:
+                    case StageStatus.SKIPPED:
+                        self._skipped_count += 1
+                    case StageStatus.RAN:
+                        self._ran_count += 1
+                    case StageStatus.FAILED:
+                        self._failed_count += 1
+                self._completion_buffer.append(event)
+                self._update_live()
+            case "log_line":
+                stage = event["stage"]
+                buf = self._stage_logs.setdefault(stage, [])
+                if len(buf) < _MAX_LOG_LINES_PER_STAGE:
+                    buf.append(event["line"])
+                if self._show_output:
+                    line = rich.markup.escape(event["line"])
+                    if event["is_stderr"]:
+                        self._console.print(f"[dim red]\\[{stage}] {line}[/dim red]")
+                    else:
+                        self._console.print(f"[dim]\\[{stage}] {line}[/dim]")
+            case "engine_diagnostic":
+                msg = rich.markup.escape(event["message"])
+                detail = rich.markup.escape(event["detail"]) if event["detail"] else ""
+                self._console.print(f"[yellow bold]⚠ Engine diagnostic:[/yellow bold] {msg}")
+                if detail:
+                    self._console.print(f"  [dim]{detail}[/dim]")
+            case _:
+                pass
+
+    async def close(self) -> None:
+        if self._live is not None:
+            self._live.update(rich.text.Text(""))
+            self._live.stop()
+        _print_completions(
+            self._console,
+            self._completion_buffer,
+            total=self._total,
+            max_name_width=self._max_name_width,
+            stage_logs=self._stage_logs,
+        )
 
 
 class ResultCollectorSink:

--- a/packages/pivot/src/pivot/engine/types.py
+++ b/packages/pivot/src/pivot/engine/types.py
@@ -51,7 +51,7 @@ class StageExecutionState(IntEnum):
     PREPARING = 3  # Pivot clearing outputs
     WAITING_ON_LOCK = 4  # Waiting for artifact lock
     RUNNING = 5  # Stage function executing
-    COMPLETED = 6  # Terminal (ran/skipped/failed)
+    COMPLETED = 6  # Terminal (ran/cached/blocked/cancelled/failed)
 
 
 class NodeType(Enum):
@@ -171,7 +171,7 @@ class OutputChangeSummary(TypedDict):
 
 
 class StageCompleted(TypedDict):
-    """A stage finished (ran, skipped, or failed)."""
+    """A stage finished (ran, cached, blocked, cancelled, or failed)."""
 
     type: Literal["stage_completed"]
     seq: NotRequired[int]

--- a/packages/pivot/src/pivot/executor/core.py
+++ b/packages/pivot/src/pivot/executor/core.py
@@ -14,13 +14,7 @@ from pivot import config, discovery, exceptions, outputs, parameters, registry
 from pivot.executor import worker
 from pivot.storage import cache, lock, track
 from pivot.storage import state as state_mod
-from pivot.types import (
-    DisplayCategory,
-    OnError,
-    StageResult,
-    StageStatus,
-    categorize_stage_result,
-)
+from pivot.types import OnError, StageResult, StageStatus
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -117,41 +111,40 @@ def _ensure_cleanup_registered() -> None:
 class ExecutionSummary(TypedDict):
     """Summary result for a single stage after execution (returned by executor.run)."""
 
-    status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED, StageStatus.UNKNOWN]
+    status: Literal[
+        StageStatus.RAN,
+        StageStatus.CACHED,
+        StageStatus.BLOCKED,
+        StageStatus.CANCELLED,
+        StageStatus.FAILED,
+        StageStatus.UNKNOWN,
+    ]
     reason: str
     input_hash: str | None
 
 
-def count_results(results: dict[str, ExecutionSummary]) -> tuple[int, int, int, int]:
-    """Count results by category: ran, cached, blocked, failed.
-
-    Uses shared categorization for consistent treatment across TUI and plain mode.
+def count_results(results: dict[str, ExecutionSummary]) -> tuple[int, int, int, int, int]:
+    """Count results by category.
 
     Returns:
-        Tuple of (ran, cached, blocked, failed) counts
+        Tuple of (ran, cached, blocked, cancelled, failed) counts.
     """
-    ran = cached = blocked = failed = 0
+    ran = cached = blocked = cancelled = failed = 0
     for result in results.values():
-        category = categorize_stage_result(result["status"], result["reason"])
-        match category:
-            case DisplayCategory.SUCCESS:
+        match result["status"]:
+            case StageStatus.RAN:
                 ran += 1
-            case DisplayCategory.FAILED:
+            case StageStatus.FAILED:
                 failed += 1
-            case DisplayCategory.BLOCKED:
+            case StageStatus.BLOCKED:
                 blocked += 1
-            case DisplayCategory.CACHED | DisplayCategory.CANCELLED:
-                # Cancelled stages are counted with cached (both are skipped, not failed)
+            case StageStatus.CACHED:
                 cached += 1
-            case (
-                DisplayCategory.UNKNOWN
-                | DisplayCategory.PENDING
-                | DisplayCategory.WAITING_ON_LOCK
-                | DisplayCategory.RUNNING
-            ):
-                # UNKNOWN/PENDING/WAITING_ON_LOCK/RUNNING shouldn't appear in final results
+            case StageStatus.CANCELLED:
+                cancelled += 1
+            case _:
                 pass
-    return ran, cached, blocked, failed
+    return ran, cached, blocked, cancelled, failed
 
 
 def run(
@@ -186,7 +179,7 @@ def run(
         checkout_missing: If True, restore missing tracked files from cache before running.
 
     Returns:
-        Dict of stage_name -> {status: "ran"|"skipped"|"failed", reason: str}
+        Dict of stage_name -> {status: "ran"|"cached"|"blocked"|"cancelled"|"failed", reason: str}
     """
     return _run_inner(
         stages=stages,

--- a/packages/pivot/src/pivot/executor/worker.py
+++ b/packages/pivot/src/pivot/executor/worker.py
@@ -154,7 +154,7 @@ class WorkerStageInfo(TypedDict):
 
 
 def _make_result(
-    status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED],
+    status: Literal[StageStatus.RAN, StageStatus.CACHED, StageStatus.FAILED],
     reason: str,
     ring_buffer: _OutputRingBuffer,
     input_hash: str | None = None,
@@ -273,7 +273,7 @@ def execute_stage(
                             )
                             if restored:
                                 return _make_result(
-                                    StageStatus.SKIPPED,
+                                    StageStatus.CACHED,
                                     "unchanged (generation)",
                                     ring_buffer,
                                     input_hash=input_hash,
@@ -326,7 +326,7 @@ def execute_stage(
                         )
                         if restored:
                             return _make_result(
-                                StageStatus.SKIPPED,
+                                StageStatus.CACHED,
                                 skip_reason,
                                 ring_buffer,
                                 input_hash=input_hash,
@@ -347,7 +347,7 @@ def execute_stage(
                         if run_cache_skip is not None:
                             if no_commit:
                                 return _make_result(
-                                    StageStatus.SKIPPED,
+                                    StageStatus.CACHED,
                                     "unchanged (run cache)",
                                     ring_buffer,
                                     input_hash=input_hash,
@@ -369,7 +369,7 @@ def execute_stage(
                                 increment_outputs=False,
                             )
                             return StageResult(
-                                status=StageStatus.SKIPPED,
+                                status=StageStatus.CACHED,
                                 reason="unchanged (run cache)",
                                 input_hash=input_hash,
                                 output_lines=ring_buffer.snapshot(),

--- a/packages/pivot/src/pivot/run_history.py
+++ b/packages/pivot/src/pivot/run_history.py
@@ -4,7 +4,7 @@ import datetime
 import hashlib
 import json
 import uuid
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from pivot.types import (
     DepEntry,
@@ -13,6 +13,7 @@ from pivot.types import (
     FileHash,
     HashInfo,
     StageStatus,
+    ensure_completion_type,
     is_dir_hash,
 )
 
@@ -21,7 +22,13 @@ class StageRunRecord(TypedDict):
     """Record of a stage execution within a run."""
 
     input_hash: str | None
-    status: StageStatus
+    status: Literal[
+        StageStatus.RAN,
+        StageStatus.CACHED,
+        StageStatus.BLOCKED,
+        StageStatus.CANCELLED,
+        StageStatus.FAILED,
+    ]
     reason: str
     duration_ms: int
 
@@ -113,14 +120,17 @@ def deserialize_run_manifest(data: bytes) -> RunManifest:
 
     stages: dict[str, StageRunRecord] = {}
     for stage_name, record in parsed["stages"].items():
+        raw_status = record["status"]
+        if raw_status == "skipped":
+            raw_status = "cached"
         try:
-            status = StageStatus(record["status"])
+            status = StageStatus(raw_status)
         except ValueError:
             msg = f"Invalid status '{record['status']}' for stage '{stage_name}'"
             raise ValueError(msg) from None
         stages[stage_name] = StageRunRecord(
             input_hash=record["input_hash"],
-            status=status,
+            status=ensure_completion_type(status),
             reason=record["reason"],
             duration_ms=record["duration_ms"],
         )

--- a/packages/pivot/src/pivot/types.py
+++ b/packages/pivot/src/pivot/types.py
@@ -2,15 +2,7 @@ from __future__ import annotations
 
 import enum
 from collections.abc import Callable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    NotRequired,
-    Required,
-    TypedDict,
-    TypeGuard,
-)
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Required, TypedDict, TypeGuard, cast
 
 if TYPE_CHECKING:
     from pivot.run_history import RunCacheEntry
@@ -46,14 +38,43 @@ class StageStatus(enum.StrEnum):
     READY = "ready"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
-    SKIPPED = "skipped"
+    CACHED = "cached"  # Was SKIPPED — stage up-to-date, outputs restored from cache
+    BLOCKED = "blocked"  # Was SKIPPED — upstream dependency failed
+    CANCELLED = "cancelled"  # Was SKIPPED — run cancelled by user
     FAILED = "failed"
     RAN = "ran"
     UNKNOWN = "unknown"
 
 
-CompletionType = Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED]
+CompletionType = Literal[
+    StageStatus.RAN,
+    StageStatus.CACHED,
+    StageStatus.BLOCKED,
+    StageStatus.CANCELLED,
+    StageStatus.FAILED,
+]
 """Status values for stages that have finished execution."""
+
+_COMPLETION_STATUSES: frozenset[StageStatus] = frozenset(
+    {
+        StageStatus.RAN,
+        StageStatus.CACHED,
+        StageStatus.BLOCKED,
+        StageStatus.CANCELLED,
+        StageStatus.FAILED,
+    }
+)
+
+
+def ensure_completion_type(status: StageStatus) -> CompletionType:
+    """Validate and narrow StageStatus to CompletionType.
+
+    Raises ValueError if status is not a terminal completion status.
+    """
+    if status not in _COMPLETION_STATUSES:
+        msg = f"Expected completion status, got '{status}'"
+        raise ValueError(msg)
+    return cast("CompletionType", status)
 
 
 class DisplayCategory(enum.StrEnum):
@@ -74,8 +95,8 @@ class DisplayCategory(enum.StrEnum):
     UNKNOWN = "unknown"
 
 
-def categorize_stage_result(status: StageStatus, reason: str) -> DisplayCategory:
-    """Map (status, reason) to display category for consistent UI."""
+def categorize_stage_result(status: StageStatus) -> DisplayCategory:
+    """Map status to display category for consistent UI."""
     match status:
         case StageStatus.READY:
             return DisplayCategory.PENDING
@@ -85,13 +106,12 @@ def categorize_stage_result(status: StageStatus, reason: str) -> DisplayCategory
             return DisplayCategory.SUCCESS
         case StageStatus.FAILED:
             return DisplayCategory.FAILED
-        case StageStatus.SKIPPED:
-            if reason.startswith("upstream"):
-                return DisplayCategory.BLOCKED
-            elif reason == "cancelled":
-                return DisplayCategory.CANCELLED
-            else:
-                return DisplayCategory.CACHED
+        case StageStatus.CACHED:
+            return DisplayCategory.CACHED
+        case StageStatus.BLOCKED:
+            return DisplayCategory.BLOCKED
+        case StageStatus.CANCELLED:
+            return DisplayCategory.CANCELLED
         case StageStatus.UNKNOWN:
             return DisplayCategory.UNKNOWN
 
@@ -733,7 +753,13 @@ class StageCompleteEvent(TypedDict):
 
     type: Literal[RunEventType.STAGE_COMPLETE]
     stage: str
-    status: Literal[StageStatus.RAN, StageStatus.SKIPPED, StageStatus.FAILED]
+    status: Literal[
+        StageStatus.RAN,
+        StageStatus.CACHED,
+        StageStatus.BLOCKED,
+        StageStatus.CANCELLED,
+        StageStatus.FAILED,
+    ]
     reason: str
     duration_ms: float
     timestamp: str  # ISO 8601 UTC

--- a/packages/pivot/tests/cli/test_cli.py
+++ b/packages/pivot/tests/cli/test_cli.py
@@ -713,7 +713,7 @@ pipeline.register(my_stage)
 
         first_event = json.loads(lines[0])
         assert first_event["type"] == "schema_version"
-        assert first_event["version"] == 1
+        assert first_event["version"] == 2
 
 
 def test_cli_run_json_emits_stage_events(runner: CliRunner, tmp_path: pathlib.Path) -> None:

--- a/packages/pivot/tests/cli/test_cli_commit.py
+++ b/packages/pivot/tests/cli/test_cli_commit.py
@@ -260,7 +260,7 @@ def test_commit_after_no_commit_makes_subsequent_run_skip(
 
     # Now run normally - should skip because commit recorded the state
     results = executor.run(pipeline=mock_discovery)
-    assert results["process"]["status"] == "skipped", (
+    assert results["process"]["status"] == "cached", (
         f"Stage should skip after commit, got: {results['process']}"
     )
 

--- a/packages/pivot/tests/cli/test_cli_history.py
+++ b/packages/pivot/tests/cli/test_cli_history.py
@@ -43,7 +43,7 @@ def project_with_runs(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -
                 stages={
                     "train": run_history.StageRunRecord(
                         input_hash="hash_train",
-                        status=StageStatus.RAN if i == 2 else StageStatus.SKIPPED,
+                        status=StageStatus.RAN if i == 2 else StageStatus.CACHED,
                         reason="Code changed" if i == 2 else "unchanged",
                         duration_ms=5000 if i == 2 else 100,
                     ),

--- a/packages/pivot/tests/cli/test_cli_run_common.py
+++ b/packages/pivot/tests/cli/test_cli_run_common.py
@@ -520,11 +520,16 @@ def test_configure_output_sink_quiet_mode(mocker: MockerFixture) -> None:
     mock_engine.add_sink.assert_not_called()
 
 
-def test_configure_output_sink_console_mode(mocker: MockerFixture) -> None:
-    """configure_output_sink adds ConsoleSink when use_console=True."""
+def test_configure_output_sink_picks_live_for_terminal(mocker: MockerFixture) -> None:
+    """configure_output_sink adds LiveConsoleSink for terminal consoles."""
     from pivot.engine import engine, sinks
 
     mock_engine = mocker.MagicMock(spec=engine.Engine)
+    mocker.patch(
+        "rich.console.Console.is_terminal",
+        new_callable=mocker.PropertyMock,
+        return_value=True,
+    )
 
     _run_common.configure_output_sink(
         mock_engine,
@@ -536,7 +541,31 @@ def test_configure_output_sink_console_mode(mocker: MockerFixture) -> None:
 
     mock_engine.add_sink.assert_called_once()
     added_sink = mock_engine.add_sink.call_args[0][0]
-    assert isinstance(added_sink, sinks.ConsoleSink)
+    assert isinstance(added_sink, sinks.LiveConsoleSink), "Should add LiveConsoleSink"
+
+
+def test_configure_output_sink_picks_static_for_non_terminal(mocker: MockerFixture) -> None:
+    """configure_output_sink adds StaticConsoleSink for non-terminal consoles."""
+    from pivot.engine import engine, sinks
+
+    mock_engine = mocker.MagicMock(spec=engine.Engine)
+    mocker.patch(
+        "rich.console.Console.is_terminal",
+        new_callable=mocker.PropertyMock,
+        return_value=False,
+    )
+
+    _run_common.configure_output_sink(
+        mock_engine,
+        quiet=False,
+        as_json=False,
+        use_console=True,
+        jsonl_callback=None,
+    )
+
+    mock_engine.add_sink.assert_called_once()
+    added_sink = mock_engine.add_sink.call_args[0][0]
+    assert isinstance(added_sink, sinks.StaticConsoleSink), "Should add StaticConsoleSink"
 
 
 def test_configure_output_sink_json_overrides_quiet(mocker: MockerFixture) -> None:

--- a/packages/pivot/tests/cli/test_cli_run_common.py
+++ b/packages/pivot/tests/cli/test_cli_run_common.py
@@ -641,7 +641,7 @@ def test_convert_results_handles_multiple_stages() -> None:
             type="stage_completed",
             seq=1,
             stage="evaluate",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="unchanged",
             duration_ms=0.0,
             index=1,
@@ -654,7 +654,7 @@ def test_convert_results_handles_multiple_stages() -> None:
 
     assert len(summaries) == 2
     assert summaries["train"]["status"] == StageStatus.RAN
-    assert summaries["evaluate"]["status"] == StageStatus.SKIPPED
+    assert summaries["evaluate"]["status"] == StageStatus.CACHED
 
 
 def test_convert_results_empty_dict() -> None:

--- a/packages/pivot/tests/cli/test_cli_run_keep_going.py
+++ b/packages/pivot/tests/cli/test_cli_run_keep_going.py
@@ -121,8 +121,8 @@ def test_repro_keep_going_flag_continues_after_failure(
     result = runner.invoke(cli.cli, ["repro", "--keep-going"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    assert "succeeding: done" in result.output  # Console sink outputs "done" for successful stages
+    assert "failing" in result.output and "FAILED" in result.output
+    assert "succeeding" in result.output and "done" in result.output
     assert (tmp_path / "succeeding.txt").read_text() == "success"
 
 
@@ -142,12 +142,12 @@ def test_repro_keep_going_flag_skips_downstream(
     result = runner.invoke(cli.cli, ["repro", "--keep-going"])
 
     assert result.exit_code == 0
-    assert "first: FAILED" in result.output
-    # Blocked stages show as "skipped" in console output (status is SKIPPED with reason)
-    assert "second: skipped" in result.output
+    assert "first" in result.output and "FAILED" in result.output
+    # Blocked stages now show as "blocked" in console output
+    assert "second" in result.output and "blocked" in result.output
     # Summary shows blocked count
     assert "blocked" in result.output
-    assert "independent: done" in result.output
+    assert "independent" in result.output and "done" in result.output
 
 
 def test_repro_keep_going_short_flag(
@@ -165,8 +165,8 @@ def test_repro_keep_going_short_flag(
     result = runner.invoke(cli.cli, ["repro", "-k"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    assert "succeeding: done" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
+    assert "succeeding" in result.output and "done" in result.output
 
 
 def test_repro_without_keep_going_stops_on_failure(
@@ -186,9 +186,9 @@ def test_repro_without_keep_going_stops_on_failure(
     result = runner.invoke(cli.cli, ["repro"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    # Without --keep-going, downstream stages show as skipped (blocked internally)
-    assert "downstream: skipped" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
+    # Without --keep-going, downstream stages show as blocked
+    assert "downstream" in result.output and "blocked" in result.output
     # Summary shows blocked count
     assert "blocked" in result.output
     assert not (tmp_path / "downstream.txt").exists()
@@ -301,7 +301,7 @@ def test_run_default_fails_fast(
     result = runner.invoke(cli.cli, ["run", "failing", "succeeding"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
 
 
 def test_run_fail_fast_stops_early(
@@ -319,7 +319,7 @@ def test_run_fail_fast_stops_early(
     result = runner.invoke(cli.cli, ["run", "--fail-fast", "failing", "succeeding"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
 
 
 def test_run_keep_going_continues_after_failure(
@@ -337,8 +337,8 @@ def test_run_keep_going_continues_after_failure(
     result = runner.invoke(cli.cli, ["run", "--keep-going", "failing", "succeeding"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    assert "succeeding: done" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
+    assert "succeeding" in result.output and "done" in result.output
     assert (tmp_path / "succeeding.txt").read_text() == "success"
 
 
@@ -357,8 +357,8 @@ def test_run_keep_going_short_flag(
     result = runner.invoke(cli.cli, ["run", "-k", "failing", "succeeding"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    assert "succeeding: done" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
+    assert "succeeding" in result.output and "done" in result.output
 
 
 def test_run_keep_going_flag_shown_in_help(runner: CliRunner) -> None:
@@ -394,8 +394,8 @@ def test_repro_fail_fast_stops_on_failure(
     result = runner.invoke(cli.cli, ["repro", "--fail-fast"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
-    assert "downstream: skipped" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
+    assert "downstream" in result.output and "blocked" in result.output
     assert not (tmp_path / "downstream.txt").exists()
 
 

--- a/packages/pivot/tests/cli/test_jsonl_sink.py
+++ b/packages/pivot/tests/cli/test_jsonl_sink.py
@@ -200,7 +200,7 @@ async def test_jsonl_sink_close_is_noop(
 @pytest.mark.parametrize(
     ("status", "reason", "duration"),
     [
-        pytest.param(StageStatus.SKIPPED, "unchanged", 0.0, id="skipped"),
+        pytest.param(StageStatus.CACHED, "unchanged", 0.0, id="cached"),
         pytest.param(StageStatus.FAILED, "execution error", 1234.5, id="failed"),
         pytest.param(StageStatus.RAN, "executed", 100.0, id="ran"),
         pytest.param(StageStatus.RAN, "executed", 0.0, id="instant_completion"),

--- a/packages/pivot/tests/cli/test_run.py
+++ b/packages/pivot/tests/cli/test_run.py
@@ -205,7 +205,7 @@ def test_run_default_fails_fast(
     result = runner.invoke(cli.cli, ["run", "failing", "stage_a"])
 
     assert result.exit_code == 0
-    assert "failing: FAILED" in result.output
+    assert "failing" in result.output and "FAILED" in result.output
 
 
 def test_run_fail_fast_option_accepted(

--- a/packages/pivot/tests/engine/test_engine.py
+++ b/packages/pivot/tests/engine/test_engine.py
@@ -1222,7 +1222,7 @@ async def test_coordinator_skip_avoids_worker_dispatch(
         )
 
         assert skipped is True, "Coordinator should skip inline when generations match"
-        assert results["skip_stage"]["status"] == "skipped"
+        assert results["skip_stage"]["status"] == "cached"
         engine._worker_pool.submit.assert_not_called()
 
 
@@ -1299,7 +1299,7 @@ async def test_all_cached_pipeline_skips_without_workers(
 
         assert engine._worker_pool is None, "Pool should not be created when all stages skip"
         assert "cached_stage" in results, "Skipped stage should be in results"
-        assert results["cached_stage"]["status"] == "skipped"
+        assert results["cached_stage"]["status"] == "cached"
 
 
 @pytest.mark.anyio
@@ -1437,7 +1437,7 @@ async def test_coordinator_tier2_skip_when_generation_unavailable(
         )
 
         assert skipped is True, "Coordinator should skip via Tier 2 when generations unavailable"
-        assert results["tier2_stage"]["status"] == "skipped"
+        assert results["tier2_stage"]["status"] == "cached"
         assert results["tier2_stage"]["reason"] == "unchanged", (
             "Tier 2 skip reason should be 'unchanged', not 'unchanged (generation)'"
         )

--- a/packages/pivot/tests/engine/test_engine_shutdown.py
+++ b/packages/pivot/tests/engine/test_engine_shutdown.py
@@ -84,7 +84,9 @@ async def test_engine_shutdown_completes_without_hanging(minimal_pipeline: Pipel
         assert "test_stage" in results
         assert results["test_stage"]["status"] in (
             StageStatus.RAN,
-            StageStatus.SKIPPED,
+            StageStatus.CACHED,
+            StageStatus.BLOCKED,
+            StageStatus.CANCELLED,
             StageStatus.FAILED,
         )
 

--- a/packages/pivot/tests/engine/test_lock_state.py
+++ b/packages/pivot/tests/engine/test_lock_state.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from io import StringIO
-
-import rich.console
-
-from pivot.engine.sinks import ConsoleSink
-from pivot.engine.types import StageExecutionState, StageStateChanged
+from pivot.engine.types import StageExecutionState
 from pivot.types import DisplayCategory, LogMessage, OutputMessage, OutputMessageKind, StateChange
 
 
@@ -49,44 +44,6 @@ def test_state_message_output_message_type() -> None:
 
     none_msg: OutputMessage = None
     assert none_msg is None
-
-
-async def test_console_sink_displays_waiting_on_lock() -> None:
-    """ConsoleSink prints waiting status for WAITING_ON_LOCK state change."""
-    output = StringIO()
-    console = rich.console.Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
-
-    event = StageStateChanged(
-        type="stage_state_changed",
-        seq=0,
-        stage="train",
-        state=StageExecutionState.WAITING_ON_LOCK,
-        previous_state=StageExecutionState.PREPARING,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    assert "train" in result, "Stage name should appear in output"
-    assert "waiting for artifact lock" in result, "Lock waiting message should appear"
-
-
-async def test_console_sink_ignores_other_state_changes() -> None:
-    """ConsoleSink does not print for non-WAITING_ON_LOCK state changes."""
-    output = StringIO()
-    console = rich.console.Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
-
-    event = StageStateChanged(
-        type="stage_state_changed",
-        seq=0,
-        stage="train",
-        state=StageExecutionState.RUNNING,
-        previous_state=StageExecutionState.PREPARING,
-    )
-    await sink.handle(event)
-
-    assert output.getvalue() == "", "Should not print for RUNNING state change"
 
 
 def test_display_category_has_waiting_on_lock() -> None:

--- a/packages/pivot/tests/engine/test_sinks.py
+++ b/packages/pivot/tests/engine/test_sinks.py
@@ -2,57 +2,137 @@
 
 from __future__ import annotations
 
+import time
+from io import StringIO
+
 import anyio
 import pytest
+import rich.live
+from rich.console import Console
 
 from pivot.engine import engine as engine_mod
-from pivot.engine import types
-from pivot.engine.types import OutputEvent, SinkState, StageCompleted, StageStarted
-from pivot.types import StageStatus
+from pivot.engine import sinks
+from pivot.engine.types import (
+    EngineDiagnostic,
+    LogLine,
+    OutputEvent,
+    SinkState,
+    StageCompleted,
+    StageExecutionState,
+    StageStarted,
+    StageStateChanged,
+)
+from pivot.types import DisplayCategory, StageStatus
 
-# =============================================================================
-# ConsoleSink Tests
-# =============================================================================
 
-
-async def test_console_sink_handles_stage_started() -> None:
-    """ConsoleSink prints stage_started events."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageStarted
-
+def _helper_render_markup(text: str) -> str:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    console.print(text)
+    return output.getvalue()
 
-    event = StageStarted(
-        type="stage_started",
-        seq=0,
-        stage="train",
+
+def _helper_render_renderable(renderable: object) -> str:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    console.print(renderable)
+    return output.getvalue()
+
+
+# =============================================================================
+# Formatting Helper Tests
+# =============================================================================
+
+
+def test_format_stage_line_ran_includes_duration() -> None:
+    line = sinks._format_stage_line(
         index=0,
-        total=2,
+        total=12,
+        stage="train",
+        category=DisplayCategory.SUCCESS,
+        duration_ms=3400.0,
+        name_width=10,
     )
-    await sink.handle(event)
-    await sink.close()
+    rendered = _helper_render_markup(line)
+    assert "[ 1/12]" in rendered, "Should include right-aligned progress counter"
+    assert "✓" in rendered, "Should include checkmark for RAN"
+    assert "train" in rendered, "Should include stage name"
+    assert "done" in rendered, "Should include done status word"
+    assert "3.4s" in rendered, "Should include formatted duration"
 
-    assert "train" in output.getvalue()
+
+def test_format_stage_line_skipped_omits_duration() -> None:
+    line = sinks._format_stage_line(
+        index=1,
+        total=12,
+        stage="skip_stage",
+        category=DisplayCategory.CACHED,
+        duration_ms=1200.0,
+        name_width=12,
+    )
+    rendered = _helper_render_markup(line)
+    assert "○" in rendered, "Should include skip symbol"
+    assert "cached" in rendered, "Should include cached status word"
+    assert "1.2s" not in rendered, "Cached stages should not include duration"
 
 
-async def test_console_sink_handles_stage_completed_ran() -> None:
-    """ConsoleSink prints done message for RAN status."""
-    from io import StringIO
+def test_format_stage_line_failed_uses_failed_status() -> None:
+    line = sinks._format_stage_line(
+        index=2,
+        total=12,
+        stage="fail_stage",
+        category=DisplayCategory.FAILED,
+        duration_ms=1000.0,
+        name_width=12,
+    )
+    rendered = _helper_render_markup(line)
+    assert "✗" in rendered, "Should include failure symbol"
+    assert "FAILED" in rendered, "Should include FAILED status word"
+    assert "1.0s" not in rendered, "Failed stages should not include duration"
 
-    from rich.console import Console
 
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageCompleted
+def test_format_stage_line_truncates_long_names() -> None:
+    line = sinks._format_stage_line(
+        index=0,
+        total=1,
+        stage="very_long_stage_name",
+        category=DisplayCategory.SUCCESS,
+        duration_ms=100.0,
+        name_width=8,
+    )
+    rendered = _helper_render_markup(line)
+    assert "very_lo…" in rendered, "Should truncate long names with ellipsis"
+    assert "very_long_stage_name" not in rendered, "Should not include full long name"
 
+
+def test_format_skip_group_line_includes_range_and_count() -> None:
+    line = sinks._format_skip_group_line(start_index=0, end_index=2, total=9, count=3)
+    rendered = _helper_render_markup(line)
+    assert "1–3/9" in rendered, "Should include collapsed range"
+    assert "3 stages skipped" in rendered, "Should include skipped count text"
+    assert "○" in rendered, "Should include skip symbol"
+
+
+def test_format_error_detail_indents_each_line() -> None:
+    details = sinks._format_error_detail("Line 1\nLine 2", total=12)
+    assert len(details) == 2, "Should return one line per input line"
+    rendered = [_helper_render_markup(line) for line in details]
+    leading_spaces = [len(line) - len(line.lstrip(" ")) for line in rendered]
+    assert leading_spaces[0] >= 2, "Error detail lines should be indented"
+    assert leading_spaces[0] == leading_spaces[1], "Indentation should be consistent"
+    assert "Line 1" in rendered[0], "First error line should be present"
+    assert "Line 2" in rendered[1], "Second error line should be present"
+
+
+# =============================================================================
+# StaticConsoleSink Tests
+# =============================================================================
+
+
+async def test_static_sink_prints_ran_stage_line() -> None:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
 
     event = StageCompleted(
         type="stage_completed",
@@ -60,136 +140,608 @@ async def test_console_sink_handles_stage_completed_ran() -> None:
         stage="train",
         status=StageStatus.RAN,
         reason="",
-        duration_ms=1500,
+        duration_ms=1200.0,
         index=0,
         total=1,
         run_id="test-run",
         input_hash=None,
     )
     await sink.handle(event)
+    await sink.close()
 
-    assert "train" in output.getvalue()
-    assert "done" in output.getvalue()
+    result = output.getvalue()
+    assert "1/1" in result, "Should include progress counter"
+    assert "train" in result, "Should include stage name"
+    assert "done" in result, "Should include done status"
+    assert "1.2s" in result, "Should include duration"
 
 
-async def test_console_sink_handles_stage_completed_skipped() -> None:
-    """ConsoleSink prints skipped message for SKIPPED status."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageCompleted
-
+async def test_static_sink_prints_skipped_stages_individually_when_low_count() -> None:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
 
-    event = StageCompleted(
-        type="stage_completed",
+    events = [
+        StageCompleted(
+            type="stage_completed",
+            seq=idx,
+            stage=f"skip_{idx}",
+            status=StageStatus.SKIPPED,
+            reason="up-to-date",
+            duration_ms=10.0,
+            index=idx,
+            total=3,
+            run_id="test-run",
+            input_hash=None,
+        )
+        for idx in range(2)
+    ]
+    for event in events:
+        await sink.handle(event)
+    await sink.close()
+
+    result = output.getvalue()
+    assert "skip_0" in result, "Should include first skipped stage"
+    assert "skip_1" in result, "Should include second skipped stage"
+    assert "cached" in result, "Should show cached status for up-to-date stages"
+    assert "stages skipped" not in result, "Should not collapse low skip counts"
+
+
+async def test_static_sink_collapses_skips_over_threshold() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
+
+    for idx in range(21):
+        event = StageCompleted(
+            type="stage_completed",
+            seq=idx,
+            stage=f"skip_{idx}",
+            status=StageStatus.SKIPPED,
+            reason="up-to-date",
+            duration_ms=10.0,
+            index=idx,
+            total=21,
+            run_id="test-run",
+            input_hash=None,
+        )
+        await sink.handle(event)
+    await sink.close()
+
+    result = output.getvalue()
+    assert "21 stages skipped" in result, "Should collapse skipped stages over threshold"
+
+
+async def test_static_sink_does_not_collapse_skips_at_threshold() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
+
+    for idx in range(20):
+        event = StageCompleted(
+            type="stage_completed",
+            seq=idx,
+            stage=f"skip_{idx}",
+            status=StageStatus.SKIPPED,
+            reason="up-to-date",
+            duration_ms=10.0,
+            index=idx,
+            total=20,
+            run_id="test-run",
+            input_hash=None,
+        )
+        await sink.handle(event)
+    await sink.close()
+
+    result = output.getvalue()
+    assert "stages skipped" not in result, "Should not collapse skips at threshold"
+
+
+async def test_static_sink_ignores_waiting_on_lock_state_changes() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
+
+    event = StageStateChanged(
+        type="stage_state_changed",
         seq=0,
         stage="train",
-        status=StageStatus.SKIPPED,
-        reason="up-to-date",
-        duration_ms=10,
-        index=0,
-        total=1,
+        state=StageExecutionState.WAITING_ON_LOCK,
+        previous_state=StageExecutionState.PREPARING,
         run_id="test-run",
-        input_hash=None,
     )
     await sink.handle(event)
+    await sink.close()
 
-    assert "train" in output.getvalue()
-    assert "skipped" in output.getvalue()
+    assert output.getvalue() == "", "Should not print state changes"
 
 
-async def test_console_sink_handles_stage_completed_failed() -> None:
-    """ConsoleSink prints FAILED message for FAILED status."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageCompleted
-
+async def test_static_sink_prints_failed_with_error_details() -> None:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
 
     event = StageCompleted(
         type="stage_completed",
         seq=0,
         stage="train",
         status=StageStatus.FAILED,
-        reason="exception",
-        duration_ms=100,
+        reason="first line\nsecond line",
+        duration_ms=100.0,
         index=0,
         total=1,
         run_id="test-run",
         input_hash=None,
     )
     await sink.handle(event)
+    await sink.close()
 
     result = output.getvalue()
-    assert "train" in result
-    assert "FAILED" in result
-    assert "exception" in result  # Reason should now be displayed
+    assert "FAILED" in result, "Should include FAILED status"
+    assert "first line" in result, "Should include first error detail"
+    assert "second line" in result, "Should include second error detail"
 
 
-async def test_console_sink_handles_multiline_reason() -> None:
-    """ConsoleSink indents multi-line error reasons."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageCompleted
-
+async def test_static_sink_ignores_stage_started() -> None:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
 
-    event = StageCompleted(
-        type="stage_completed",
+    event = StageStarted(
+        type="stage_started",
         seq=0,
         stage="train",
-        status=StageStatus.FAILED,
-        reason="Traceback (most recent call last):\n  File test.py\nValueError: bad",
-        duration_ms=100,
         index=0,
-        total=1,
+        total=2,
         run_id="test-run",
-        input_hash=None,
+    )
+    await sink.handle(event)
+    await sink.close()
+
+    assert output.getvalue() == "", "Should not print stage_started events"
+
+
+async def test_static_sink_sorts_completions_by_index() -> None:
+    """Completions are printed sorted by index on close(), not arrival order."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
+
+    # Send in reverse index order
+    for idx, name in [(2, "third"), (0, "first"), (1, "second")]:
+        await sink.handle(
+            StageCompleted(
+                type="stage_completed",
+                seq=idx,
+                stage=name,
+                status=StageStatus.RAN,
+                reason="",
+                duration_ms=100.0,
+                index=idx,
+                total=3,
+                run_id="test-run",
+                input_hash=None,
+            )
+        )
+    await sink.close()
+
+    result = output.getvalue()
+    assert result.index("first") < result.index("second") < result.index("third"), (
+        "Completions should be sorted by index"
+    )
+
+
+async def test_static_sink_prints_log_lines_when_show_output_enabled() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console, show_output=True)
+
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="Processing batch 1...",
+        is_stderr=False,
     )
     await sink.handle(event)
 
     result = output.getvalue()
-    assert "FAILED" in result
-    assert "Traceback" in result
-    assert "ValueError" in result
+    assert "train" in result, "Should include stage name"
+    assert "Processing batch" in result, "Should include log line text"
 
 
-async def test_console_sink_ignores_other_events() -> None:
-    """ConsoleSink ignores events it doesn't handle."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-
+async def test_static_sink_stderr_log_line() -> None:
     output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console, show_output=True)
 
-    event: types.EngineStateChanged = {
-        "type": "engine_state_changed",
-        "seq": 0,
-        "state": types.EngineState.ACTIVE,
-    }
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="Warning: GPU not available",
+        is_stderr=True,
+    )
     await sink.handle(event)
 
-    # Should not print anything for unhandled events
-    assert output.getvalue() == ""
+    result = output.getvalue()
+    assert "train" in result, "Should include stage name"
+    assert "Warning: GPU not available" in result, "Should include stderr text"
+
+
+async def test_static_sink_escapes_rich_markup_in_log_lines() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console, show_output=True)
+
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="[bold red]FAKE ERROR[/bold red] - this should display literally",
+        is_stderr=False,
+    )
+    await sink.handle(event)
+
+    result = output.getvalue()
+    assert "train" in result, "Should include stage name"
+    assert "FAKE ERROR" in result, "Should include escaped log content"
+    assert "this should display literally" in result, "Should include full log line"
+    assert "[bold red]" in result or "\\[bold red]" in result, (
+        "Should render markup tags as literal text"
+    )
+
+
+async def test_static_sink_ignores_log_lines_when_show_output_disabled() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console, show_output=False)
+
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="Processing batch 1...",
+        is_stderr=False,
+    )
+    await sink.handle(event)
+
+    assert output.getvalue() == "", "Should ignore log lines when show_output=False"
+
+
+async def test_static_sink_log_lines_stream_before_completions() -> None:
+    """Log lines print in real-time, completions print on close."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console, show_output=True)
+
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=0,
+            stage="skip_stage",
+            status=StageStatus.SKIPPED,
+            reason="cached",
+            duration_ms=10.0,
+            index=0,
+            total=2,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.handle(
+        LogLine(
+            type="log_line",
+            seq=1,
+            stage="log_stage",
+            line="hello",
+            is_stderr=False,
+        )
+    )
+
+    # Before close: only log lines should be printed (completions are buffered)
+    before_close = output.getvalue()
+    assert "log_stage" in before_close, "Log lines should stream immediately"
+    assert "skip_stage" not in before_close, "Completions should be buffered until close"
+
+    await sink.close()
+
+    # After close: completions appear
+    result = output.getvalue()
+    assert "skip_stage" in result, "Completions should appear after close"
+
+
+async def test_static_sink_prints_engine_diagnostics() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.StaticConsoleSink(console=console)
+
+    event = EngineDiagnostic(
+        type="engine_diagnostic",
+        seq=0,
+        message="Scheduler delay",
+        detail="Loop blocked",
+    )
+    await sink.handle(event)
+
+    result = output.getvalue()
+    assert "Engine diagnostic" in result, "Should include diagnostic prefix"
+    assert "Scheduler delay" in result, "Should include diagnostic message"
+    assert "Loop blocked" in result, "Should include diagnostic detail"
+
+
+# =============================================================================
+# LiveConsoleSink Tests
+# =============================================================================
+
+
+async def test_live_sink_prints_completion_to_scrollback() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    await sink.handle(
+        StageStarted(
+            type="stage_started",
+            seq=0,
+            stage="train",
+            index=0,
+            total=1,
+            run_id="test-run",
+        )
+    )
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=1,
+            stage="train",
+            status=StageStatus.RAN,
+            reason="",
+            duration_ms=1200.0,
+            index=0,
+            total=1,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.close()
+
+    result = output.getvalue()
+    assert "train" in result, "Should include stage name"
+    assert "done" in result, "Should include completion status"
+
+
+async def test_live_sink_tracks_running_stages() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    start = time.monotonic()
+    await sink.handle(
+        StageStarted(
+            type="stage_started",
+            seq=0,
+            stage="train",
+            index=0,
+            total=1,
+            run_id="test-run",
+        )
+    )
+
+    assert "train" in sink._running, "Should track running stage"  # type: ignore[reportPrivateUsage] - testing internal state
+    assert sink._running["train"] >= start, "Start time should be recorded"  # type: ignore[reportPrivateUsage] - testing internal state
+    assert isinstance(sink._live, rich.live.Live), "Should start Rich Live renderer"  # type: ignore[reportPrivateUsage] - testing internal state
+
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=1,
+            stage="train",
+            status=StageStatus.RAN,
+            reason="",
+            duration_ms=50.0,
+            index=0,
+            total=1,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.close()
+
+    assert "train" not in sink._running, "Should remove stage after completion"  # type: ignore[reportPrivateUsage] - testing internal state
+
+
+async def test_live_sink_ignores_waiting_on_lock() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    event = StageStateChanged(
+        type="stage_state_changed",
+        seq=0,
+        stage="train",
+        state=StageExecutionState.WAITING_ON_LOCK,
+        previous_state=StageExecutionState.PREPARING,
+        run_id="test-run",
+    )
+    await sink.handle(event)
+    await sink.close()
+
+    assert output.getvalue() == "", "Should ignore waiting-on-lock events"
+
+
+async def test_live_sink_collapses_many_skips_in_scrollback() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    for idx in range(21):
+        await sink.handle(
+            StageCompleted(
+                type="stage_completed",
+                seq=idx,
+                stage=f"skip_{idx}",
+                status=StageStatus.SKIPPED,
+                reason="cached",
+                duration_ms=10.0,
+                index=idx,
+                total=21,
+                run_id="test-run",
+                input_hash=None,
+            )
+        )
+    await sink.close()
+
+    result = output.getvalue()
+    assert "21 stages skipped" in result, "Should collapse skipped stages over threshold"
+
+
+async def test_live_sink_prints_all_statuses_on_close() -> None:
+    """LiveConsoleSink prints ran, skipped, failed completions on close."""
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=0,
+            stage="ran_stage",
+            status=StageStatus.RAN,
+            reason="",
+            duration_ms=1000.0,
+            index=0,
+            total=3,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=1,
+            stage="skipped_stage",
+            status=StageStatus.SKIPPED,
+            reason="cached",
+            duration_ms=2000.0,
+            index=1,
+            total=3,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=2,
+            stage="failed_stage",
+            status=StageStatus.FAILED,
+            reason="boom",
+            duration_ms=500.0,
+            index=2,
+            total=3,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+    await sink.close()
+
+    result = output.getvalue()
+    assert "ran_stage" in result and "done" in result, "Should include ran stage"
+    assert "skipped_stage" in result and "cached" in result, (
+        "Should include skipped stage with cached status"
+    )
+    assert "failed_stage" in result and "FAILED" in result, "Should include failed stage"
+
+
+async def test_live_sink_show_output_prints_log_lines() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console, show_output=True)
+
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="Processing batch 1...",
+        is_stderr=False,
+    )
+    await sink.handle(event)
+    await sink.close()
+
+    result = output.getvalue()
+    assert "train" in result, "Should include stage name"
+    assert "Processing batch" in result, "Should include log line text"
+
+
+async def test_live_sink_hides_log_lines_by_default() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console, show_output=False)
+
+    event = LogLine(
+        type="log_line",
+        seq=0,
+        stage="train",
+        line="Processing batch 1...",
+        is_stderr=False,
+    )
+    await sink.handle(event)
+    await sink.close()
+
+    assert output.getvalue() == "", "Should ignore log lines when show_output=False"
+
+
+async def test_live_sink_live_renderable_shows_running_stages() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    await sink.handle(
+        StageStarted(
+            type="stage_started",
+            seq=0,
+            stage="train",
+            index=0,
+            total=1,
+            run_id="test-run",
+        )
+    )
+
+    rendered = _helper_render_renderable(
+        sink._build_live_group()  # type: ignore[reportPrivateUsage] - testing live renderable
+    )
+    await sink.close()
+
+    assert "train" in rendered, "Live renderable should include running stage"
+
+
+async def test_live_sink_live_renderable_shows_progress() -> None:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True)
+    sink = sinks.LiveConsoleSink(console=console)
+
+    await sink.handle(
+        StageCompleted(
+            type="stage_completed",
+            seq=0,
+            stage="train",
+            status=StageStatus.RAN,
+            reason="",
+            duration_ms=1000.0,
+            index=0,
+            total=3,
+            run_id="test-run",
+            input_hash=None,
+        )
+    )
+
+    rendered = _helper_render_renderable(
+        sink._build_live_group()  # type: ignore[reportPrivateUsage] - testing live renderable
+    )
+    await sink.close()
+
+    assert "1/3" in rendered, "Live renderable should include progress counts"
 
 
 # =============================================================================
@@ -199,10 +751,7 @@ async def test_console_sink_ignores_other_events() -> None:
 
 async def test_result_collector_sink_collects_completed() -> None:
     """ResultCollectorSink collects stage_completed events."""
-    from pivot.engine.sinks import ResultCollectorSink
-    from pivot.engine.types import StageCompleted
-
-    sink = ResultCollectorSink()
+    sink = sinks.ResultCollectorSink()
 
     event = StageCompleted(
         type="stage_completed",
@@ -227,10 +776,7 @@ async def test_result_collector_sink_collects_completed() -> None:
 
 async def test_result_collector_sink_ignores_other_events() -> None:
     """ResultCollectorSink ignores non-completed events."""
-    from pivot.engine.sinks import ResultCollectorSink
-    from pivot.engine.types import StageStarted
-
-    sink = ResultCollectorSink()
+    sink = sinks.ResultCollectorSink()
 
     event = StageStarted(
         type="stage_started",
@@ -249,10 +795,7 @@ async def test_result_collector_sink_ignores_other_events() -> None:
 @pytest.mark.anyio
 async def test_result_collector_sink_concurrent_access() -> None:
     """ResultCollectorSink protects shared state with lock under concurrent access."""
-    from pivot.engine.sinks import ResultCollectorSink
-    from pivot.engine.types import StageCompleted
-
-    sink = ResultCollectorSink()
+    sink = sinks.ResultCollectorSink()
 
     async def worker(stage_name: str) -> None:
         event = StageCompleted(
@@ -287,10 +830,7 @@ async def test_result_collector_sink_prevents_lost_updates() -> None:
     This test verifies that the lock actually prevents race conditions by
     checking that the final result for each stage matches the last iteration.
     """
-    from pivot.engine.sinks import ResultCollectorSink
-    from pivot.engine.types import StageCompleted
-
-    sink = ResultCollectorSink()
+    sink = sinks.ResultCollectorSink()
 
     async def worker(stage_name: str) -> None:
         for i in range(100):
@@ -325,271 +865,6 @@ async def test_result_collector_sink_prevents_lost_updates() -> None:
         assert stage_result["duration_ms"] == 99.0, (
             f"stage_{i} should have final duration, verifying no corruption"
         )
-
-
-async def test_console_sink_formats_duration_correctly() -> None:
-    """ConsoleSink formats duration with correct precision in output."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageCompleted
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
-
-    event = StageCompleted(
-        type="stage_completed",
-        seq=0,
-        stage="train",
-        status=StageStatus.RAN,
-        reason="",
-        duration_ms=1500.0,
-        index=0,
-        total=1,
-        run_id="test-run",
-        input_hash=None,
-    )
-    await sink.handle(event)
-
-    text = output.getvalue()
-    assert "train" in text, "Stage name should appear"
-    assert "done" in text, "Status should appear"
-    # Rich adds ANSI escape codes that can split numbers, verify components
-    assert "1." in text and "5s" in text, "Duration components should appear"
-
-
-async def test_console_sink_running_message_format() -> None:
-    """ConsoleSink prints 'Running <stage>...' for stage_started events."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import StageStarted
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)
-
-    event = StageStarted(
-        type="stage_started",
-        seq=0,
-        stage="train",
-        index=0,
-        total=2,
-        run_id="test-run",
-    )
-    await sink.handle(event)
-
-    text = output.getvalue()
-    assert "Running train" in text, "Should include 'Running' prefix"
-    assert "..." in text, "Should include trailing ellipsis"
-
-
-async def test_console_sink_handles_log_line_when_show_output_enabled() -> None:
-    """ConsoleSink prints log lines when show_output=True."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="Processing batch 1...",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    # Rich adds ANSI codes that can split brackets, check components separately
-    assert "train" in result
-    assert "Processing batch" in result
-
-
-async def test_console_sink_stderr_line_contains_content() -> None:
-    """ConsoleSink prints stderr lines with stage prefix."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="Warning: GPU not available",
-        is_stderr=True,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    # Rich adds ANSI codes that can split brackets, check components separately
-    assert "train" in result
-    assert "Warning: GPU not available" in result
-
-
-async def test_console_sink_ignores_log_line_when_show_output_disabled() -> None:
-    """ConsoleSink ignores log lines when show_output=False (default)."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console)  # show_output defaults to False
-
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="Processing batch 1...",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    # Should not print anything when show_output is False
-    assert output.getvalue() == ""
-
-
-async def test_console_sink_handles_empty_log_line() -> None:
-    """ConsoleSink handles empty log lines without errors."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    # Should still print stage prefix even with empty line
-    assert "train" in result
-
-
-async def test_console_sink_handles_multiline_log_output() -> None:
-    """ConsoleSink prints each line from multiline output separately."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    # Simulate a stage that outputs multiline logs
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="Line 1\nLine 2\nLine 3",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    assert "train" in result
-    # Rich may tokenize numbers separately, check components
-    assert "Line" in result
-    assert "1" in result and "2" in result and "3" in result
-
-
-async def test_console_sink_handles_special_characters() -> None:
-    """ConsoleSink handles special characters without crashing."""
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    console = Console(file=output, force_terminal=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    # Test with brackets that could conflict with Rich markup
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="[INFO] Processing <data> with 'quotes' and \"double quotes\"",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    assert "train" in result
-    assert "INFO" in result
-    assert "Processing" in result
-
-
-async def test_console_sink_escapes_rich_markup_in_log_lines() -> None:
-    """ConsoleSink escapes Rich markup in log lines to prevent injection.
-
-    Stage output containing Rich markup syntax (e.g. [red]text[/red]) should
-    be displayed literally, not interpreted as formatting instructions.
-    """
-    from io import StringIO
-
-    from rich.console import Console
-
-    from pivot.engine.sinks import ConsoleSink
-    from pivot.engine.types import LogLine
-
-    output = StringIO()
-    # no_color=True ensures we get plain text output for easier assertion
-    console = Console(file=output, force_terminal=False, no_color=True)
-    sink = ConsoleSink(console=console, show_output=True)
-
-    # Simulate a stage that outputs text containing Rich markup syntax
-    event = LogLine(
-        type="log_line",
-        seq=0,
-        stage="train",
-        line="[bold red]FAKE ERROR[/bold red] - this should display literally",
-        is_stderr=False,
-    )
-    await sink.handle(event)
-
-    result = output.getvalue()
-    # The markup tags should be visible as literal text, not interpreted
-    assert "[bold red]" in result or "\\[bold red]" in result
-    assert "FAKE ERROR" in result
-    assert "this should display literally" in result
 
 
 # =============================================================================

--- a/packages/pivot/tests/engine/test_sinks.py
+++ b/packages/pivot/tests/engine/test_sinks.py
@@ -46,7 +46,7 @@ def _helper_render_renderable(renderable: object) -> str:
 
 def test_format_stage_line_ran_includes_duration() -> None:
     line = sinks._format_stage_line(
-        index=0,
+        index=1,
         total=12,
         stage="train",
         category=DisplayCategory.SUCCESS,
@@ -63,7 +63,7 @@ def test_format_stage_line_ran_includes_duration() -> None:
 
 def test_format_stage_line_skipped_omits_duration() -> None:
     line = sinks._format_stage_line(
-        index=1,
+        index=2,
         total=12,
         stage="skip_stage",
         category=DisplayCategory.CACHED,
@@ -78,7 +78,7 @@ def test_format_stage_line_skipped_omits_duration() -> None:
 
 def test_format_stage_line_failed_uses_failed_status() -> None:
     line = sinks._format_stage_line(
-        index=2,
+        index=3,
         total=12,
         stage="fail_stage",
         category=DisplayCategory.FAILED,
@@ -93,7 +93,7 @@ def test_format_stage_line_failed_uses_failed_status() -> None:
 
 def test_format_stage_line_truncates_long_names() -> None:
     line = sinks._format_stage_line(
-        index=0,
+        index=1,
         total=1,
         stage="very_long_stage_name",
         category=DisplayCategory.SUCCESS,
@@ -106,10 +106,10 @@ def test_format_stage_line_truncates_long_names() -> None:
 
 
 def test_format_skip_group_line_includes_range_and_count() -> None:
-    line = sinks._format_skip_group_line(start_index=0, end_index=2, total=9, count=3)
+    line = sinks._format_skip_group_line(start_index=1, end_index=3, total=9, count=3)
     rendered = _helper_render_markup(line)
     assert "1–3/9" in rendered, "Should include collapsed range"
-    assert "3 stages skipped" in rendered, "Should include skipped count text"
+    assert "3 stages not run" in rendered, "Should include skipped count text"
     assert "○" in rendered, "Should include skip symbol"
 
 
@@ -141,7 +141,7 @@ async def test_static_sink_prints_ran_stage_line() -> None:
         status=StageStatus.RAN,
         reason="",
         duration_ms=1200.0,
-        index=0,
+        index=1,
         total=1,
         run_id="test-run",
         input_hash=None,
@@ -166,10 +166,10 @@ async def test_static_sink_prints_skipped_stages_individually_when_low_count() -
             type="stage_completed",
             seq=idx,
             stage=f"skip_{idx}",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="up-to-date",
             duration_ms=10.0,
-            index=idx,
+            index=idx + 1,
             total=3,
             run_id="test-run",
             input_hash=None,
@@ -184,7 +184,7 @@ async def test_static_sink_prints_skipped_stages_individually_when_low_count() -
     assert "skip_0" in result, "Should include first skipped stage"
     assert "skip_1" in result, "Should include second skipped stage"
     assert "cached" in result, "Should show cached status for up-to-date stages"
-    assert "stages skipped" not in result, "Should not collapse low skip counts"
+    assert "stages not run" not in result, "Should not collapse low skip counts"
 
 
 async def test_static_sink_collapses_skips_over_threshold() -> None:
@@ -197,10 +197,10 @@ async def test_static_sink_collapses_skips_over_threshold() -> None:
             type="stage_completed",
             seq=idx,
             stage=f"skip_{idx}",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="up-to-date",
             duration_ms=10.0,
-            index=idx,
+            index=idx + 1,
             total=21,
             run_id="test-run",
             input_hash=None,
@@ -209,7 +209,7 @@ async def test_static_sink_collapses_skips_over_threshold() -> None:
     await sink.close()
 
     result = output.getvalue()
-    assert "21 stages skipped" in result, "Should collapse skipped stages over threshold"
+    assert "21 stages not run" in result, "Should collapse skipped stages over threshold"
 
 
 async def test_static_sink_does_not_collapse_skips_at_threshold() -> None:
@@ -222,10 +222,10 @@ async def test_static_sink_does_not_collapse_skips_at_threshold() -> None:
             type="stage_completed",
             seq=idx,
             stage=f"skip_{idx}",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="up-to-date",
             duration_ms=10.0,
-            index=idx,
+            index=idx + 1,
             total=20,
             run_id="test-run",
             input_hash=None,
@@ -234,7 +234,7 @@ async def test_static_sink_does_not_collapse_skips_at_threshold() -> None:
     await sink.close()
 
     result = output.getvalue()
-    assert "stages skipped" not in result, "Should not collapse skips at threshold"
+    assert "stages not run" not in result, "Should not collapse skips at threshold"
 
 
 async def test_static_sink_ignores_waiting_on_lock_state_changes() -> None:
@@ -268,7 +268,7 @@ async def test_static_sink_prints_failed_with_error_details() -> None:
         status=StageStatus.FAILED,
         reason="first line\nsecond line",
         duration_ms=100.0,
-        index=0,
+        index=1,
         total=1,
         run_id="test-run",
         input_hash=None,
@@ -291,7 +291,7 @@ async def test_static_sink_ignores_stage_started() -> None:
         type="stage_started",
         seq=0,
         stage="train",
-        index=0,
+        index=1,
         total=2,
         run_id="test-run",
     )
@@ -308,11 +308,11 @@ async def test_static_sink_sorts_completions_by_index() -> None:
     sink = sinks.StaticConsoleSink(console=console)
 
     # Send in reverse index order
-    for idx, name in [(2, "third"), (0, "first"), (1, "second")]:
+    for idx, name in [(3, "third"), (1, "first"), (2, "second")]:
         await sink.handle(
             StageCompleted(
                 type="stage_completed",
-                seq=idx,
+                seq=idx - 1,
                 stage=name,
                 status=StageStatus.RAN,
                 reason="",
@@ -420,10 +420,10 @@ async def test_static_sink_log_lines_stream_before_completions() -> None:
             type="stage_completed",
             seq=0,
             stage="skip_stage",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="cached",
             duration_ms=10.0,
-            index=0,
+            index=1,
             total=2,
             run_id="test-run",
             input_hash=None,
@@ -485,7 +485,7 @@ async def test_live_sink_prints_completion_to_scrollback() -> None:
             type="stage_started",
             seq=0,
             stage="train",
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
         )
@@ -498,7 +498,7 @@ async def test_live_sink_prints_completion_to_scrollback() -> None:
             status=StageStatus.RAN,
             reason="",
             duration_ms=1200.0,
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
             input_hash=None,
@@ -522,7 +522,7 @@ async def test_live_sink_tracks_running_stages() -> None:
             type="stage_started",
             seq=0,
             stage="train",
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
         )
@@ -540,7 +540,7 @@ async def test_live_sink_tracks_running_stages() -> None:
             status=StageStatus.RAN,
             reason="",
             duration_ms=50.0,
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
             input_hash=None,
@@ -581,7 +581,7 @@ async def test_live_sink_collapses_many_skips_in_scrollback() -> None:
                 type="stage_completed",
                 seq=idx,
                 stage=f"skip_{idx}",
-                status=StageStatus.SKIPPED,
+                status=StageStatus.CACHED,
                 reason="cached",
                 duration_ms=10.0,
                 index=idx,
@@ -593,7 +593,7 @@ async def test_live_sink_collapses_many_skips_in_scrollback() -> None:
     await sink.close()
 
     result = output.getvalue()
-    assert "21 stages skipped" in result, "Should collapse skipped stages over threshold"
+    assert "21 stages not run" in result, "Should collapse skipped stages over threshold"
 
 
 async def test_live_sink_prints_all_statuses_on_close() -> None:
@@ -610,7 +610,7 @@ async def test_live_sink_prints_all_statuses_on_close() -> None:
             status=StageStatus.RAN,
             reason="",
             duration_ms=1000.0,
-            index=0,
+            index=1,
             total=3,
             run_id="test-run",
             input_hash=None,
@@ -621,10 +621,10 @@ async def test_live_sink_prints_all_statuses_on_close() -> None:
             type="stage_completed",
             seq=1,
             stage="skipped_stage",
-            status=StageStatus.SKIPPED,
+            status=StageStatus.CACHED,
             reason="cached",
             duration_ms=2000.0,
-            index=1,
+            index=2,
             total=3,
             run_id="test-run",
             input_hash=None,
@@ -638,7 +638,7 @@ async def test_live_sink_prints_all_statuses_on_close() -> None:
             status=StageStatus.FAILED,
             reason="boom",
             duration_ms=500.0,
-            index=2,
+            index=3,
             total=3,
             run_id="test-run",
             input_hash=None,
@@ -702,7 +702,7 @@ async def test_live_sink_live_renderable_shows_running_stages() -> None:
             type="stage_started",
             seq=0,
             stage="train",
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
         )
@@ -729,7 +729,7 @@ async def test_live_sink_live_renderable_shows_progress() -> None:
             status=StageStatus.RAN,
             reason="",
             duration_ms=1000.0,
-            index=0,
+            index=1,
             total=3,
             run_id="test-run",
             input_hash=None,
@@ -760,7 +760,7 @@ async def test_result_collector_sink_collects_completed() -> None:
         status=StageStatus.RAN,
         reason="",
         duration_ms=1000,
-        index=0,
+        index=1,
         total=1,
         run_id="test-run",
         input_hash=None,
@@ -782,7 +782,7 @@ async def test_result_collector_sink_ignores_other_events() -> None:
         type="stage_started",
         seq=0,
         stage="train",
-        index=0,
+        index=1,
         total=2,
         run_id="test-run",
     )
@@ -805,7 +805,7 @@ async def test_result_collector_sink_concurrent_access() -> None:
             status=StageStatus.RAN,
             reason="test",
             duration_ms=100.0,
-            index=0,
+            index=1,
             total=1,
             run_id="test-run",
             input_hash=None,
@@ -841,7 +841,7 @@ async def test_result_collector_sink_prevents_lost_updates() -> None:
                 status=StageStatus.RAN,
                 reason=f"iteration_{i}",
                 duration_ms=float(i),
-                index=0,
+                index=1,
                 total=1,
                 run_id="test-run",
                 input_hash=None,
@@ -876,7 +876,7 @@ _EVENTS = [
         type="stage_started",
         seq=i,
         stage=f"s{i}",
-        index=i,
+        index=i + 1,
         total=5,
         run_id="test-run",
     )
@@ -953,7 +953,7 @@ async def test_per_sink_ordering_preserved() -> None:
             status=StageStatus.RAN,
             reason="",
             duration_ms=float(i),
-            index=i,
+            index=i + 1,
             total=10,
             input_hash=None,
         )
@@ -1030,7 +1030,9 @@ async def test_queue_full_disables_stalled_sink() -> None:
             # The stalling sink blocks on event 1, so the queue fills after 1025 more.
             for i in range(2000):
                 await eng.emit(
-                    StageStarted(type="stage_started", seq=i, stage=f"s{i}", index=i, total=2000)
+                    StageStarted(
+                        type="stage_started", seq=i, stage=f"s{i}", index=i + 1, total=2000
+                    )
                 )
                 sent_count += 1
 

--- a/packages/pivot/tests/engine/test_types.py
+++ b/packages/pivot/tests/engine/test_types.py
@@ -439,7 +439,7 @@ def test_output_event_union() -> None:
         {
             "type": "sink_state_changed",
             "seq": 6,
-            "sink_id": "ConsoleSink",
+            "sink_id": "StaticConsoleSink",
             "state": types.SinkState.ENABLED,
             "reason": "manual",
             "failure_count": 0,
@@ -477,7 +477,7 @@ def test_sink_state_changed_event() -> None:
     event: types.SinkStateChanged = {
         "type": "sink_state_changed",
         "seq": 1,
-        "sink_id": "ConsoleSink",
+        "sink_id": "StaticConsoleSink",
         "state": types.SinkState.DISABLED,
         "reason": "exception",
         "failure_count": 5,

--- a/packages/pivot/tests/engine/test_types.py
+++ b/packages/pivot/tests/engine/test_types.py
@@ -258,14 +258,14 @@ def test_stage_completed_event() -> None:
         type="stage_completed",
         seq=1,
         stage="evaluate",
-        status=StageStatus.SKIPPED,
+        status=StageStatus.CACHED,
         reason="unchanged",
         duration_ms=0.0,
         index=4,
         total=5,
         input_hash=None,
     )
-    assert event_skip["status"] == StageStatus.SKIPPED
+    assert event_skip["status"] == StageStatus.CACHED
 
 
 def test_stage_completed_without_output_summary_is_valid() -> None:
@@ -288,7 +288,7 @@ def test_stage_completed_with_output_summary_none() -> None:
     event: types.StageCompleted = types.StageCompleted(
         type="stage_completed",
         stage="train",
-        status=StageStatus.SKIPPED,
+        status=StageStatus.CACHED,
         reason="unchanged",
         duration_ms=0.0,
         index=0,

--- a/packages/pivot/tests/execution/test_execution_modes.py
+++ b/packages/pivot/tests/execution/test_execution_modes.py
@@ -230,7 +230,7 @@ def test_run_cache_restores_directory_output(
 
     # Second run - should skip via run cache and restore directory
     result2 = worker.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == StageStatus.SKIPPED
+    assert result2["status"] == StageStatus.CACHED
     assert "run cache" in result2["reason"], "Should skip via run cache"
     assert execution_count[0] == 1, "Should not have executed again"
 

--- a/packages/pivot/tests/execution/test_executor.py
+++ b/packages/pivot/tests/execution/test_executor.py
@@ -890,7 +890,7 @@ def test_unchanged_stages_are_skipped(pipeline_dir: pathlib.Path, test_pipeline:
 
     # Second run - should skip (nothing changed)
     results = executor.run(pipeline=test_pipeline)
-    assert results["step1"]["status"] == "skipped"
+    assert results["step1"]["status"] == "cached"
 
 
 def test_code_change_triggers_rerun(pipeline_dir: pathlib.Path, test_pipeline: Pipeline) -> None:
@@ -1334,7 +1334,7 @@ def test_on_error_keep_going_skips_downstream_of_failed(
     results = executor.run(on_error="keep_going", pipeline=test_pipeline)
 
     assert results["first"]["status"] == "failed"
-    assert results["second"]["status"] == "skipped"
+    assert results["second"]["status"] == "blocked"
     assert "upstream" in results["second"]["reason"]
     assert results["independent"]["status"] == "ran"
 
@@ -1637,7 +1637,7 @@ def test_executor_restores_missing_outputs_on_skip(
 
     # Second run - should skip but restore output from cache
     results = executor.run(pipeline=test_pipeline)
-    assert results["process"]["status"] == "skipped"
+    assert results["process"]["status"] == "cached"
     assert output_file.exists(), "Output should be restored from cache"
     assert output_file.read_text() == "result"
 
@@ -1799,7 +1799,7 @@ def test_force_runs_unchanged_stage(pipeline_dir: pathlib.Path, test_pipeline: P
 
     # Second run without force - should skip (nothing changed)
     results = executor.run(pipeline=test_pipeline)
-    assert results["process"]["status"] == "skipped"
+    assert results["process"]["status"] == "cached"
 
     # Third run with force - should run despite no changes
     results = executor.run(force=True, pipeline=test_pipeline)
@@ -1818,7 +1818,7 @@ def test_force_updates_lock_file(pipeline_dir: pathlib.Path, test_pipeline: Pipe
 
     # Second run without force - should skip (lock file should be correct)
     results = executor.run(pipeline=test_pipeline)
-    assert results["process"]["status"] == "skipped", "Lock file should be valid after forced run"
+    assert results["process"]["status"] == "cached", "Lock file should be valid after forced run"
 
 
 def test_force_with_specific_stage(pipeline_dir: pathlib.Path, test_pipeline: Pipeline) -> None:
@@ -1916,7 +1916,7 @@ def test_executor_deferred_writes_applied(
 
     # Verify deferred writes were applied by checking skip works on second run
     results = executor.run(pipeline=test_pipeline)
-    assert results["process"]["status"] == "skipped", (
+    assert results["process"]["status"] == "cached", (
         "Stage should skip on second run - deferred writes recorded run cache"
     )
 
@@ -2025,6 +2025,6 @@ def test_skip_detection_fast_with_many_deps(
     results = executor.run(pipeline=test_pipeline)
     elapsed = time.time() - start_time
 
-    assert results["process"]["status"] == "skipped"
+    assert results["process"]["status"] == "cached"
     # Skip check should be fast (< 5s even with slow CI)
     assert elapsed < 5, f"Skip detection took too long: {elapsed:.1f}s"

--- a/packages/pivot/tests/execution/test_executor_worker.py
+++ b/packages/pivot/tests/execution/test_executor_worker.py
@@ -161,7 +161,7 @@ def test_execute_stage_runs_unchanged_stage(
 
     # Second run - should skip (unchanged)
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     assert result2["reason"] == "unchanged"
 
 
@@ -207,7 +207,7 @@ def test_execute_stage_generation_skip_avoids_hashing(
     result = executor.execute_stage(stage_name, stage_info, worker_env, output_queue)
 
     hash_mock.assert_not_called()
-    assert result["status"] == "skipped"
+    assert result["status"] == "cached"
     assert result["reason"] == "unchanged (generation)"
 
 
@@ -917,7 +917,7 @@ def test_generation_skip_on_second_run(
 
     # Second run - should skip via generation check
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     # Falls back to hash-based skip because input.txt is external (no generation tracking)
     assert "unchanged" in result2["reason"]
 
@@ -964,9 +964,9 @@ def test_generation_mismatch_triggers_rerun(
 
     # Second run - both should skip
     result2_step1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
-    assert result2_step1["status"] == "skipped"
+    assert result2_step1["status"] == "cached"
     result2_step2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
-    assert result2_step2["status"] == "skipped"
+    assert result2_step2["status"] == "cached"
 
     # Change input - step1 should re-run
     (tmp_path / "input.txt").write_text("modified")
@@ -1006,7 +1006,7 @@ def test_external_file_fallback_to_hash_check(
 
     # Second run - should skip (external file has no generation, falls back to hash)
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
 
     # Modify external file - should detect change via hash fallback
     (tmp_path / "external_data.txt").write_text("changed")
@@ -1049,7 +1049,7 @@ def test_deps_list_change_triggers_rerun(
 
     # Second run with same config - should skip
     result2 = executor.execute_stage("test_stage", stage_info_v1, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
 
     # Third run with deps=[A] only (B removed), DIFFERENT fingerprint
     # This simulates real usage where changing pivot.yaml deps changes fingerprint
@@ -1512,7 +1512,7 @@ def test_directory_out_skipped_on_second_run(
 
     # Second run - should skip
     result2 = executor.execute_stage("test_dir_out", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skipped, got {result2}"
+    assert result2["status"] == "cached", f"Expected cached, got {result2}"
     assert "unchanged" in result2["reason"]
 
 
@@ -1583,7 +1583,7 @@ def test_directory_out_restored_from_cache(
 
     # Second run - should skip and restore from cache
     result2 = executor.execute_stage("test_dir_out", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skipped, got {result2}"
+    assert result2["status"] == "cached", f"Expected cached, got {result2}"
 
     # Verify files were restored
     assert results_dir.exists()
@@ -2053,7 +2053,7 @@ def test_run_cache_skip_with_directory_out(
 
     # Second run - should skip via run cache and restore directory
     result2 = executor.execute_stage("test_run_cache_dir", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skipped, got {result2}"
+    assert result2["status"] == "cached", f"Expected cached, got {result2}"
     assert "run cache" in result2["reason"]
 
     # Verify files were restored
@@ -2111,7 +2111,7 @@ def test_run_cache_skip_restores_corrupted_directory(
 
     # Second run - should skip via run cache and fix corrupted file
     result2 = executor.execute_stage("test_run_cache_corrupt", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     assert "run cache" in result2["reason"]
 
     # Verify corrupted file was restored
@@ -2713,7 +2713,7 @@ def test_run_cache_skip_with_mixed_cached_and_noncached_outputs(
 
     # Second run — should skip via run cache
     result2 = executor.execute_stage("test_mixed_rc", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skipped, got {result2}"
+    assert result2["status"] == "cached", f"Expected cached, got {result2}"
     assert "run cache" in result2["reason"]
 
     # Cached output should be restored

--- a/packages/pivot/tests/fingerprint/test_no_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_no_fingerprint.py
@@ -120,7 +120,7 @@ def test_no_fingerprint_stage_skips_when_unchanged(
     _apply_deferred_writes("no_fp", stage_info, result1)
 
     result2 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skip, got: {result2}"
+    assert result2["status"] == "cached", f"Expected skip, got: {result2}"
 
 
 def test_no_fingerprint_reruns_on_source_file_change(
@@ -234,7 +234,7 @@ def test_no_fingerprint_skip_unrelated_change(
 
     (tmp_path / "unrelated.txt").write_text("unrelated")
     result2 = executor.execute_stage("no_fp", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skip, got: {result2}"
+    assert result2["status"] == "cached", f"Expected skip, got: {result2}"
 
 
 def test_no_fingerprint_mixed_pipeline(
@@ -274,10 +274,10 @@ def test_no_fingerprint_mixed_pipeline(
     _apply_deferred_writes("no_fp", no_fp_info, result1_no_fp)
 
     result2_ast = executor.execute_stage("ast_stage", ast_info, worker_env, output_queue)
-    assert result2_ast["status"] == "skipped", f"Expected skip, got: {result2_ast}"
+    assert result2_ast["status"] == "cached", f"Expected skip, got: {result2_ast}"
 
     result2_no_fp = executor.execute_stage("no_fp", no_fp_info, worker_env, output_queue)
-    assert result2_no_fp["status"] == "skipped", f"Expected skip, got: {result2_no_fp}"
+    assert result2_no_fp["status"] == "cached", f"Expected skip, got: {result2_no_fp}"
 
 
 def test_no_fingerprint_missing_code_deps_file(

--- a/packages/pivot/tests/integration/test_concurrent_locking.py
+++ b/packages/pivot/tests/integration/test_concurrent_locking.py
@@ -336,9 +336,7 @@ def test_periodic_status_during_contention(tmp_path: pathlib.Path) -> None:
         f"stage_c failed:\nstdout={stdout_c.decode()}\nstderr={stderr_c.decode()}"
     )
 
-    # Check that the blocked process emitted a waiting/lock status message.
-    # The ConsoleSink prints "waiting for artifact lock" to stdout (via rich Console).
     combined_c = stdout_c.decode() + stderr_c.decode()
-    assert "waiting" in combined_c.lower() or "lock" in combined_c.lower(), (
-        f"Expected lock-wait status in stage_c output, got:\nstdout={stdout_c.decode()}\nstderr={stderr_c.decode()}"
+    assert "waiting for artifact lock" not in combined_c.lower(), (
+        "Lock-wait message should not be emitted in console output"
     )

--- a/packages/pivot/tests/integration/test_unified_execution.py
+++ b/packages/pivot/tests/integration/test_unified_execution.py
@@ -80,7 +80,9 @@ async def test_engine_run_completes_with_exit_on_completion(
         # Stage completes (any terminal status is acceptable - the point is it doesn't hang)
         assert results["test_stage"]["status"] in (
             StageStatus.RAN,
-            StageStatus.SKIPPED,
+            StageStatus.CACHED,
+            StageStatus.BLOCKED,
+            StageStatus.CANCELLED,
             StageStatus.FAILED,
         )
 

--- a/packages/pivot/tests/storage/test_incremental_out.py
+++ b/packages/pivot/tests/storage/test_incremental_out.py
@@ -710,7 +710,7 @@ async def test_cached_incremental_output_runs_normally(
     # Second run should skip without error (output is cached, nothing changed)
     async with Engine(pipeline=test_pipeline) as engine:
         results2 = await _run_engine_once(engine, cache_dir=cache_dir)
-    assert results2["append_stage"]["status"] == "skipped"
+    assert results2["append_stage"]["status"] == "cached"
 
 
 @pytest.mark.anyio
@@ -739,7 +739,7 @@ async def test_force_runs_incremental_stage_even_when_unchanged(
     # Second run without force should skip
     async with Engine(pipeline=test_pipeline) as engine:
         results2 = await _run_engine_once(engine, cache_dir=cache_dir)
-    assert results2["append_stage"]["status"] == "skipped"
+    assert results2["append_stage"]["status"] == "cached"
     assert db_path.read_text() == "line 1\n"
 
     # Third run with force=True should run and append

--- a/packages/pivot/tests/test_executor_pvt.py
+++ b/packages/pivot/tests/test_executor_pvt.py
@@ -222,7 +222,7 @@ def test_unchanged_tracked_file_allows_skip(
 
     # Second run - should skip (nothing changed)
     results = executor.run(pipeline=test_pipeline)
-    assert results["process"]["status"] == "skipped"
+    assert results["process"]["status"] == "cached"
 
 
 # =============================================================================

--- a/packages/pivot/tests/test_run_cache_lock_update.py
+++ b/packages/pivot/tests/test_run_cache_lock_update.py
@@ -147,7 +147,7 @@ def test_run_cache_skip_updates_lock_file(
         run_id="run_3",
     )
     result3 = executor.execute_stage("test_stage", stage_info_run3, worker_env, output_queue)
-    assert result3["status"] == "skipped"
+    assert result3["status"] == "cached"
     assert "run cache" in result3["reason"], f"Expected run cache skip, got: {result3['reason']}"
 
     # CRITICAL: Lock file should now have state A (not stale state B)
@@ -223,7 +223,7 @@ def test_explain_shows_cached_after_run_cache_skip(
         run_id="run_3",
     )
     result3 = executor.execute_stage("test_stage", stage_info_run3, worker_env, output_queue)
-    assert result3["status"] == "skipped"
+    assert result3["status"] == "cached"
     assert "run cache" in result3["reason"]
 
     # CRITICAL: Explain should show stage as NOT needing to run
@@ -277,7 +277,7 @@ def test_regular_execution_still_works(
 
     # Subsequent run should skip (via generation or hash check)
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     assert "unchanged" in result2["reason"]
 
 
@@ -356,7 +356,7 @@ def test_run_cache_skip_does_not_increment_output_generations(
         run_id="run_3",
     )
     result3 = executor.execute_stage("test_stage", stage_info_run3, worker_env, output_queue)
-    assert result3["status"] == "skipped"
+    assert result3["status"] == "cached"
     assert "run cache" in result3["reason"], f"Expected run cache skip, got: {result3['reason']}"
 
     # Apply deferred writes from the SKIPPED result

--- a/packages/pivot/tests/test_run_history.py
+++ b/packages/pivot/tests/test_run_history.py
@@ -117,7 +117,7 @@ def test_serialize_deserialize_run_manifest() -> None:
             ),
             "eval": run_history.StageRunRecord(
                 input_hash="def456",
-                status=StageStatus.SKIPPED,
+                status=StageStatus.CACHED,
                 reason="unchanged",
                 duration_ms=0,
             ),
@@ -133,7 +133,7 @@ def test_serialize_deserialize_run_manifest() -> None:
     assert deserialized["targeted_stages"] == manifest["targeted_stages"]
     assert deserialized["execution_order"] == manifest["execution_order"]
     assert deserialized["stages"]["train"]["status"] == StageStatus.RAN
-    assert deserialized["stages"]["eval"]["status"] == StageStatus.SKIPPED
+    assert deserialized["stages"]["eval"]["status"] == StageStatus.CACHED
 
 
 def test_serialize_deserialize_run_cache_entry() -> None:

--- a/packages/pivot/tests/test_skip_detection_integration.py
+++ b/packages/pivot/tests/test_skip_detection_integration.py
@@ -167,7 +167,7 @@ def test_generation_skip_with_pivot_produced_deps(
 
     # Second run: step1 skips (external dep falls through to hash check)
     result2_step1 = executor.execute_stage("step1", step1_info, worker_env, output_queue)
-    assert result2_step1["status"] == "skipped"
+    assert result2_step1["status"] == "cached"
     # No need to re-apply deferred writes for skipped stages (no deferred_writes in result)
 
     # Second run: step2 should skip via generation check (intermediate.txt is Pivot-produced)
@@ -178,7 +178,7 @@ def test_generation_skip_with_pivot_produced_deps(
     )
     result2_step2 = executor.execute_stage("step2", step2_info, worker_env, output_queue)
 
-    assert result2_step2["status"] == "skipped", f"Expected skip, got: {result2_step2}"
+    assert result2_step2["status"] == "cached", f"Expected skip, got: {result2_step2}"
     assert result2_step2["reason"] == "unchanged (generation)", (
         f"Expected generation skip, got: {result2_step2['reason']}"
     )
@@ -230,7 +230,7 @@ def test_external_dep_falls_through_to_hash_check(
     )
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
 
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     assert result2["reason"] == "unchanged", (
         f"Expected hash-based skip (not generation), got: {result2['reason']}"
     )
@@ -278,7 +278,7 @@ def test_cleared_statedb_degrades_to_lock_comparison(
 
     # Second run: lock file still exists, so hash comparison should detect unchanged
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped", f"Expected skip via lock comparison, got: {result2}"
+    assert result2["status"] == "cached", f"Expected skip via lock comparison, got: {result2}"
     assert "unchanged" in result2["reason"], (
         f"Expected 'unchanged' reason, got: {result2['reason']}"
     )
@@ -340,7 +340,7 @@ def test_missing_lock_file_triggers_full_run(
 
     # Second run: should skip
     result2 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
-    assert result2["status"] == "skipped"
+    assert result2["status"] == "cached"
     assert counter_file.read_text() == "1", "Stage should not have re-executed"
 
 

--- a/packages/pivot/tests/test_types.py
+++ b/packages/pivot/tests/test_types.py
@@ -1,5 +1,9 @@
 """Tests for pivot.types module."""
 
+# pyright: reportMissingImports=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+
+from typing import get_args
+
 from pivot.types import CompletionType, StageStatus
 
 
@@ -9,10 +13,13 @@ def test_completion_type_includes_ran() -> None:
     assert status == StageStatus.RAN
 
 
-def test_completion_type_includes_skipped() -> None:
-    """CompletionType should include SKIPPED."""
-    status: CompletionType = StageStatus.SKIPPED
-    assert status == StageStatus.SKIPPED
+def test_completion_type_includes_all_terminal_statuses() -> None:
+    """CompletionType includes all terminal status values."""
+    assert StageStatus.RAN in get_args(CompletionType)
+    assert StageStatus.CACHED in get_args(CompletionType)
+    assert StageStatus.BLOCKED in get_args(CompletionType)
+    assert StageStatus.CANCELLED in get_args(CompletionType)
+    assert StageStatus.FAILED in get_args(CompletionType)
 
 
 def test_completion_type_includes_failed() -> None:


### PR DESCRIPTION
## Summary

Two related changes that improve pipeline output semantics and presentation:

### 1. Split `StageStatus.SKIPPED` into `CACHED`, `BLOCKED`, `CANCELLED`

Replace the ambiguous `SKIPPED` status with three semantic statuses so consumers get correct meaning without parsing reason strings.

- **`CACHED`** — stage up-to-date, outputs restored from cache (worker skip)
- **`BLOCKED`** — upstream dependency failed (engine skip)
- **`CANCELLED`** — run cancelled by user (engine skip)

**Source changes:**
- Remove `SKIPPED` from `StageStatus` enum; add `CACHED`/`BLOCKED`/`CANCELLED`
- Workers return `CACHED` (4 skip sites); engine emits `BLOCKED` or `CANCELLED` (3 sites)
- `categorize_stage_result()` simplified to trivial 1:1 mapping; dead `reason` param removed
- `count_results()` returns 5-tuple `(ran, cached, blocked, cancelled, failed)`
- `ensure_completion_type()` — runtime-validated narrowing replaces unsafe `cast()` calls
- Legacy `"skipped"` in run history gracefully mapped to `CACHED` during deserialization
- JSONL schema version bumped to 2 (stage status values changed)
- `console.summary()` updated to display cancelled count

### 2. Redesign console output with `StaticConsoleSink` / `LiveConsoleSink`

Replace the old `ConsoleSink` with two specialized sinks:

- **`StaticConsoleSink`** — pipe/CI mode: buffers completions, prints sorted report on close with skip collapsing (20+ consecutive non-run stages collapsed into a single range line)
- **`LiveConsoleSink`** — TTY mode: pinned status area with progress bar, running stage timers, recent completions, and per-category summary counts (ran/cached/blocked/cancelled/failed)

**Shared formatting:**
- `_format_stage_line()` — consistent `[N/total] ✓ stage_name done 1.2s` formatting with per-category symbols and colors
- `_format_skip_group_line()` — collapsed range `[1–173/173] ○ 173 stages not run`
- `_print_completions()` — sorted output with skip collapsing, shared by both sinks
- Stage log buffering with `_MAX_LOG_LINES_PER_STAGE` cap for failed stage output

### Bug fixes
- Fix off-by-one in sink index formatting (engine emits 1-based indices; sinks were adding +1 again)

## Verification

- 3940 tests pass (3512 pivot + 428 TUI)
- 0 basedpyright errors
- ruff format/check clean