### PR TITLE
fix: remove phantom state.db path and fix explain.py skip detection

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -179,7 +179,7 @@ Lock files use relative paths for portability across machines.
 │   ├── preprocess.lock
 │   └── train.lock
 ├── config.yaml          # Remote configuration
-└── state.db             # LMDB database (hash cache, generations, run cache, remote index)
+└── state.lmdb/          # LMDB database (hash cache, generations, run cache, remote index)
 ```
 
 ## Key Design Decisions

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -21,7 +21,7 @@ manifest mapping each output path to its content hash.
   stages/
     clean.lock             # lock file for "clean" stage
     train.lock             # lock file for "train" stage
-  state.db                 # LMDB database
+  state.lmdb/              # LMDB database
 ```
 
 Because the cache is content-addressed:

--- a/docs/concepts/pipelines.md
+++ b/docs/concepts/pipelines.md
@@ -202,7 +202,7 @@ By default, all pipelines share the project-level `.pivot/` directory:
   .pivot/
     cache/             # Content-addressable cache (shared across pipelines)
     stages/            # Per-stage lock files
-    state.db           # LMDB database (generations, hashes)
+    state.lmdb/        # LMDB database (generations, hashes)
     locks/             # Artifact locks for concurrent execution
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,7 +25,7 @@ Add to your `.gitignore`:
 
 ```
 .pivot/cache/
-.pivot/state.db/
+.pivot/state.lmdb/
 ```
 
 Commit the lock files — they track what ran and what outputs were produced:

--- a/packages/pivot/src/pivot/cli/fingerprint.py
+++ b/packages/pivot/src/pivot/cli/fingerprint.py
@@ -21,8 +21,7 @@ def reset() -> None:
     from pivot.config import io
     from pivot.storage import state
 
-    db_path = io.get_state_db_path()
-    with state.StateDB(db_path, readonly=False) as db:
+    with state.StateDB(io.get_state_dir(), readonly=False) as db:
         count = db.clear_ast_hashes()
 
     click.echo(f"Cleared {count} cached fingerprint entries.")

--- a/packages/pivot/src/pivot/cli/history.py
+++ b/packages/pivot/src/pivot/cli/history.py
@@ -24,9 +24,7 @@ def history(ctx: click.Context, limit: int, output_json: bool) -> None:
     cli_ctx = cli_helpers.get_cli_context(ctx)
     quiet = cli_ctx["quiet"]
 
-    state_db_path = config.get_state_db_path()
-
-    with state.StateDB(state_db_path) as state_db:
+    with state.StateDB(config.get_state_dir()) as state_db:
         runs = state_db.list_runs(limit=limit)
 
     if output_json:
@@ -76,9 +74,7 @@ def show_cmd(ctx: click.Context, run_id: str | None, output_json: bool) -> None:
     cli_ctx = cli_helpers.get_cli_context(ctx)
     quiet = cli_ctx["quiet"]
 
-    state_db_path = config.get_state_db_path()
-
-    with state.StateDB(state_db_path) as state_db:
+    with state.StateDB(config.get_state_dir()) as state_db:
         if run_id:
             run = state_db.read_run(run_id)
             if run is None:

--- a/packages/pivot/src/pivot/cli/init.py
+++ b/packages/pivot/src/pivot/cli/init.py
@@ -13,7 +13,6 @@ _GITIGNORE_CONTENT = """\
 cache/
 
 # State database (file hashes, generation counters)
-state.db
 state.lmdb/
 
 # Config lock (ruamel.yaml temporary file)

--- a/packages/pivot/src/pivot/cli/remote.py
+++ b/packages/pivot/src/pivot/cli/remote.py
@@ -128,7 +128,7 @@ def push(
     # Remote hash tracking is project-level (not per-stage), so use the
     # project-level StateDB regardless of --all mode.
     with (
-        state.StateDB(config.get_state_db_path()) as state_db,
+        state.StateDB(config.get_state_dir()) as state_db,
         cli_helpers.TransferProgress("Uploaded", quiet=quiet) as progress,
     ):
         result = transfer.push(
@@ -212,7 +212,7 @@ def fetch(
         return
 
     with (
-        state.StateDB(config.get_state_db_path()) as state_db,
+        state.StateDB(config.get_state_dir()) as state_db,
         cli_helpers.TransferProgress("Downloaded", quiet=quiet) as progress,
     ):
         result = transfer.pull(
@@ -321,7 +321,7 @@ def pull(
 
     # Step 1: Fetch from remote to cache
     with (
-        state.StateDB(config.get_state_db_path()) as state_db,
+        state.StateDB(config.get_state_dir()) as state_db,
         cli_helpers.TransferProgress("Downloaded", quiet=quiet) as progress,
     ):
         fetch_result = transfer.pull(

--- a/packages/pivot/src/pivot/config/__init__.py
+++ b/packages/pivot/src/pivot/config/__init__.py
@@ -14,7 +14,6 @@ from pivot.config.io import get_remote_connect_timeout as get_remote_connect_tim
 from pivot.config.io import get_remote_jobs as get_remote_jobs
 from pivot.config.io import get_remote_retries as get_remote_retries
 from pivot.config.io import get_run_history_retention as get_run_history_retention
-from pivot.config.io import get_state_db_path as get_state_db_path
 from pivot.config.io import get_state_dir as get_state_dir
 from pivot.config.io import get_watch_debounce as get_watch_debounce
 from pivot.config.io import load_config_file as load_config_file

--- a/packages/pivot/src/pivot/config/io.py
+++ b/packages/pivot/src/pivot/config/io.py
@@ -325,10 +325,6 @@ def get_state_dir() -> pathlib.Path:
     return state_dir
 
 
-def get_state_db_path() -> pathlib.Path:
-    """Get path to the StateDB LMDB database."""
-    return get_state_dir() / "state.db"
-
 
 def get_max_workers() -> int:
     """Get max workers from merged config."""

--- a/packages/pivot/src/pivot/config/io.py
+++ b/packages/pivot/src/pivot/config/io.py
@@ -325,7 +325,6 @@ def get_state_dir() -> pathlib.Path:
     return state_dir
 
 
-
 def get_max_workers() -> int:
     """Get max workers from merged config."""
     merged = get_merged_config()

--- a/packages/pivot/src/pivot/engine/engine.py
+++ b/packages/pivot/src/pivot/engine/engine.py
@@ -906,8 +906,7 @@ class Engine:
         def _get_state_db(stage_state_dir: pathlib.Path) -> state_mod.StateDB:
             """Get or open a StateDB for the given state_dir."""
             if stage_state_dir not in state_dbs:
-                db_path = stage_state_dir / "state.db"
-                state_dbs[stage_state_dir] = state_mod.StateDB(db_path)
+                state_dbs[stage_state_dir] = state_mod.StateDB(stage_state_dir)
             return state_dbs[stage_state_dir]
 
         try:
@@ -1543,12 +1542,11 @@ class Engine:
         from pivot import skip as skip_mod
 
         def _get_skip_state_db() -> state_mod.StateDB:
-            state_db_path = stage_state_dir / "state.db"
             if skip_state_dbs is not None:
-                if state_db_path not in skip_state_dbs:
-                    skip_state_dbs[state_db_path] = state_mod.StateDB(state_db_path, readonly=True)
-                return skip_state_dbs[state_db_path]
-            return state_mod.StateDB(state_db_path, readonly=True)
+                if stage_state_dir not in skip_state_dbs:
+                    skip_state_dbs[stage_state_dir] = state_mod.StateDB(stage_state_dir, readonly=True)
+                return skip_state_dbs[stage_state_dir]
+            return state_mod.StateDB(stage_state_dir, readonly=True)
 
         def _try_generation_skip() -> tuple[bool, str | None]:
             state_db = _get_skip_state_db()
@@ -1927,7 +1925,7 @@ class Engine:
             stages=stages_records,
         )
 
-        with state_mod.StateDB(config.get_state_db_path()) as state_db:
+        with state_mod.StateDB(config.get_state_dir()) as state_db:
             state_db.write_run(manifest)
             state_db.prune_runs(retention)
 

--- a/packages/pivot/src/pivot/engine/engine.py
+++ b/packages/pivot/src/pivot/engine/engine.py
@@ -1544,7 +1544,9 @@ class Engine:
         def _get_skip_state_db() -> state_mod.StateDB:
             if skip_state_dbs is not None:
                 if stage_state_dir not in skip_state_dbs:
-                    skip_state_dbs[stage_state_dir] = state_mod.StateDB(stage_state_dir, readonly=True)
+                    skip_state_dbs[stage_state_dir] = state_mod.StateDB(
+                        stage_state_dir, readonly=True
+                    )
                 return skip_state_dbs[stage_state_dir]
             return state_mod.StateDB(stage_state_dir, readonly=True)
 

--- a/packages/pivot/src/pivot/executor/AGENTS.md
+++ b/packages/pivot/src/pivot/executor/AGENTS.md
@@ -18,7 +18,7 @@ Workers execute in separate processes via `loky.get_reusable_executor()`.
 ## Path Derivation
 
 Workers derive all paths from `project_root` and `state_dir` in `WorkerStageInfo`:
-- `state_db_path = stage_info["state_dir"] / "state.db"`
+- `state_dir = stage_info["state_dir"]` (passed directly to `StateDB`)
 - Workers `chdir(project_root)` before execution
 
 Do not assume paths from `cache_dir` location—it's passed separately to `execute_stage()`.

--- a/packages/pivot/src/pivot/executor/commit.py
+++ b/packages/pivot/src/pivot/executor/commit.py
@@ -72,7 +72,7 @@ def commit_stages(
     def _get_state_db(stage_state_dir: pathlib.Path) -> state_mod.StateDB:
         if stage_state_dir not in state_dbs:
             stage_state_dir.mkdir(parents=True, exist_ok=True)
-            state_dbs[stage_state_dir] = state_mod.StateDB(stage_state_dir / "state.db")
+            state_dbs[stage_state_dir] = state_mod.StateDB(stage_state_dir)
         return state_dbs[stage_state_dir]
 
     try:

--- a/packages/pivot/src/pivot/executor/core.py
+++ b/packages/pivot/src/pivot/executor/core.py
@@ -402,7 +402,7 @@ def verify_tracked_files(project_root: pathlib.Path, checkout_missing: bool = Fa
     missing = list[str]()
     cache_dir = config.get_cache_dir() / "files"
 
-    with state_mod.StateDB(config.get_state_db_path()) as state_db:
+    with state_mod.StateDB(config.get_state_dir()) as state_db:
         for data_path, track_data in tracked_files.items():
             path = pathlib.Path(data_path)
 

--- a/packages/pivot/src/pivot/executor/worker.py
+++ b/packages/pivot/src/pivot/executor/worker.py
@@ -184,7 +184,7 @@ def execute_stage(
     metrics.clear()
     ring_buffer = _OutputRingBuffer()
     files_cache_dir = cache_dir / "files"
-    state_db_path = stage_info["state_dir"] / "state.db"
+    state_dir = stage_info["state_dir"]
     project_root = stage_info["project_root"]
 
     # Set project root cache explicitly - workers in reusable pool may have
@@ -241,7 +241,7 @@ def execute_stage(
                     )
                 lock_data = production_lock.read()
 
-                with state.StateDB(state_db_path, readonly=True) as state_db:
+                with state.StateDB(state_dir, readonly=True) as state_db:
                     outputs_missing_from_cache = False
                     if lock_data is not None and not stage_info["force"]:
                         out_paths = _get_normalized_out_paths(stage_info)
@@ -426,7 +426,7 @@ def execute_stage(
                 )
 
                 # Single StateDB open for post-execution work
-                with state.StateDB(state_db_path, readonly=True) as state_db:
+                with state.StateDB(state_dir, readonly=True) as state_db:
                     deferred = _commit_lock_and_build_deferred(
                         stage_info,
                         new_lock_data,

--- a/packages/pivot/src/pivot/explain.py
+++ b/packages/pivot/src/pivot/explain.py
@@ -135,29 +135,27 @@ def get_stage_explanation(
 
     # Check generation tracking first (O(1) skip detection)
     # Use verify_files=False since status predicts run behavior after restoration
-    state_db_path = state_dir / "state.db"
-    if state_db_path.exists():
-        with state.StateDB(state_db_path, readonly=True) as state_db:
-            if not force and worker.can_skip_via_generation(
+    with state.StateDB(state_dir, readonly=True) as state_db:
+        if not force and worker.can_skip_via_generation(
+            stage_name=stage_name,
+            fingerprint=fingerprint,
+            deps=deps,
+            outs_paths=outs_paths,
+            current_params=current_params,
+            lock_data=lock_data,
+            state_db=state_db,
+            verify_files=False,
+        ):
+            return StageExplanation(
                 stage_name=stage_name,
-                fingerprint=fingerprint,
-                deps=deps,
-                outs_paths=outs_paths,
-                current_params=current_params,
-                lock_data=lock_data,
-                state_db=state_db,
-                verify_files=False,
-            ):
-                return StageExplanation(
-                    stage_name=stage_name,
-                    will_run=False,
-                    is_forced=False,
-                    reason="",
-                    code_changes=[],
-                    param_changes=[],
-                    dep_changes=[],
-                    upstream_stale=[],
-                )
+                will_run=False,
+                is_forced=False,
+                reason="",
+                code_changes=[],
+                param_changes=[],
+                dep_changes=[],
+                upstream_stale=[],
+            )
 
     # Hash dependencies - with optional fallback for missing files
     if allow_missing:

--- a/packages/pivot/src/pivot/explain.py
+++ b/packages/pivot/src/pivot/explain.py
@@ -82,6 +82,11 @@ def _find_tracked_hash(
     return None  # Path not found in manifest
 
 
+def _state_db_exists(state_dir: pathlib.Path) -> bool:
+    """Return True when the LMDB data file already exists."""
+    return (state_dir / "state.lmdb" / "data.mdb").exists()
+
+
 def get_stage_explanation(
     stage_name: str,
     fingerprint: dict[str, str],
@@ -133,29 +138,31 @@ def get_stage_explanation(
             upstream_stale=[],
         )
 
-    # Check generation tracking first (O(1) skip detection)
-    # Use verify_files=False since status predicts run behavior after restoration
-    with state.StateDB(state_dir, readonly=True) as state_db:
-        if not force and worker.can_skip_via_generation(
-            stage_name=stage_name,
-            fingerprint=fingerprint,
-            deps=deps,
-            outs_paths=outs_paths,
-            current_params=current_params,
-            lock_data=lock_data,
-            state_db=state_db,
-            verify_files=False,
-        ):
-            return StageExplanation(
+    # Check generation tracking first (O(1) skip detection) when StateDB exists.
+    # explain/status should not create state.lmdb as a side effect.
+    # Use verify_files=False since status predicts run behavior after restoration.
+    if _state_db_exists(state_dir):
+        with state.StateDB(state_dir, readonly=True) as state_db:
+            if not force and worker.can_skip_via_generation(
                 stage_name=stage_name,
-                will_run=False,
-                is_forced=False,
-                reason="",
-                code_changes=[],
-                param_changes=[],
-                dep_changes=[],
-                upstream_stale=[],
-            )
+                fingerprint=fingerprint,
+                deps=deps,
+                outs_paths=outs_paths,
+                current_params=current_params,
+                lock_data=lock_data,
+                state_db=state_db,
+                verify_files=False,
+            ):
+                return StageExplanation(
+                    stage_name=stage_name,
+                    will_run=False,
+                    is_forced=False,
+                    reason="",
+                    code_changes=[],
+                    param_changes=[],
+                    dep_changes=[],
+                    upstream_stale=[],
+                )
 
     # Hash dependencies - with optional fallback for missing files
     if allow_missing:

--- a/packages/pivot/src/pivot/explain.py
+++ b/packages/pivot/src/pivot/explain.py
@@ -83,8 +83,8 @@ def _find_tracked_hash(
 
 
 def _state_db_exists(state_dir: pathlib.Path) -> bool:
-    """Return True when the LMDB data file already exists."""
-    return (state_dir / "state.lmdb" / "data.mdb").exists()
+    """Return True when the LMDB directory already exists."""
+    return (state_dir / "state.lmdb").exists()
 
 
 def get_stage_explanation(

--- a/packages/pivot/src/pivot/fingerprint.py
+++ b/packages/pivot/src/pivot/fingerprint.py
@@ -151,7 +151,7 @@ def _get_state_db() -> "StateDB | None":
         from pivot.config import io
         from pivot.storage import state
 
-        _state_db = state.StateDB(io.get_state_db_path(), readonly=True)
+        _state_db = state.StateDB(io.get_state_dir(), readonly=True)
         return _state_db
     except Exception:
         # OSError (filesystem), ImportError (module), lmdb.Error, etc.
@@ -275,7 +275,7 @@ def flush_ast_hash_cache() -> None:
         from pivot.config import io
         from pivot.storage import state
 
-        with state.StateDB(io.get_state_db_path(), readonly=False) as db:
+        with state.StateDB(io.get_state_dir(), readonly=False) as db:
             db.save_ast_hash_many(pending)
         metrics.count("fingerprint.ast_hash_cache.flush")
     except Exception:
@@ -299,7 +299,7 @@ def flush_manifest_cache() -> None:
         from pivot.config import io
         from pivot.storage import state
 
-        with state.StateDB(io.get_state_db_path(), readonly=False) as db:
+        with state.StateDB(io.get_state_dir(), readonly=False) as db:
             db.put_raw_many(pending)
         metrics.count("fingerprint.manifest_cache.flush")
     except Exception:
@@ -362,7 +362,7 @@ def invalidate_manifests_for_paths(
 
     keys_to_delete = set[bytes]()
     try:
-        with state.StateDB(io.get_state_db_path(), readonly=True) as db:
+        with state.StateDB(io.get_state_dir(), readonly=True) as db:
             for key, raw in db.iter_prefix(b"sm:"):
                 if _manifest_references_paths(raw, changed_paths):
                     keys_to_delete.add(key)
@@ -384,7 +384,7 @@ def invalidate_manifests_for_paths(
         return
 
     try:
-        with state.StateDB(io.get_state_db_path(), readonly=False) as db:
+        with state.StateDB(io.get_state_dir(), readonly=False) as db:
             db.delete_raw_many(list(keys_to_delete))
     except Exception:
         _logger.debug(

--- a/packages/pivot/src/pivot/pipeline/pipeline.py
+++ b/packages/pivot/src/pivot/pipeline/pipeline.py
@@ -160,7 +160,7 @@ def _find_producer_via_scan(
 class Pipeline:
     """A pipeline with its own stage registry and state directory.
 
-    Each pipeline maintains isolated state (lock files, state.db) while
+    Each pipeline maintains isolated state (lock files, state.lmdb) while
     sharing the project-wide cache.
 
     Args:
@@ -221,7 +221,7 @@ class Pipeline:
 
     @property
     def state_dir(self) -> pathlib.Path:
-        """State directory for this pipeline's lock files and state.db."""
+        """State directory for this pipeline's lock files and state database."""
         return self._root / ".pivot"
 
     def _resolve_path(self, annotation_path: str) -> str:

--- a/packages/pivot/src/pivot/status.py
+++ b/packages/pivot/src/pivot/status.py
@@ -342,7 +342,7 @@ def get_tracked_files_status(
     results = list[TrackedFileInfo]()
 
     # Use state_db for hash caching (mtime-based)
-    with state_mod.StateDB(config.get_state_db_path()) as state_db:
+    with state_mod.StateDB(config.get_state_dir()) as state_db:
         for i, (abs_path_str, track_data) in enumerate(sorted(tracked.items()), 1):
             path = pathlib.Path(abs_path_str)
             rel_path = str(path.relative_to(project_root))
@@ -401,7 +401,7 @@ def get_remote_status(
     if not local_hashes:
         return RemoteSyncInfo(name=resolved_name, url=url, push_count=0, pull_count=0)
 
-    with state_mod.StateDB(config.get_state_db_path()) as state_db:
+    with state_mod.StateDB(config.get_state_dir()) as state_db:
         status = asyncio.run(
             transfer.compare_status(local_hashes, s3_remote, state_db, resolved_name)
         )

--- a/packages/pivot/src/pivot/storage/state.py
+++ b/packages/pivot/src/pivot/storage/state.py
@@ -168,12 +168,12 @@ class StateDB:
 
     def __init__(
         self,
-        db_path: pathlib.Path,
+        state_dir: pathlib.Path,
         readonly: bool = False,
         write_timeout: float = 30.0,
     ) -> None:
-        lmdb_path = db_path.parent / "state.lmdb"
-        lmdb_path.parent.mkdir(parents=True, exist_ok=True)
+        lmdb_path = state_dir / "state.lmdb"
+        state_dir.mkdir(parents=True, exist_ok=True)
 
         # LMDB readonly mode can't create database - create empty one first if needed
         if readonly and not lmdb_path.exists():

--- a/packages/pivot/tests/cli/test_cli_history.py
+++ b/packages/pivot/tests/cli/test_cli_history.py
@@ -31,8 +31,7 @@ def project_with_runs(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -
     project._project_root_cache = None
 
     # Write some test runs
-    state_db_path = project_dir / ".pivot" / "state.db"
-    with state.StateDB(state_db_path) as db:
+    with state.StateDB(project_dir / ".pivot") as db:
         for i in range(3):
             manifest = run_history.RunManifest(
                 run_id=f"2025011{i}_143000_abc1234{i}",

--- a/packages/pivot/tests/cli/test_cli_init.py
+++ b/packages/pivot/tests/cli/test_cli_init.py
@@ -32,7 +32,6 @@ def test_init_creates_gitignore(runner: click.testing.CliRunner, tmp_path: pathl
     "expected_content",
     [
         pytest.param("cache/", id="cache_dir"),
-        pytest.param("state.db", id="state_db"),
         pytest.param("state.lmdb/", id="state_lmdb"),
         pytest.param("config.yaml.lock", id="config_lock"),
     ],

--- a/packages/pivot/tests/cli/test_fingerprint_cli.py
+++ b/packages/pivot/tests/cli/test_fingerprint_cli.py
@@ -19,7 +19,7 @@ def test_fingerprint_reset_clears_statedb_entries(
         # Create .pivot in isolated dir
         pivot_dir = pathlib.Path(isolated_dir) / ".pivot"
         pivot_dir.mkdir()
-        db_path = pivot_dir / "state.db"
+        db_path = pivot_dir
 
         # Add entries to this new db
         with state.StateDB(db_path, readonly=False) as db:
@@ -52,7 +52,7 @@ def test_fingerprint_reset_reports_zero_when_empty(
         # Create .pivot but don't add any entries
         pivot_dir = pathlib.Path(".pivot")
         pivot_dir.mkdir()
-        db_path = pivot_dir / "state.db"
+        db_path = pivot_dir
 
         # Initialize empty StateDB
         with state.StateDB(db_path, readonly=False):

--- a/packages/pivot/tests/conftest.py
+++ b/packages/pivot/tests/conftest.py
@@ -544,7 +544,6 @@ def minimal_pipeline(
 
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
-    monkeypatch.setattr(config, "get_state_db_path", lambda: tmp_path / "state" / "state.db")
     monkeypatch.chdir(tmp_path)
 
     (tmp_path / ".pivot").mkdir(exist_ok=True)

--- a/packages/pivot/tests/core/test_explain.py
+++ b/packages/pivot/tests/core/test_explain.py
@@ -349,6 +349,32 @@ def test_get_stage_explanation_unchanged(tmp_path: Path) -> None:
     assert result["dep_changes"] == []
 
 
+def test_get_stage_explanation_without_state_db_has_no_side_effects(tmp_path: Path) -> None:
+    """Does not create state.lmdb when explain falls back to hash-based checks."""
+    stage_lock = lock.StageLock("unchanged_stage", tmp_path / "stages")
+    stage_lock.write(
+        LockData(
+            code_manifest={"self:unchanged_stage": "abc123"},
+            params={},
+            dep_hashes={},
+            output_hashes={},
+        )
+    )
+
+    result = explain.get_stage_explanation(
+        stage_name="unchanged_stage",
+        fingerprint={"self:unchanged_stage": "abc123"},
+        deps=[],
+        outs_paths=[],
+        params_instance=None,
+        overrides=None,
+        state_dir=tmp_path,
+    )
+
+    assert result["will_run"] is False
+    assert not (tmp_path / "state.lmdb").exists(), "explain should not create state.lmdb"
+
+
 def test_get_stage_explanation_code_changed(tmp_path: Path) -> None:
     """Returns detailed code changes when code differs."""
     stage_lock = lock.StageLock("code_stage", tmp_path / "stages")

--- a/packages/pivot/tests/engine/test_engine.py
+++ b/packages/pivot/tests/engine/test_engine.py
@@ -1182,7 +1182,7 @@ async def test_coordinator_skip_avoids_worker_dispatch(
         stage_info["params"], "skip_stage", parameters.ParamsOverrides()
     )
 
-    with state_mod.StateDB(state_dir / "state.db") as state_db:
+    with state_mod.StateDB(state_dir) as state_db:
         dep_hash, _ = cache.hash_file(input_path, state_db)
         out_hash, _ = cache.hash_file(output_path, state_db)
 
@@ -1262,7 +1262,7 @@ async def test_all_cached_pipeline_skips_without_workers(
         stage_info["params"], "cached_stage", parameters.ParamsOverrides()
     )
 
-    with state_mod.StateDB(state_dir / "state.db") as state_db:
+    with state_mod.StateDB(state_dir) as state_db:
         dep_hash, _ = cache.hash_file(input_path, state_db)
         out_hash, _ = cache.hash_file(output_path, state_db)
 
@@ -1394,7 +1394,7 @@ async def test_coordinator_tier2_skip_when_generation_unavailable(
     # Write lock data and file hashes — but do NOT record dep generations.
     # This makes Tier 1 (can_skip_via_generation) return False,
     # forcing the code through Tier 2 (skip.check_stage).
-    with state_mod.StateDB(state_dir / "state.db") as state_db:
+    with state_mod.StateDB(state_dir) as state_db:
         dep_hash, _ = cache.hash_file(input_path, state_db)
         out_hash, _ = cache.hash_file(output_path, state_db)
 

--- a/packages/pivot/tests/engine/test_run_history.py
+++ b/packages/pivot/tests/engine/test_run_history.py
@@ -47,7 +47,7 @@ async def test_engine_writes_run_history(
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
-    monkeypatch.setattr(config, "get_state_db_path", lambda: state_dir / "state.db")
+    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # Run the stage
     collector = sinks.ResultCollectorSink()
@@ -66,7 +66,7 @@ async def test_engine_writes_run_history(
     assert registered_stage in results
 
     # Verify run history was written
-    with state_mod.StateDB(state_dir / "state.db") as state_db:
+    with state_mod.StateDB(state_dir) as state_db:
         runs = state_db.list_runs(limit=1)
 
     assert len(runs) >= 1
@@ -89,7 +89,7 @@ async def test_engine_run_history_contains_stage_records(
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
-    monkeypatch.setattr(config, "get_state_db_path", lambda: state_dir / "state.db")
+    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # Run the stage
     collector = sinks.ResultCollectorSink()
@@ -105,7 +105,7 @@ async def test_engine_run_history_contains_stage_records(
     await test_engine.run(exit_on_completion=True)
 
     # Verify run history contains stage record
-    with state_mod.StateDB(state_dir / "state.db") as state_db:
+    with state_mod.StateDB(state_dir) as state_db:
         runs = state_db.list_runs(limit=1)
 
     assert len(runs) >= 1
@@ -133,7 +133,7 @@ async def test_engine_writes_run_cache_entry(
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
-    monkeypatch.setattr(config, "get_state_db_path", lambda: state_dir / "state.db")
+    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # First run - executes the stage
     async with Engine(pipeline=test_pipeline) as engine1:

--- a/packages/pivot/tests/engine/test_run_history.py
+++ b/packages/pivot/tests/engine/test_run_history.py
@@ -47,7 +47,6 @@ async def test_engine_writes_run_history(
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
-    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # Run the stage
     collector = sinks.ResultCollectorSink()
@@ -88,7 +87,6 @@ async def test_engine_run_history_contains_stage_records(
     cache_dir = tmp_path / "cache"
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # Run the stage
@@ -132,7 +130,6 @@ async def test_engine_writes_run_cache_entry(
     cache_dir = tmp_path / "cache"
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "get_cache_dir", lambda: cache_dir)
-    monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
     monkeypatch.setattr(config, "get_state_dir", lambda: state_dir)
 
     # First run - executes the stage

--- a/packages/pivot/tests/execution/test_execution_modes.py
+++ b/packages/pivot/tests/execution/test_execution_modes.py
@@ -209,7 +209,7 @@ def test_run_cache_restores_directory_output(
 
     # Apply deferred writes (simulating what coordinator does)
     assert "deferred_writes" in result1, "Should have deferred writes for directory output"
-    state_db_path = worker_env.parent / "state.db"
+    state_db_path = worker_env.parent
     output_paths = [str(out.path) for out in stage_info["outs"]]
     with state.StateDB(state_db_path) as db:
         db.apply_deferred_writes("test_stage", output_paths, result1["deferred_writes"])
@@ -282,7 +282,7 @@ def test_run_cache_reruns_when_noncached_output_missing(
     # Apply deferred writes (simulating what coordinator does)
     # With a cached output, deferred_writes MUST contain a run cache entry
     assert "deferred_writes" in result1, "Should have deferred writes with cached output"
-    state_db_path = worker_env.parent / "state.db"
+    state_db_path = worker_env.parent
     output_paths: list[str] = [str(out.path) for out in stage_info["outs"]]
     with state.StateDB(state_db_path) as db:
         db.apply_deferred_writes("test_stage", output_paths, result1["deferred_writes"])

--- a/packages/pivot/tests/execution/test_executor.py
+++ b/packages/pivot/tests/execution/test_executor.py
@@ -1906,7 +1906,7 @@ def test_executor_deferred_writes_applied(
     assert results["process"]["status"] == "ran"
 
     # Verify StateDB has output generation incremented
-    db_path = pipeline_dir / ".pivot" / "state.db"
+    db_path = pipeline_dir / ".pivot"
     with state.StateDB(db_path, readonly=True) as db:
         output_path = pipeline_dir / "output.txt"
         output_gen = db.get_generation(output_path)
@@ -1937,7 +1937,7 @@ def test_executor_multi_stage_generation_tracking(
     assert results["step1"]["status"] == "ran"
     assert results["step2"]["status"] == "ran"
 
-    db_path = pipeline_dir / ".pivot" / "state.db"
+    db_path = pipeline_dir / ".pivot"
     with state.StateDB(db_path, readonly=True) as db:
         step1_gen = db.get_generation(pipeline_dir / "step1.txt")
         step2_gen = db.get_generation(pipeline_dir / "step2.txt")

--- a/packages/pivot/tests/execution/test_executor_worker.py
+++ b/packages/pivot/tests/execution/test_executor_worker.py
@@ -186,7 +186,7 @@ def test_execute_stage_generation_skip_avoids_hashing(
 
     state_dir = tmp_path / ".pivot"
     with _chdir_and_reset_project_root(tmp_path):
-        with state.StateDB(state_dir / "state.db") as state_db:
+        with state.StateDB(state_dir) as state_db:
             dep_hash, _ = cache.hash_file(dep_path, state_db)
             state_db.increment_generation(dep_path)
             dep_gen = state_db.get_generation(dep_path)
@@ -232,7 +232,7 @@ def test_execute_stage_hashes_when_generation_missing(
 
     state_dir = tmp_path / ".pivot"
     with _chdir_and_reset_project_root(tmp_path):
-        with state.StateDB(state_dir / "state.db") as state_db:
+        with state.StateDB(state_dir) as state_db:
             dep_hash, _ = cache.hash_file(dep_path, state_db)
             normalized_dep = str(project.normalize_path("input.txt"))
             state_db.record_dep_generations(stage_name, {normalized_dep: 1})
@@ -1946,7 +1946,7 @@ def test_file_needs_restore_uses_state_db(tmp_path: pathlib.Path) -> None:
     """_file_needs_restore accepts state_db parameter for hash caching."""
     file_path = tmp_path / "output.txt"
     file_path.write_text("content")
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         file_hash, _ = cache.hash_file(file_path, db)
@@ -2038,7 +2038,7 @@ def test_run_cache_skip_with_directory_out(
     # Manually write the run cache entry (normally done by coordinator)
     deferred = result1.get("deferred_writes", {})
     if "run_cache_input_hash" in deferred and "run_cache_entry" in deferred:
-        state_db = state.StateDB(tmp_path / ".pivot" / "state.db")
+        state_db = state.StateDB(tmp_path / ".pivot")
         state_db.write_run_cache(
             "test_run_cache_dir", deferred["run_cache_input_hash"], deferred["run_cache_entry"]
         )
@@ -2093,7 +2093,7 @@ def test_run_cache_skip_restores_corrupted_directory(
     # Manually write the run cache entry (normally done by coordinator)
     deferred = result1.get("deferred_writes", {})
     if "run_cache_input_hash" in deferred and "run_cache_entry" in deferred:
-        state_db = state.StateDB(tmp_path / ".pivot" / "state.db")
+        state_db = state.StateDB(tmp_path / ".pivot")
         state_db.write_run_cache(
             "test_run_cache_corrupt", deferred["run_cache_input_hash"], deferred["run_cache_entry"]
         )
@@ -2209,7 +2209,7 @@ def test_try_skip_via_run_cache_returns_none_for_incremental_out(
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    state_db = state.StateDB(state_dir / "state.db")
+    state_db = state.StateDB(state_dir)
 
     incremental_out = outputs.IncrementalOut("output.txt", loaders.PathOnly())
 
@@ -2234,7 +2234,7 @@ def test_try_skip_via_run_cache_returns_none_when_no_entry(
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    state_db = state.StateDB(state_dir / "state.db")
+    state_db = state.StateDB(state_dir)
 
     out = outputs.Out(str(tmp_path / "output.txt"), loaders.PathOnly())
 
@@ -2599,7 +2599,7 @@ def test_build_deferred_writes_excludes_noncached_from_run_cache(
     """
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    state_db = state.StateDB(state_dir / "state.db")
+    state_db = state.StateDB(state_dir)
 
     out = outputs.Out("output.txt", loader=loaders.PathOnly())
     metric = outputs.Metric("metrics.json")
@@ -2639,7 +2639,7 @@ def test_build_deferred_writes_no_run_cache_when_all_noncached(
     """
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    state_db = state.StateDB(state_dir / "state.db")
+    state_db = state.StateDB(state_dir)
 
     metric1 = outputs.Metric("metrics1.json")
     metric2 = outputs.Metric("metrics2.json")
@@ -2697,7 +2697,7 @@ def test_run_cache_skip_with_mixed_cached_and_noncached_outputs(
     # Apply deferred writes (run cache entry) to state DB
     deferred = result1.get("deferred_writes", {})
     if "run_cache_input_hash" in deferred and "run_cache_entry" in deferred:
-        with state.StateDB(tmp_path / ".pivot" / "state.db") as state_db:
+        with state.StateDB(tmp_path / ".pivot") as state_db:
             state_db.write_run_cache(
                 "test_mixed_rc", deferred["run_cache_input_hash"], deferred["run_cache_entry"]
             )
@@ -2750,7 +2750,7 @@ def test_build_deferred_writes_sets_increment_outputs_true_by_default(
         "output.txt": FileHash(hash="abc123"),
     }
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(state_dir) as state_db:
         result = worker._build_deferred_writes(stage_info, "input_hash_1", output_hashes, state_db)
 
     assert "increment_outputs" in result
@@ -2781,7 +2781,7 @@ def test_build_deferred_writes_omits_increment_outputs_when_false(
         "output.txt": FileHash(hash="abc123"),
     }
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(state_dir) as state_db:
         result = worker._build_deferred_writes(
             stage_info, "input_hash_1", output_hashes, state_db, increment_outputs=False
         )

--- a/packages/pivot/tests/fingerprint/test_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_fingerprint.py
@@ -2026,7 +2026,7 @@ def test_persistent_cache_full_roundtrip(tmp_path, monkeypatch):
     # Set up isolated state directory
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Create initial StateDB so fingerprint module can open it in readonly mode
     with state.StateDB(db_path):
@@ -2034,7 +2034,7 @@ def test_persistent_cache_full_roundtrip(tmp_path, monkeypatch):
 
     # Patch project root and state db path
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     # Reset fingerprint module state
     fingerprint._pending_ast_writes.clear()
@@ -2135,8 +2135,8 @@ def test_graceful_degradation_when_statedb_unavailable(tmp_path, monkeypatch):
     # Patch to simulate StateDB unavailable (init throws)
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
     monkeypatch.setattr(
-        "pivot.config.io.get_state_db_path",
-        lambda: tmp_path / "nonexistent" / "deeply" / "nested" / "state.db",
+        "pivot.config.io.get_state_dir",
+        lambda: tmp_path / "nonexistent" / "deeply" / "nested",
     )
 
     # Reset fingerprint module state
@@ -2185,13 +2185,13 @@ def test_flush_ast_hash_cache_writes_to_statedb(tmp_path, monkeypatch):
     # Set up isolated state directory
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Create initial StateDB
     with state.StateDB(db_path) as db:
         pass
 
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     # Reset fingerprint module state
     fingerprint._pending_ast_writes.clear()
@@ -2389,12 +2389,12 @@ def test_manifest_cache_hit(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     # Reset fingerprint state
     fingerprint._pending_ast_writes.clear()
@@ -2451,12 +2451,12 @@ def test_manifest_cache_miss_on_source_change(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._pending_ast_writes.clear()
     fingerprint._pending_manifest_writes.clear()
@@ -2523,12 +2523,12 @@ def test_manifest_cache_miss_on_file_deleted(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._pending_ast_writes.clear()
     fingerprint._pending_manifest_writes.clear()
@@ -2594,12 +2594,12 @@ def test_manifest_cache_non_file_backed_function(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._pending_ast_writes.clear()
     fingerprint._pending_manifest_writes.clear()
@@ -2671,8 +2671,8 @@ def test_flush_manifest_cache_failure_restores_pending(tmp_path, monkeypatch):
     blocker = tmp_path / "blocker"
     blocker.write_text("not a directory")
     monkeypatch.setattr(
-        "pivot.config.io.get_state_db_path",
-        lambda: blocker / "subdir" / "state.db",
+        "pivot.config.io.get_state_dir",
+        lambda: blocker / "subdir",
     )
 
     # Queue some entries
@@ -2697,7 +2697,7 @@ def test_try_manifest_cache_hit_corrupted_json(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Write corrupted data directly into the db
     with state_mod.StateDB(db_path) as db:
@@ -2705,7 +2705,7 @@ def test_try_manifest_cache_hit_corrupted_json(tmp_path, monkeypatch):
         db.put_raw(key, b"NOT VALID JSON {{{")
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2826,14 +2826,14 @@ def test_try_manifest_cache_hit_non_dict_json(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     with state_mod.StateDB(db_path) as db:
         key = fingerprint._make_manifest_cache_key("list_stage")
         db.put_raw(key, b"[1, 2, 3]")  # Valid JSON, but not a dict
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2854,14 +2854,14 @@ def test_try_manifest_cache_hit_missing_m_or_s_keys(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     with state_mod.StateDB(db_path) as db:
         key = fingerprint._make_manifest_cache_key("missing_keys")
         db.put_raw(key, b'{"m": {"self:x": "hash"}}')  # Missing "s" key
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2882,14 +2882,14 @@ def test_try_manifest_cache_hit_empty_sources_forces_recompute(tmp_path, monkeyp
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     with state_mod.StateDB(db_path) as db:
         key = fingerprint._make_manifest_cache_key("empty_sources")
         db.put_raw(key, b'{"m":{"self:x":"hash"},"s":{}}')
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2910,7 +2910,7 @@ def test_try_manifest_cache_hit_corrupted_stats_length(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Source file exists but stats array has only 2 elements instead of 3
     src_file = tmp_path / "stage.py"
@@ -2921,7 +2921,7 @@ def test_try_manifest_cache_hit_corrupted_stats_length(tmp_path, monkeypatch):
         db.put_raw(key, b'{"m":{"self:stage":"hash"},"s":{"stage.py":[1000,200]}}')
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2942,7 +2942,7 @@ def test_try_manifest_cache_hit_path_traversal_blocked(tmp_path, monkeypatch):
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Test with absolute path
     with state_mod.StateDB(db_path) as db:
@@ -2950,7 +2950,7 @@ def test_try_manifest_cache_hit_path_traversal_blocked(tmp_path, monkeypatch):
         db.put_raw(key, b'{"m":{"self:x":"hash"},"s":{"/etc/passwd":[1000,200,555]}}')
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._state_db = None
     fingerprint._state_db_init_attempted = False
@@ -2995,7 +2995,7 @@ def test_manifest_cache_flush_persists_to_statedb(tmp_path, monkeypatch):
     # Set up isolated state directory
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
 
     # Create initial StateDB
     with state.StateDB(db_path):
@@ -3003,7 +3003,7 @@ def test_manifest_cache_flush_persists_to_statedb(tmp_path, monkeypatch):
 
     # Patch project root and state db path
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     # Reset fingerprint module state
     fingerprint._pending_manifest_writes.clear()
@@ -3061,12 +3061,12 @@ def test_invalidate_manifests_for_paths_selective(tmp_path, monkeypatch):
     """Invalidate only manifests referencing changed source files."""
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     key_a = fingerprint._make_manifest_cache_key("stage_a")
     key_b = fingerprint._make_manifest_cache_key("stage_b")
@@ -3107,12 +3107,12 @@ def test_invalidate_manifests_for_paths_cold_start(tmp_path, monkeypatch):
     """Invalidation is a no-op when no cached manifests exist."""
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint.invalidate_manifests_for_paths([tmp_path / "missing.py"])
 
@@ -3124,12 +3124,12 @@ def test_invalidate_manifests_for_paths_recomputes_affected_stage(tmp_path, monk
     """Invalidation forces a cache miss and re-cache for affected stages."""
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir()
-    db_path = state_dir / "state.db"
+    db_path = state_dir
     with state_mod.StateDB(db_path):
         pass
 
     monkeypatch.setattr("pivot.project._project_root_cache", tmp_path)
-    monkeypatch.setattr("pivot.config.io.get_state_db_path", lambda: db_path)
+    monkeypatch.setattr("pivot.config.io.get_state_dir", lambda: db_path)
 
     fingerprint._pending_manifest_writes.clear()
     fingerprint._hash_function_ast_cache.clear()

--- a/packages/pivot/tests/fingerprint/test_no_fingerprint.py
+++ b/packages/pivot/tests/fingerprint/test_no_fingerprint.py
@@ -95,7 +95,7 @@ def _apply_deferred_writes(
     state_dir = stage_info["state_dir"]
     out_paths = [str(out.path) for out in stage_info["outs"]]
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(state_dir) as state_db:
         state_db.apply_deferred_writes(stage_name, out_paths, deferred)
 
 

--- a/packages/pivot/tests/integration/test_lazy_resolution.py
+++ b/packages/pivot/tests/integration/test_lazy_resolution.py
@@ -139,7 +139,7 @@ def test_lazy_resolution_builds_complete_dag(set_project_root: pathlib.Path) -> 
 def test_lazy_resolution_preserves_parent_state_dir(set_project_root: pathlib.Path) -> None:
     """Included parent stages should retain their original state_dir.
 
-    Critical for correctness: lock files and state.db must remain in parent's
+    Critical for correctness: lock files and state database must remain in parent's
     .pivot directory, not child's, to avoid conflicts and enable proper
     incremental builds.
     """

--- a/packages/pivot/tests/integration/test_unified_execution.py
+++ b/packages/pivot/tests/integration/test_unified_execution.py
@@ -50,7 +50,6 @@ def minimal_pipeline(
 
     monkeypatch.setattr(config, "get_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(config, "get_state_dir", lambda: tmp_path / "state")
-    monkeypatch.setattr(config, "get_state_db_path", lambda: tmp_path / "state" / "state.db")
     monkeypatch.chdir(tmp_path)
 
     # Create .pivot directory (required for project root detection)

--- a/packages/pivot/tests/pipeline/test_pipeline.py
+++ b/packages/pivot/tests/pipeline/test_pipeline.py
@@ -352,7 +352,7 @@ def test_pipeline_include_preserves_state_dir_transitively(set_project_root: pat
     """Transitive inclusion should preserve original state_dir through multiple levels.
 
     When A includes B and B includes C, C's stages in A should retain C's state_dir.
-    Critical for ensuring lock files and state.db remain in correct locations.
+    Critical for ensuring lock files and state database remain in correct locations.
     """
     # Level 1: Base pipeline
     base = Pipeline("base", root=set_project_root / "base")

--- a/packages/pivot/tests/remote/test_transfer.py
+++ b/packages/pivot/tests/remote/test_transfer.py
@@ -723,7 +723,7 @@ async def test_push_async_integration(
     cache_path2.write_bytes(b"content2")
 
     state_dir.mkdir(parents=True, exist_ok=True)
-    state_db = state_mod.StateDB(state_dir / "state.db")
+    state_db = state_mod.StateDB(state_dir)
 
     await transfer._push_async(cache_dir, state_dir, s3_remote, state_db, "origin")
 
@@ -754,7 +754,7 @@ async def test_pull_async_integration(
     cache_dir = state_dir / "cache"
     cache_dir.mkdir(parents=True)
 
-    state_db = state_mod.StateDB(state_dir / "state.db")
+    state_db = state_mod.StateDB(state_dir)
 
     await transfer._pull_async(cache_dir, state_dir, s3_remote, state_db, "origin")
 
@@ -781,14 +781,14 @@ async def test_push_pull_roundtrip_integration(
     cache_path1.parent.mkdir(parents=True, exist_ok=True)
     cache_path1.write_bytes(b"original")
 
-    state_db1 = state_mod.StateDB(state_dir1 / "state.db")
+    state_db1 = state_mod.StateDB(state_dir1)
 
     await transfer._push_async(cache_dir1, state_dir1, s3_remote, state_db1, "origin")
 
     state_dir2 = tmp_path / ".pivot2"
     cache_dir2 = state_dir2 / "cache"
     cache_dir2.mkdir(parents=True)
-    state_db2 = state_mod.StateDB(state_dir2 / "state.db")
+    state_db2 = state_mod.StateDB(state_dir2)
 
     await transfer._pull_async(cache_dir2, state_dir2, s3_remote, state_db2, "origin")
 
@@ -820,7 +820,7 @@ async def test_compare_status_integration(
 
     state_dir = tmp_path / ".pivot"
     state_dir.mkdir(parents=True, exist_ok=True)
-    state_db = state_mod.StateDB(state_dir / "state.db")
+    state_db = state_mod.StateDB(state_dir)
 
     status = await transfer.compare_status(
         {hash_common, hash_local_only},
@@ -869,7 +869,7 @@ async def test_pull_async_with_deps_integration(
     with lock_path.open("w") as f:
         yaml.dump(lock_data, f)
 
-    state_db = state_mod.StateDB(state_dir / "state.db")
+    state_db = state_mod.StateDB(state_dir)
 
     await transfer._pull_async(
         cache_dir,

--- a/packages/pivot/tests/storage/test_cache.py
+++ b/packages/pivot/tests/storage/test_cache.py
@@ -89,7 +89,7 @@ def test_hash_file_uses_state_cache(tmp_path: pathlib.Path) -> None:
     """hash_file uses state cache to skip rehashing."""
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         cache.hash_file(test_file, state_db=db)  # First hash populates cache
@@ -341,7 +341,7 @@ def test_hash_file_state_cache_invalidation(tmp_path: pathlib.Path) -> None:
     """State cache correctly invalidates when file mtime or size changes."""
     test_file = tmp_path / "file.txt"
     test_file.write_text("original")
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # First hash - cache miss

--- a/packages/pivot/tests/storage/test_state.py
+++ b/packages/pivot/tests/storage/test_state.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def test_state_cache_hit(tmp_path: pathlib.Path) -> None:
     """Unchanged mtime/size/inode returns cached hash."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -31,7 +31,7 @@ def test_state_cache_hit(tmp_path: pathlib.Path) -> None:
 
 def test_state_cache_miss_mtime(tmp_path: pathlib.Path) -> None:
     """Changed mtime triggers cache miss."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     old_stat = test_file.stat()
@@ -50,7 +50,7 @@ def test_state_cache_miss_mtime(tmp_path: pathlib.Path) -> None:
 
 def test_state_cache_miss_size(tmp_path: pathlib.Path) -> None:
     """Changed size triggers cache miss."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("short")
     old_stat = test_file.stat()
@@ -69,7 +69,7 @@ def test_state_cache_miss_size(tmp_path: pathlib.Path) -> None:
 
 def test_state_cache_miss_inode(tmp_path: pathlib.Path) -> None:
     """Changed inode triggers cache miss."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     old_stat = test_file.stat()
@@ -96,7 +96,7 @@ def test_state_cache_miss_inode(tmp_path: pathlib.Path) -> None:
 
 def test_state_save_many(tmp_path: pathlib.Path) -> None:
     """Batch save works correctly."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     files = list[tuple[pathlib.Path, os.stat_result]]()
     entries = list[tuple[pathlib.Path, os.stat_result, str]]()
 
@@ -117,7 +117,7 @@ def test_state_save_many(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_persistence(tmp_path: pathlib.Path) -> None:
     """State survives process restart (new instance)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -133,7 +133,7 @@ def test_state_db_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_state_get_missing_path(tmp_path: pathlib.Path) -> None:
     """Getting uncached path returns None."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -146,7 +146,7 @@ def test_state_get_missing_path(tmp_path: pathlib.Path) -> None:
 
 def test_state_update_existing(tmp_path: pathlib.Path) -> None:
     """Saving same path updates the cached hash."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -161,22 +161,21 @@ def test_state_update_existing(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_creates_parent_dirs(tmp_path: pathlib.Path) -> None:
     """StateDB creates parent directories if needed."""
-    db_path = tmp_path / "nested" / "deep" / "state.db"
+    state_dir = tmp_path / "nested" / "deep"
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
 
-    with state.StateDB(db_path) as db:
+    with state.StateDB(state_dir) as db:
         db.save(test_file, file_stat, "hash")
 
-    # LMDB creates a directory (state.lmdb/) not a file (state.db)
-    lmdb_path = db_path.parent / "state.lmdb"
+    lmdb_path = state_dir / "state.lmdb"
     assert lmdb_path.is_dir()
 
 
 def test_state_close(tmp_path: pathlib.Path) -> None:
     """StateDB can be closed and reopened."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -193,7 +192,7 @@ def test_state_close(tmp_path: pathlib.Path) -> None:
 
 def test_state_context_manager(tmp_path: pathlib.Path) -> None:
     """StateDB works as context manager."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -209,7 +208,7 @@ def test_state_context_manager(tmp_path: pathlib.Path) -> None:
 
 def test_state_absolute_paths(tmp_path: pathlib.Path) -> None:
     """Paths are stored as absolute for consistency."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -223,7 +222,7 @@ def test_state_absolute_paths(tmp_path: pathlib.Path) -> None:
 
 def test_state_get_many(tmp_path: pathlib.Path) -> None:
     """Batch get returns correct hashes for multiple files."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     files = list[tuple[pathlib.Path, os.stat_result]]()
     entries = list[tuple[pathlib.Path, os.stat_result, str]]()
 
@@ -244,7 +243,7 @@ def test_state_get_many(tmp_path: pathlib.Path) -> None:
 
 def test_state_get_many_mixed(tmp_path: pathlib.Path) -> None:
     """Batch get handles mix of cached and uncached files."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     # Create cached file
     cached = tmp_path / "cached.txt"
@@ -266,7 +265,7 @@ def test_state_get_many_mixed(tmp_path: pathlib.Path) -> None:
 
 def test_state_get_many_empty(tmp_path: pathlib.Path) -> None:
     """Batch get with empty list returns empty dict."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         results = db.get_many([])
@@ -276,7 +275,7 @@ def test_state_get_many_empty(tmp_path: pathlib.Path) -> None:
 
 def test_state_path_too_long_error(tmp_path: pathlib.Path) -> None:
     """PathTooLongError raised for paths exceeding LMDB key limit."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     # Create a deeply nested path that exceeds 511 bytes when encoded
     # Each segment is 50 chars, need ~10 segments to exceed limit
     nested = tmp_path
@@ -296,7 +295,7 @@ def test_state_path_too_long_error(tmp_path: pathlib.Path) -> None:
 
 def test_state_path_too_long_error_save_many(tmp_path: pathlib.Path) -> None:
     """PathTooLongError raised in save_many for paths exceeding limit."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     nested = tmp_path
     for i in range(12):
         nested = nested / ("e" * 50 + str(i))
@@ -311,7 +310,7 @@ def test_state_path_too_long_error_save_many(tmp_path: pathlib.Path) -> None:
 
 def test_state_raises_after_close(tmp_path: pathlib.Path) -> None:
     """Operations on closed StateDB raise RuntimeError."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -330,7 +329,7 @@ def test_state_raises_after_close(tmp_path: pathlib.Path) -> None:
 
 def test_generation_get_nonexistent(tmp_path: pathlib.Path) -> None:
     """Getting generation for untracked path returns None."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "output.txt"
 
     with state.StateDB(db_path) as db:
@@ -341,7 +340,7 @@ def test_generation_get_nonexistent(tmp_path: pathlib.Path) -> None:
 
 def test_generation_increment_creates_new(tmp_path: pathlib.Path) -> None:
     """Incrementing untracked path creates it with generation 1."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "output.txt"
 
     with state.StateDB(db_path) as db:
@@ -352,7 +351,7 @@ def test_generation_increment_creates_new(tmp_path: pathlib.Path) -> None:
 
 def test_generation_increment_existing(tmp_path: pathlib.Path) -> None:
     """Incrementing tracked path increases generation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "output.txt"
 
     with state.StateDB(db_path) as db:
@@ -365,7 +364,7 @@ def test_generation_increment_existing(tmp_path: pathlib.Path) -> None:
 
 def test_generation_persistence(tmp_path: pathlib.Path) -> None:
     """Generations persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "output.txt"
 
     with state.StateDB(db_path) as db:
@@ -380,7 +379,7 @@ def test_generation_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_generation_get_many(tmp_path: pathlib.Path) -> None:
     """Batch query returns generations for multiple paths."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     files = [tmp_path / f"file_{i}.txt" for i in range(3)]
 
     with state.StateDB(db_path) as db:
@@ -398,7 +397,7 @@ def test_generation_get_many(tmp_path: pathlib.Path) -> None:
 
 def test_generation_get_many_empty(tmp_path: pathlib.Path) -> None:
     """Batch query with empty list returns empty dict."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         results = db.get_many_generations([])
@@ -408,7 +407,7 @@ def test_generation_get_many_empty(tmp_path: pathlib.Path) -> None:
 
 def test_dep_generations_get_nonexistent(tmp_path: pathlib.Path) -> None:
     """Getting dep generations for unknown stage returns None."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         result = db.get_dep_generations("unknown_stage")
@@ -418,7 +417,7 @@ def test_dep_generations_get_nonexistent(tmp_path: pathlib.Path) -> None:
 
 def test_dep_generations_record_and_get(tmp_path: pathlib.Path) -> None:
     """Record and retrieve dependency generations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     deps = {"/path/to/dep1.csv": 5, "/path/to/dep2.csv": 3}
 
     with state.StateDB(db_path) as db:
@@ -430,7 +429,7 @@ def test_dep_generations_record_and_get(tmp_path: pathlib.Path) -> None:
 
 def test_dep_generations_update_replaces(tmp_path: pathlib.Path) -> None:
     """Recording dep generations replaces previous values."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     old_deps = {"/path/to/dep1.csv": 1, "/path/to/dep2.csv": 2}
     new_deps = {"/path/to/dep1.csv": 5, "/path/to/dep3.csv": 1}
 
@@ -444,7 +443,7 @@ def test_dep_generations_update_replaces(tmp_path: pathlib.Path) -> None:
 
 def test_dep_generations_multiple_stages(tmp_path: pathlib.Path) -> None:
     """Different stages have independent dep generations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     stage1_deps = {"/dep1.csv": 1}
     stage2_deps = {"/dep2.csv": 2, "/dep3.csv": 3}
 
@@ -461,7 +460,7 @@ def test_dep_generations_multiple_stages(tmp_path: pathlib.Path) -> None:
 
 def test_dep_generations_persistence(tmp_path: pathlib.Path) -> None:
     """Dep generations persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     deps = {"/path/to/dep.csv": 42}
 
     with state.StateDB(db_path) as db:
@@ -485,7 +484,7 @@ def test_generation_tracks_logical_path_not_symlink_target(tmp_path: pathlib.Pat
     If we resolved symlinks, the generation key would change every time the file's
     hash changes (different cache path). We need to track the DECLARED path.
     """
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     real_dir = tmp_path / "real_data"
     real_dir.mkdir()
     output_file = real_dir / "output.csv"
@@ -519,7 +518,7 @@ def test_generation_tracks_logical_path_not_symlink_target(tmp_path: pathlib.Pat
 
 def test_remote_hash_exists_false(tmp_path: pathlib.Path) -> None:
     """Unknown hash returns False."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         result = db.remote_hash_exists("origin", "abc123def456")
@@ -529,7 +528,7 @@ def test_remote_hash_exists_false(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hash_exists_true(tmp_path: pathlib.Path) -> None:
     """Added hash returns True."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["abc123def456"])
@@ -540,7 +539,7 @@ def test_remote_hash_exists_true(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_add_multiple(tmp_path: pathlib.Path) -> None:
     """Multiple hashes can be added at once."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     hashes = ["hash1", "hash2", "hash3"]
 
     with state.StateDB(db_path) as db:
@@ -552,7 +551,7 @@ def test_remote_hashes_add_multiple(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_intersection(tmp_path: pathlib.Path) -> None:
     """Intersection returns only hashes known to exist on remote."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     known = {"hash1", "hash2", "hash3"}
     query = {"hash1", "hash3", "hash4", "hash5"}
 
@@ -565,7 +564,7 @@ def test_remote_hashes_intersection(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_intersection_empty_query(tmp_path: pathlib.Path) -> None:
     """Empty query returns empty set."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1", "hash2"])
@@ -576,7 +575,7 @@ def test_remote_hashes_intersection_empty_query(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_intersection_no_matches(tmp_path: pathlib.Path) -> None:
     """No matches returns empty set."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1", "hash2"])
@@ -587,7 +586,7 @@ def test_remote_hashes_intersection_no_matches(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_remove(tmp_path: pathlib.Path) -> None:
     """Removed hashes no longer exist."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1", "hash2", "hash3"])
@@ -600,7 +599,7 @@ def test_remote_hashes_remove(tmp_path: pathlib.Path) -> None:
 
 def test_remote_index_clear(tmp_path: pathlib.Path) -> None:
     """Clear removes all hashes for a remote."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1", "hash2"])
@@ -616,7 +615,7 @@ def test_remote_index_clear(tmp_path: pathlib.Path) -> None:
 
 def test_remote_hashes_different_remotes_independent(tmp_path: pathlib.Path) -> None:
     """Different remotes have independent hash indexes."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1"])
@@ -630,7 +629,7 @@ def test_remote_hashes_different_remotes_independent(tmp_path: pathlib.Path) -> 
 
 def test_remote_hashes_persistence(tmp_path: pathlib.Path) -> None:
     """Remote hashes persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["persistent_hash"])
@@ -641,7 +640,7 @@ def test_remote_hashes_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_remote_get_url_returns_none_for_unknown(tmp_path: pathlib.Path) -> None:
     """remote_get_url returns None for untracked remote."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         result = db.remote_get_url("unknown")
@@ -651,7 +650,7 @@ def test_remote_get_url_returns_none_for_unknown(tmp_path: pathlib.Path) -> None
 
 def test_remote_set_url_and_get_url_roundtrip(tmp_path: pathlib.Path) -> None:
     """remote_set_url stores URL and remote_get_url retrieves it."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_url = "s3://my-bucket/prefix"
 
     with state.StateDB(db_path) as db:
@@ -663,7 +662,7 @@ def test_remote_set_url_and_get_url_roundtrip(tmp_path: pathlib.Path) -> None:
 
 def test_remote_set_url_overwrites_existing(tmp_path: pathlib.Path) -> None:
     """remote_set_url overwrites previously stored URL."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_set_url("origin", "s3://old-bucket")
@@ -675,7 +674,7 @@ def test_remote_set_url_overwrites_existing(tmp_path: pathlib.Path) -> None:
 
 def test_remote_url_persistence(tmp_path: pathlib.Path) -> None:
     """Remote URLs persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_url = "s3://persistent-bucket/path"
 
     with state.StateDB(db_path) as db:
@@ -687,7 +686,7 @@ def test_remote_url_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_remote_index_clear_also_deletes_url(tmp_path: pathlib.Path) -> None:
     """remote_index_clear also deletes the remote URL entry."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_set_url("origin", "s3://bucket")
@@ -700,7 +699,7 @@ def test_remote_index_clear_also_deletes_url(tmp_path: pathlib.Path) -> None:
 
 def test_remote_urls_different_remotes_independent(tmp_path: pathlib.Path) -> None:
     """Different remotes have independent URL storage."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_set_url("origin", "s3://origin-bucket")
@@ -717,7 +716,7 @@ def test_remote_urls_different_remotes_independent(tmp_path: pathlib.Path) -> No
 
 def test_readonly_allows_reads(tmp_path: pathlib.Path) -> None:
     """Readonly mode allows all read operations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -739,7 +738,7 @@ def test_readonly_allows_reads(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_save(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks save operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -756,7 +755,7 @@ def test_readonly_blocks_save(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_save_many(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks save_many operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -773,7 +772,7 @@ def test_readonly_blocks_save_many(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_increment_generation(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks increment_generation operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "output.txt"
 
     with state.StateDB(db_path) as db:
@@ -788,7 +787,7 @@ def test_readonly_blocks_increment_generation(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_record_dep_generations(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks record_dep_generations operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Just create
@@ -802,7 +801,7 @@ def test_readonly_blocks_record_dep_generations(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_remote_hashes_add(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks remote_hashes_add operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Just create
@@ -816,7 +815,7 @@ def test_readonly_blocks_remote_hashes_add(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_remote_hashes_remove(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks remote_hashes_remove operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1"])
@@ -830,7 +829,7 @@ def test_readonly_blocks_remote_hashes_remove(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_remote_index_clear(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks remote_index_clear operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.remote_hashes_add("origin", ["hash1"])
@@ -844,7 +843,7 @@ def test_readonly_blocks_remote_index_clear(tmp_path: pathlib.Path) -> None:
 
 def test_readonly_blocks_remote_set_url(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks remote_set_url operation."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Just create
@@ -863,7 +862,7 @@ def test_readonly_blocks_remote_set_url(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_dep_generations(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes records dependency generations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     deferred: DeferredWrites = {"dep_generations": {"/path/dep1.csv": 5, "/path/dep2.csv": 3}}
 
     with state.StateDB(db_path) as db:
@@ -875,7 +874,7 @@ def test_apply_deferred_writes_dep_generations(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_output_generations(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes increments output generations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     output1 = tmp_path / "output1.csv"
     output2 = tmp_path / "output2.csv"
     deferred: DeferredWrites = {"increment_outputs": True}
@@ -896,7 +895,7 @@ def test_apply_deferred_writes_skips_output_increment_when_flag_absent(
     tmp_path: pathlib.Path,
 ) -> None:
     """Output generations should NOT be incremented when increment_outputs is absent."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     output1 = tmp_path / "output1.csv"
     deferred: DeferredWrites = {"dep_generations": {"/dep.csv": 5}}
 
@@ -908,7 +907,7 @@ def test_apply_deferred_writes_skips_output_increment_when_flag_absent(
 
 def test_apply_deferred_writes_file_hash_entries(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes stores file hash entries."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     file_path = tmp_path / "input.txt"
     file_path.write_text("data")
     file_stat = file_path.stat()
@@ -934,7 +933,7 @@ def test_apply_deferred_writes_file_hash_entries(tmp_path: pathlib.Path) -> None
 
 def test_apply_deferred_writes_run_cache(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes writes run cache entry."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     run_cache_entry = run_history.RunCacheEntry(
         run_id="test_run_123",
         output_hashes=[run_history.OutputHashEntry(path="/output.csv", hash="abc123")],
@@ -956,7 +955,7 @@ def test_apply_deferred_writes_run_cache(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_all_fields(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes handles all fields atomically."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     output_path = tmp_path / "output.csv"
     input_path = tmp_path / "input.csv"
     input_path.write_text("data")
@@ -996,7 +995,7 @@ def test_apply_deferred_writes_all_fields(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_empty(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes handles empty deferred dict."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     deferred: DeferredWrites = {}
 
     with state.StateDB(db_path) as db:
@@ -1006,7 +1005,7 @@ def test_apply_deferred_writes_empty(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_readonly_blocked(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes blocked in readonly mode."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Create database
@@ -1022,7 +1021,7 @@ def test_apply_deferred_writes_readonly_blocked(tmp_path: pathlib.Path) -> None:
 
 def test_apply_deferred_writes_path_too_long_dep(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes raises PathTooLongError for long dep paths."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     long_path = "/" + "d" * 600  # Exceeds 511 byte limit
     deferred: DeferredWrites = {"dep_generations": {long_path: 1}}
 
@@ -1032,7 +1031,7 @@ def test_apply_deferred_writes_path_too_long_dep(tmp_path: pathlib.Path) -> None
 
 def test_apply_deferred_writes_path_too_long_output(tmp_path: pathlib.Path) -> None:
     """apply_deferred_writes raises PathTooLongError for long output paths."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     # Create a deeply nested path that exceeds 511 bytes
     nested = tmp_path
     for i in range(12):
@@ -1055,7 +1054,7 @@ _TEST_SCHEMA_VERSION = 1
 
 def test_ast_hash_cache_roundtrip(tmp_path: pathlib.Path) -> None:
     """Save and retrieve AST hash."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1087,7 +1086,7 @@ def test_ast_hash_cache_roundtrip(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_miss_on_mtime_change(tmp_path: pathlib.Path) -> None:
     """Different mtime returns None (automatic invalidation)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1120,7 +1119,7 @@ def test_ast_hash_cache_miss_on_mtime_change(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_miss_on_size_change(tmp_path: pathlib.Path) -> None:
     """Different size returns None (automatic invalidation)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1153,7 +1152,7 @@ def test_ast_hash_cache_miss_on_size_change(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_miss_on_inode_change(tmp_path: pathlib.Path) -> None:
     """Different inode returns None (file replaced, even with same mtime)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1186,7 +1185,7 @@ def test_ast_hash_cache_miss_on_inode_change(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_miss_on_qualname_change(tmp_path: pathlib.Path) -> None:
     """Different qualname returns None (different function)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1219,7 +1218,7 @@ def test_ast_hash_cache_miss_on_qualname_change(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_miss_on_py_version_change(tmp_path: pathlib.Path) -> None:
     """Different Python version returns None (automatic invalidation)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1246,7 +1245,7 @@ def test_ast_hash_cache_miss_on_py_version_change(tmp_path: pathlib.Path) -> Non
 
 def test_ast_hash_cache_miss_on_schema_version_change(tmp_path: pathlib.Path) -> None:
     """Different schema version returns None (automatic invalidation)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1273,7 +1272,7 @@ def test_ast_hash_cache_miss_on_schema_version_change(tmp_path: pathlib.Path) ->
 
 def test_ast_hash_cache_persistence(tmp_path: pathlib.Path) -> None:
     """AST hashes persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1308,7 +1307,7 @@ def test_ast_hash_cache_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_multiple_functions(tmp_path: pathlib.Path) -> None:
     """Multiple functions in same file have independent hashes."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1386,7 +1385,7 @@ def test_ast_hash_cache_multiple_functions(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_update_existing(tmp_path: pathlib.Path) -> None:
     """Saving same key updates the cached hash."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1432,7 +1431,7 @@ def test_ast_hash_cache_update_existing(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_many(tmp_path: pathlib.Path) -> None:
     """Batch save works correctly."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     entries: list[tuple[str, int, int, int, str, str, int, str]] = [
         ("src/a.py", 1000, 100, 1, "func_a", _TEST_PY_VERSION, _TEST_SCHEMA_VERSION, "hash_a"),
         ("src/b.py", 2000, 200, 2, "func_b", _TEST_PY_VERSION, _TEST_SCHEMA_VERSION, "hash_b"),
@@ -1464,7 +1463,7 @@ def test_ast_hash_cache_many(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_many_empty(tmp_path: pathlib.Path) -> None:
     """Batch save with empty list doesn't error."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many([])  # Should not raise
@@ -1472,7 +1471,7 @@ def test_ast_hash_cache_many_empty(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_skips_long_keys(tmp_path: pathlib.Path) -> None:
     """Long keys are silently skipped (no error)."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     # Create a path long enough to exceed 511 bytes with prefix
     long_path = "a" * 600
 
@@ -1491,7 +1490,7 @@ def test_ast_hash_cache_skips_long_keys(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_skips_empty_rel_path(tmp_path: pathlib.Path) -> None:
     """Empty rel_path is silently skipped."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # Should not raise - silently skips invalid entries
@@ -1506,7 +1505,7 @@ def test_ast_hash_cache_skips_empty_rel_path(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_skips_empty_qualname(tmp_path: pathlib.Path) -> None:
     """Empty qualname is silently skipped."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # Should not raise - silently skips invalid entries
@@ -1523,7 +1522,7 @@ def test_ast_hash_cache_skips_empty_qualname(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_skips_null_byte_in_path(tmp_path: pathlib.Path) -> None:
     """Null byte in rel_path is silently skipped."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # Should not raise - silently skips invalid entries
@@ -1551,7 +1550,7 @@ def test_ast_hash_cache_skips_null_byte_in_path(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_skips_null_byte_in_qualname(tmp_path: pathlib.Path) -> None:
     """Null byte in qualname is silently skipped."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # Should not raise - silently skips invalid entries
@@ -1579,7 +1578,7 @@ def test_ast_hash_cache_skips_null_byte_in_qualname(tmp_path: pathlib.Path) -> N
 
 def test_ast_hash_cache_readonly_blocked(tmp_path: pathlib.Path) -> None:
     """Readonly mode blocks save operations."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Create database
@@ -1606,7 +1605,7 @@ def test_ast_hash_cache_readonly_blocked(tmp_path: pathlib.Path) -> None:
 
 def test_ast_hash_cache_readonly_allows_reads(tmp_path: pathlib.Path) -> None:
     """Readonly mode allows reading AST hashes."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1640,7 +1639,7 @@ def test_ast_hash_cache_readonly_allows_reads(tmp_path: pathlib.Path) -> None:
 
 def test_clear_ast_hashes_deletes_all_entries(tmp_path: pathlib.Path) -> None:
     """clear_ast_hashes removes all fp: prefixed entries."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         # Add multiple AST hash entries
@@ -1727,7 +1726,7 @@ def test_clear_ast_hashes_deletes_all_entries(tmp_path: pathlib.Path) -> None:
 
 def test_clear_ast_hashes_returns_zero_when_empty(tmp_path: pathlib.Path) -> None:
     """clear_ast_hashes returns 0 when no entries exist."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         deleted = db.clear_ast_hashes()
@@ -1737,7 +1736,7 @@ def test_clear_ast_hashes_returns_zero_when_empty(tmp_path: pathlib.Path) -> Non
 
 def test_clear_ast_hashes_only_deletes_fp_prefix(tmp_path: pathlib.Path) -> None:
     """clear_ast_hashes only deletes fp: prefixed entries, not other data."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -1764,7 +1763,7 @@ def test_clear_ast_hashes_only_deletes_fp_prefix(tmp_path: pathlib.Path) -> None
 
 def test_clear_ast_hashes_readonly_blocked(tmp_path: pathlib.Path) -> None:
     """clear_ast_hashes blocked in readonly mode."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.save_ast_hash_many(
@@ -1785,7 +1784,7 @@ def test_clear_ast_hashes_readonly_blocked(tmp_path: pathlib.Path) -> None:
 
 def test_stage_manifest_roundtrip(tmp_path: pathlib.Path) -> None:
     """Save and retrieve a stage manifest."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     key = "sm:my_stage\x003.13\x001"
     manifest = {"self:train": "aabb", "func:helper": "ccdd"}
     sources = {"src/train.py": [1000, 200, 555], "src/helper.py": [2000, 300, 666]}
@@ -1801,7 +1800,7 @@ def test_stage_manifest_roundtrip(tmp_path: pathlib.Path) -> None:
 
 def test_stage_manifest_not_found(tmp_path: pathlib.Path) -> None:
     """Returns None for unknown key."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     with state.StateDB(db_path) as db:
         result = db.get_raw(b"sm:nonexistent\x003.13\x001")
     assert result is None
@@ -1809,7 +1808,7 @@ def test_stage_manifest_not_found(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_readonly_blocked(tmp_path: pathlib.Path) -> None:
     """put_raw blocked in readonly mode."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Create database
@@ -1823,7 +1822,7 @@ def test_put_raw_readonly_blocked(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_many_readonly_blocked(tmp_path: pathlib.Path) -> None:
     """put_raw_many blocked in readonly mode."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         pass  # Create database
@@ -1837,7 +1836,7 @@ def test_put_raw_many_readonly_blocked(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_key_too_long(tmp_path: pathlib.Path) -> None:
     """put_raw raises PathTooLongError for oversized keys."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     long_key = b"k" * 512  # Exceeds 511 byte limit
 
     with state.StateDB(db_path) as db, pytest.raises(state.PathTooLongError):
@@ -1846,7 +1845,7 @@ def test_put_raw_key_too_long(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_many_skips_oversized_keys(tmp_path: pathlib.Path) -> None:
     """put_raw_many silently skips entries with oversized keys."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     long_key = b"k" * 512  # Exceeds 511 byte limit
     normal_key = b"sm:normal\x003.13\x001"
 
@@ -1865,7 +1864,7 @@ def test_put_raw_many_skips_oversized_keys(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_many_empty(tmp_path: pathlib.Path) -> None:
     """put_raw_many with empty list does not error."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     with state.StateDB(db_path) as db:
         db.put_raw_many([])  # Should not raise
@@ -1873,7 +1872,7 @@ def test_put_raw_many_empty(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_many_persistence(tmp_path: pathlib.Path) -> None:
     """put_raw_many entries persist across DB instances."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     entries = [
         (b"sm:stage_a\x003.13\x001", b'{"m":{"self:a":"hash_a"},"s":{}}'),
         (b"sm:stage_b\x003.13\x001", b'{"m":{"self:b":"hash_b"},"s":{}}'),
@@ -1889,7 +1888,7 @@ def test_put_raw_many_persistence(tmp_path: pathlib.Path) -> None:
 
 def test_get_raw_after_close_raises(tmp_path: pathlib.Path) -> None:
     """get_raw on closed StateDB raises RuntimeError."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
 
     db = state.StateDB(db_path)
     db.close()
@@ -1900,7 +1899,7 @@ def test_get_raw_after_close_raises(tmp_path: pathlib.Path) -> None:
 
 def test_put_raw_overwrites_existing(tmp_path: pathlib.Path) -> None:
     """put_raw with same key overwrites the previous value."""
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     key = b"sm:overwrite_test\x003.13\x001"
 
     with state.StateDB(db_path) as db:
@@ -1917,7 +1916,7 @@ def test_apply_deferred_writes_skips_output_increment_when_flag_false(
     This covers the case where the worker explicitly sets increment_outputs=False
     (as opposed to the key being absent entirely). Both should skip incrementing.
     """
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     output1 = tmp_path / "output1.csv"
     deferred: DeferredWrites = {"increment_outputs": False, "dep_generations": {"/dep.csv": 5}}
 
@@ -1937,7 +1936,7 @@ def test_apply_deferred_writes_empty_output_paths_with_flag_true(
     A stage with no declared outputs but increment_outputs=True should
     simply be a no-op for output generation incrementing.
     """
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     deferred: DeferredWrites = {"increment_outputs": True}
 
     with state.StateDB(db_path) as db:

--- a/packages/pivot/tests/storage/test_state_db_timeout.py
+++ b/packages/pivot/tests/storage/test_state_db_timeout.py
@@ -22,7 +22,7 @@ def _helper_hold_write_lock(db_path: str, ready: Event, hold_seconds: float) -> 
 
 
 def test_write_succeeds_within_timeout(tmp_path: pathlib.Path) -> None:
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -32,7 +32,7 @@ def test_write_succeeds_within_timeout(tmp_path: pathlib.Path) -> None:
 
 
 def test_write_timeout_raises_error(tmp_path: pathlib.Path) -> None:
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()
@@ -59,7 +59,7 @@ def test_write_timeout_raises_error(tmp_path: pathlib.Path) -> None:
 
 
 def test_timeout_is_configurable(tmp_path: pathlib.Path) -> None:
-    db_path = tmp_path / "state.db"
+    db_path = tmp_path
     test_file = tmp_path / "file.txt"
     test_file.write_text("content")
     file_stat = test_file.stat()

--- a/packages/pivot/tests/test_directory_out_integration.py
+++ b/packages/pivot/tests/test_directory_out_integration.py
@@ -847,13 +847,10 @@ def test_h16_missing_cache_triggers_rerun(
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
 
-    # Also clear run cache (in state.db) by removing state.db
-    state_db = tmp_path / ".pivot/state.db"
-    state_db_lock = tmp_path / ".pivot/state.db-lock"
-    if state_db.exists():
-        state_db.unlink()
-    if state_db_lock.exists():
-        state_db_lock.unlink()
+    # Also clear run cache by removing state.lmdb
+    state_lmdb = tmp_path / ".pivot/state.lmdb"
+    if state_lmdb.exists():
+        shutil.rmtree(state_lmdb)
 
     # Corrupt output
     (results_dir / "a.json").unlink()

--- a/packages/pivot/tests/test_run_cache_lock_update.py
+++ b/packages/pivot/tests/test_run_cache_lock_update.py
@@ -97,7 +97,7 @@ def test_run_cache_skip_updates_lock_file(
         run_id="run_1",
     )
 
-    state_db_path = tmp_path / ".pivot" / "state.db"
+    state_db_path = tmp_path / ".pivot"
 
     # Step 1: First run - creates lock file with state A
     result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
@@ -187,7 +187,7 @@ def test_explain_shows_cached_after_run_cache_skip(
         run_id="run_1",
     )
 
-    state_db_path = tmp_path / ".pivot" / "state.db"
+    state_db_path = tmp_path / ".pivot"
 
     # Step 1: First run - creates lock file with state A
     result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)
@@ -312,7 +312,7 @@ def test_run_cache_skip_does_not_increment_output_generations(
         run_id="run_1",
     )
 
-    state_db_path = tmp_path / ".pivot" / "state.db"
+    state_db_path = tmp_path / ".pivot"
 
     # Step 1: First run - creates lock file with state A, output gen -> 1
     result1 = executor.execute_stage("test_stage", stage_info, worker_env, output_queue)

--- a/packages/pivot/tests/test_run_history.py
+++ b/packages/pivot/tests/test_run_history.py
@@ -196,7 +196,7 @@ def test_deserialize_run_cache_entry_missing_keys() -> None:
 
 def test_state_db_write_read_run(tmp_path: pathlib.Path) -> None:
     """StateDB should write and read run manifests."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         manifest = run_history.RunManifest(
             run_id="20250110_143000_abc12345",
             started_at="2025-01-10T14:30:00+00:00",
@@ -222,14 +222,14 @@ def test_state_db_write_read_run(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_read_nonexistent_run(tmp_path: pathlib.Path) -> None:
     """StateDB should return None for nonexistent run."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         result = db.read_run("nonexistent")
         assert result is None
 
 
 def test_state_db_list_runs_ordering(tmp_path: pathlib.Path) -> None:
     """StateDB should list runs in reverse chronological order."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         # Write runs with different timestamps
         for i in range(3):
             manifest = run_history.RunManifest(
@@ -252,7 +252,7 @@ def test_state_db_list_runs_ordering(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_list_runs_limit(tmp_path: pathlib.Path) -> None:
     """StateDB should respect limit parameter."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         for i in range(5):
             manifest = run_history.RunManifest(
                 run_id=f"2025011{i}_143000_abc12345",
@@ -270,7 +270,7 @@ def test_state_db_list_runs_limit(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_prune_runs(tmp_path: pathlib.Path) -> None:
     """StateDB should prune old runs beyond retention limit."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         # Write 5 runs
         for i in range(5):
             manifest = run_history.RunManifest(
@@ -296,7 +296,7 @@ def test_state_db_prune_runs(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_prune_runs_no_op_when_under_limit(tmp_path: pathlib.Path) -> None:
     """StateDB prune should do nothing when under limit."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         manifest = run_history.RunManifest(
             run_id="20250110_143000_abc12345",
             started_at="",
@@ -321,7 +321,7 @@ def test_state_db_prune_runs_no_op_when_under_limit(tmp_path: pathlib.Path) -> N
 
 def test_state_db_run_cache_write_lookup(tmp_path: pathlib.Path) -> None:
     """StateDB should write and lookup run cache entries."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         entry = run_history.RunCacheEntry(
             run_id="20250110_143000_abc12345",
             output_hashes=[run_history.OutputHashEntry(path="out.txt", hash="abc")],
@@ -336,14 +336,14 @@ def test_state_db_run_cache_write_lookup(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_run_cache_lookup_nonexistent(tmp_path: pathlib.Path) -> None:
     """StateDB should return None for nonexistent run cache entry."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         result = db.lookup_run_cache("nonexistent", "nonexistent")
         assert result is None
 
 
 def test_state_db_run_cache_different_stages(tmp_path: pathlib.Path) -> None:
     """Run cache entries for different stages should be independent."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         entry1 = run_history.RunCacheEntry(
             run_id="run1",
             output_hashes=[run_history.OutputHashEntry(path="out1.txt", hash="hash1")],
@@ -368,7 +368,7 @@ def test_state_db_run_cache_different_stages(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_run_cache_overwrite(tmp_path: pathlib.Path) -> None:
     """Writing to same run cache key should overwrite."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         entry1 = run_history.RunCacheEntry(run_id="run1", output_hashes=[])
         entry2 = run_history.RunCacheEntry(run_id="run2", output_hashes=[])
 
@@ -382,7 +382,7 @@ def test_state_db_run_cache_overwrite(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_prune_run_cache(tmp_path: pathlib.Path) -> None:
     """Run cache pruning should remove entries referencing invalid run_ids."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         # Create cache entries with different run_ids
         entry1 = run_history.RunCacheEntry(run_id="valid_run", output_hashes=[])
         entry2 = run_history.RunCacheEntry(run_id="orphan_run", output_hashes=[])
@@ -402,7 +402,7 @@ def test_state_db_prune_run_cache(tmp_path: pathlib.Path) -> None:
 
 def test_state_db_prune_runs_also_prunes_cache(tmp_path: pathlib.Path) -> None:
     """Pruning runs should also prune run cache entries referencing deleted runs."""
-    with state.StateDB(tmp_path / "state.db") as db:
+    with state.StateDB(tmp_path) as db:
         # Create 3 runs
         for i in range(3):
             manifest = run_history.RunManifest(

--- a/packages/pivot/tests/test_skip_detection_integration.py
+++ b/packages/pivot/tests/test_skip_detection_integration.py
@@ -105,7 +105,7 @@ def _apply_deferred_writes(
     # Compute output paths (same logic as coordinator)
     out_paths = [str(out.path) for out in stage_info["outs"]]
 
-    with state.StateDB(state_dir / "state.db") as state_db:
+    with state.StateDB(state_dir) as state_db:
         state_db.apply_deferred_writes(stage_name, out_paths, deferred)
 
 
@@ -456,7 +456,7 @@ def test_deferred_file_hash_writeback(
     _apply_deferred_writes("test_stage", stage_info, result)
 
     input_path = tmp_path / "input.txt"
-    with state.StateDB(stage_info["state_dir"] / "state.db", readonly=True) as state_db:
+    with state.StateDB(stage_info["state_dir"], readonly=True) as state_db:
         stat = input_path.stat()
         cached = state_db.get_many([(input_path, stat)])
         assert cached.get(input_path) is not None, (


### PR DESCRIPTION
## Summary

- **Bug fix**: `explain.py` gated the O(1) generation skip check on `state.db` existing — a file Pivot never creates. This made `pivot status`, `pivot repro -n`, and `pivot repro -n -e` extremely slow because every dependency was re-hashed from scratch.
- **Cleanup**: `StateDB.__init__` now accepts the state directory directly instead of a phantom `state.db` path. Removed `get_state_db_path()` — callers use `get_state_dir()` directly.
- Removed `state.db` from the `.gitignore` template since it was never a real file.
- Updated docs to reference `state.lmdb/` instead of `state.db`.

## Root cause

`StateDB` has always used LMDB (`state.lmdb/` directory), but callers constructed a `state.db` path that was passed to the constructor, which then did `db_path.parent / "state.lmdb"` to find the actual storage. No code ever created a `state.db` file.

In `explain.py`, an `if state_db_path.exists():` guard (added in #245) checked for this phantom file before attempting the fast generation-based skip detection. Since the file never existed, the fast path was always skipped, falling through to expensive per-file rehashing with no hash cache.

## Test plan

- [x] All 806 affected tests pass (4 skipped)
- [x] `ruff check` clean
- [x] `basedpyright` clean (no new errors — 19 pre-existing errors, 444 pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)