### PR TITLE
feat(remote): scope fetch/pull to locally tracked files when no targets given

### DIFF
--- a/packages/pivot/src/pivot/cli/checkout.py
+++ b/packages/pivot/src/pivot/cli/checkout.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Literal
 
 import click
 
-from pivot import config, path_utils, project, registry
+from pivot import config, project
 from pivot.cli import completion
 from pivot.cli import decorators as cli_decorators
 from pivot.cli import helpers as cli_helpers
-from pivot.storage import cache, lock, track
+from pivot.storage import cache, track
 from pivot.types import HashInfo, is_dir_hash
 
 if TYPE_CHECKING:
@@ -27,37 +27,6 @@ class CheckoutBehavior(enum.StrEnum):
     ERROR = "error"  # Error if file already exists (default)
     SKIP_EXISTING = "skip_existing"  # Skip files that already exist (--only-missing)
     FORCE = "force"  # Overwrite existing files (--force)
-
-
-def _get_stage_output_info() -> dict[str, HashInfo]:
-    """Get output hash info from lock files for cached stage outputs only.
-
-    Non-cached outputs (e.g. Metric with cache=False) are excluded —
-    they are git-tracked and not Pivot's responsibility to restore.
-
-    Uses per-stage state_dir from the registry for lock file lookup.
-    """
-    result = dict[str, HashInfo]()
-
-    for stage_name in cli_helpers.list_stages():
-        stage_info = cli_helpers.get_stage(stage_name)
-        project_root = project.get_project_root()
-        cached_paths = {
-            path_utils.canonicalize_artifact_path(str(out.path), project_root)
-            for out in stage_info["outs"]
-            if out.cache
-        }
-
-        stage_state_dir = registry.get_stage_state_dir(stage_info, config.get_state_dir())
-        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(stage_state_dir))
-        lock_data = stage_lock.read()
-        if lock_data:
-            for out_path, out_hash in lock_data["output_hashes"].items():
-                norm_path = path_utils.canonicalize_artifact_path(out_path, project_root)
-                if norm_path in cached_paths:
-                    result[norm_path] = out_hash
-
-    return result
 
 
 def _on_disk_matches_expected(path: pathlib.Path, expected_hash: HashInfo) -> bool:
@@ -400,7 +369,7 @@ def checkout(
 
     # Get stage output info from lock files (cached outputs only)
     pipeline = cli_decorators.get_pipeline_from_context()
-    stage_outputs = {} if pipeline is None else _get_stage_output_info()
+    stage_outputs = {} if pipeline is None else cli_helpers.get_stage_output_info()
 
     state_dir = config.get_state_dir()
 

--- a/packages/pivot/src/pivot/cli/helpers.py
+++ b/packages/pivot/src/pivot/cli/helpers.py
@@ -15,8 +15,10 @@ if TYPE_CHECKING:
     from pivot.pipeline.pipeline import Pipeline
     from pivot.registry import RegistryStageInfo, StageRegistry
 
-from pivot import exceptions
+from pivot import config, exceptions, path_utils, project, registry
 from pivot.cli import decorators as cli_decorators
+from pivot.storage import lock, track
+from pivot.types import HashInfo
 
 
 class NoPipelineError(exceptions.PivotError):
@@ -153,6 +155,47 @@ class TransferProgress:
             )
         self._bar.desc = f"{self._action} {filename}"
         self._bar.update(completed - self._bar.n)
+
+
+def get_stage_output_info() -> dict[str, HashInfo]:
+    """Get output hash info from lock files for cached stage outputs only.
+
+    Non-cached outputs (e.g. Metric with cache=False) are excluded —
+    they are git-tracked and not Pivot's responsibility to restore.
+    """
+    result = dict[str, HashInfo]()
+    proj_root = project.get_project_root()
+    state_dir = config.get_state_dir()
+
+    for stage_name in list_stages():
+        stage_info = get_stage(stage_name)
+        cached_paths = {
+            path_utils.canonicalize_artifact_path(str(out.path), proj_root)
+            for out in stage_info["outs"]
+            if out.cache
+        }
+        stage_state_dir = registry.get_stage_state_dir(stage_info, state_dir)
+        stage_lock = lock.StageLock(stage_name, lock.get_stages_dir(stage_state_dir))
+        lock_data = stage_lock.read()
+        if lock_data:
+            for out_path, out_hash in lock_data["output_hashes"].items():
+                norm_path = path_utils.canonicalize_artifact_path(out_path, proj_root)
+                if norm_path in cached_paths:
+                    result[norm_path] = out_hash
+
+    return result
+
+
+def get_locally_tracked_targets() -> list[str]:
+    """Return paths of all files tracked locally via .pvt files and stage lockfiles."""
+    proj_root = project.get_project_root()
+    targets = list(track.discover_pvt_files(proj_root))
+
+    pipeline = cli_decorators.get_pipeline_from_context()
+    if pipeline is not None:
+        targets.extend(get_stage_output_info())
+
+    return targets
 
 
 def print_transfer_errors(errors: list[str], max_shown: int = 5) -> None:

--- a/packages/pivot/src/pivot/cli/remote.py
+++ b/packages/pivot/src/pivot/cli/remote.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import pathlib
 
 import click
@@ -175,8 +174,8 @@ def fetch(
     """Fetch cached outputs from remote storage to local cache.
 
     TARGETS can be stage names or file paths. If specified, fetches those
-    outputs (and dependencies for stages). Otherwise, fetches all available
-    files from remote.
+    outputs (and dependencies for stages). Otherwise, fetches files referenced
+    by local tracking files (.pvt and stage lockfiles).
 
     This command only downloads to the local cache. Use 'pivot pull' to also
     restore files to your workspace, or 'pivot checkout' to restore from cache.
@@ -195,16 +194,17 @@ def fetch(
 
     stage_names = set(all_stages) if all_stages is not None else None
     normalized = _normalize_cli_targets(targets, known_stages=stage_names)
-    targets_list = _get_targets_list(normalized)
+    targets_list = _get_targets_list(normalized) or cli_helpers.get_locally_tracked_targets()
+
+    if not targets_list:
+        if not quiet:
+            click.echo(f"Fetched from '{resolved_name}': 0 transferred, 0 skipped, 0 failed")
+        return
 
     if dry_run:
-        if targets_list:
-            needed = transfer.get_target_hashes(
-                targets_list, state_dir, include_deps=True, all_stages=all_stages
-            )
-        else:
-            needed = asyncio.run(s3_remote.list_hashes())
-
+        needed = transfer.get_target_hashes(
+            targets_list, state_dir, include_deps=True, all_stages=all_stages
+        )
         local = transfer.get_local_cache_hashes(cache_dir)
         missing = needed - local
         if not quiet:
@@ -276,7 +276,8 @@ def pull(
     This matches the behavior of 'git pull' and 'dvc pull'.
 
     TARGETS can be stage names or file paths. If specified, pulls those
-    outputs (and dependencies for stages). Otherwise, pulls all available files.
+    outputs (and dependencies for stages). Otherwise, pulls files referenced
+    by local tracking files (.pvt and stage lockfiles).
     """
     if force and only_missing:
         raise click.ClickException("--force and --only-missing are mutually exclusive")
@@ -295,24 +296,18 @@ def pull(
 
     stage_names = set(all_stages) if all_stages is not None else None
     normalized = _normalize_cli_targets(targets, known_stages=stage_names)
-    targets_list = _get_targets_list(normalized)
+    targets_list = _get_targets_list(normalized) or cli_helpers.get_locally_tracked_targets()
 
-    # Fail early if no pipeline and no targets specified (unless --all was used)
-    use_all = cli_decorators.get_all_pipelines_from_context()
-    if pipeline is None and not targets_list and not use_all:
-        raise click.UsageError(
-            "No pipeline found. Use --all to pull from all pipelines, or specify file targets."
-        )
+    if not targets_list:
+        if not quiet:
+            click.echo(f"Fetched from '{resolved_name}': 0 transferred, 0 skipped, 0 failed")
+        return
 
     # Dry-run: show what would be fetched, don't proceed to checkout
     if dry_run:
-        if targets_list:
-            needed = transfer.get_target_hashes(
-                targets_list, state_dir, include_deps=True, all_stages=all_stages
-            )
-        else:
-            needed = asyncio.run(s3_remote.list_hashes())
-
+        needed = transfer.get_target_hashes(
+            targets_list, state_dir, include_deps=True, all_stages=all_stages
+        )
         local = transfer.get_local_cache_hashes(cache_dir)
         missing = needed - local
         if not quiet:

--- a/packages/pivot/tests/remote/test_cli_remote.py
+++ b/packages/pivot/tests/remote/test_cli_remote.py
@@ -254,26 +254,29 @@ def test_fetch_dry_run_all(
     monkeypatch: pytest.MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
-    """Fetch dry run without stages lists all remote files."""
+    """Fetch dry run without targets scopes to locally tracked files."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".pivot").mkdir()
         pathlib.Path(".git").mkdir()
         monkeypatch.setattr(project, "_project_root_cache", None)
 
-        mock_remote = mocker.MagicMock()
-
-        async def mock_list_hashes() -> set[str]:
-            return {"remote1", "remote2", "remote3"}
-
-        mock_remote.list_hashes = mock_list_hashes
-
         mocker.patch.object(config_mod, "get_cache_dir", return_value=tmp_path / ".pivot/cache")
         mocker.patch.object(
             transfer,
             "create_remote_from_name",
-            return_value=(mock_remote, "origin"),
+            return_value=(mocker.MagicMock(), "origin"),
         )
-        mocker.patch.object(transfer, "get_local_cache_hashes", return_value={"remote1"})
+        mocker.patch.object(transfer, "get_local_cache_hashes", return_value={"hash1"})
+        mocker.patch.object(
+            cli_helpers,
+            "get_locally_tracked_targets",
+            return_value=["data/file1.csv", "data/file2.csv"],
+        )
+        mocker.patch.object(
+            transfer,
+            "get_target_hashes",
+            return_value={"hash1", "hash2", "hash3"},
+        )
 
         result = runner.invoke(cli.cli, ["fetch", "--dry-run"])
 
@@ -302,6 +305,9 @@ def test_fetch_success(
             return_value=(mocker.MagicMock(), "origin"),
         )
 
+        mocker.patch.object(
+            cli_helpers, "get_locally_tracked_targets", return_value=["data/file1.csv"]
+        )
         mock_pull = mocker.patch.object(
             transfer,
             "pull",
@@ -337,6 +343,9 @@ def test_fetch_with_errors(
             transfer,
             "create_remote_from_name",
             return_value=(mocker.MagicMock(), "origin"),
+        )
+        mocker.patch.object(
+            cli_helpers, "get_locally_tracked_targets", return_value=["data/file1.csv"]
         )
         mocker.patch.object(
             transfer,
@@ -429,29 +438,32 @@ def test_pull_dry_run_all(
     monkeypatch: pytest.MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
-    """Pull dry run without stages lists all remote files."""
+    """Pull dry run without targets scopes to locally tracked files."""
 
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".pivot").mkdir()
         pathlib.Path(".git").mkdir()
         monkeypatch.setattr(project, "_project_root_cache", None)
 
-        mock_remote = mocker.MagicMock()
-
-        async def mock_list_hashes() -> set[str]:
-            return {"remote1", "remote2", "remote3"}
-
-        mock_remote.list_hashes = mock_list_hashes
-
         mocker.patch.object(config_mod, "get_cache_dir", return_value=tmp_path / ".pivot/cache")
         mocker.patch.object(
             transfer,
             "create_remote_from_name",
-            return_value=(mock_remote, "origin"),
+            return_value=(mocker.MagicMock(), "origin"),
         )
-        mocker.patch.object(transfer, "get_local_cache_hashes", return_value={"remote1"})
+        mocker.patch.object(transfer, "get_local_cache_hashes", return_value={"hash1"})
+        mocker.patch.object(
+            cli_helpers,
+            "get_locally_tracked_targets",
+            return_value=["data/file1.csv", "data/file2.csv"],
+        )
+        mocker.patch.object(
+            transfer,
+            "get_target_hashes",
+            return_value={"hash1", "hash2", "hash3"},
+        )
 
-        result = runner.invoke(cli.cli, ["pull", "--dry-run", "--all"])
+        result = runner.invoke(cli.cli, ["pull", "--dry-run"])
 
         assert result.exit_code == 0
         assert "Would pull 2 file(s) from 'origin'" in result.output
@@ -799,43 +811,94 @@ def test_fetch_quiet_mode_no_output(
 # =============================================================================
 
 
-def test_pull_no_pipeline_no_targets_fails_early(
+def test_pull_no_pipeline_no_targets_uses_locally_tracked(
     runner: click.testing.CliRunner,
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     mocker: MockerFixture,
 ) -> None:
-    """Pull fails early when no pipeline and no targets (and not using --all).
-
-    Without a pipeline, targets, or --all flag, pull should fail immediately
-    with a clear error message suggesting --all or targets.
-    """
+    """Pull with no pipeline and no targets scopes to locally tracked files."""
     with runner.isolated_filesystem(temp_dir=tmp_path):
         pathlib.Path(".pivot").mkdir()
         pathlib.Path(".git").mkdir()
         monkeypatch.setattr(project, "_project_root_cache", None)
 
-        # Mock remote and transfer functions
         mocker.patch.object(
             transfer,
             "create_remote_from_name",
             return_value=(mocker.MagicMock(), "origin"),
         )
-        # Mock pull to ensure it's not called (early failure should prevent it)
+        mocker.patch.object(config_mod, "get_cache_dir", return_value=tmp_path / ".pivot/cache")
+        mocker.patch.object(
+            cli_helpers,
+            "get_locally_tracked_targets",
+            return_value=["data/file1.csv"],
+        )
         mock_pull = mocker.patch.object(
             transfer,
             "pull",
-            return_value=TransferSummary(transferred=0, skipped=0, failed=0, errors=[]),
+            return_value=TransferSummary(transferred=1, skipped=0, failed=0, errors=[]),
         )
+        mock_state_db = mocker.MagicMock()
+        mocker.patch.object(state, "StateDB", return_value=mock_state_db)
 
-        # Run pull with no pipeline, no targets, no --all
         result = runner.invoke(cli.cli, ["pull"])
 
-        # Should fail early
-        assert result.exit_code != 0, f"Expected failure, got: {result.output}"
-        # Error message should suggest --all or targets
-        assert "--all" in result.output or "target" in result.output.lower()
-        # Should not have called pull (early failure prevents fetch)
+        assert result.exit_code == 0
+        mock_pull.assert_called_once()
+
+
+def test_fetch_no_locally_tracked_targets_exits_early(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Fetch exits early with 0 transferred when no locally tracked targets."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".pivot").mkdir()
+        pathlib.Path(".git").mkdir()
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+        mocker.patch.object(cli_helpers, "get_locally_tracked_targets", return_value=[])
+        mock_pull = mocker.patch.object(transfer, "pull")
+
+        result = runner.invoke(cli.cli, ["fetch"])
+
+        assert result.exit_code == 0
+        assert "0 transferred" in result.output
+        mock_pull.assert_not_called()
+
+
+def test_pull_no_locally_tracked_targets_exits_early(
+    runner: click.testing.CliRunner,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    """Pull exits early with 0 transferred when no locally tracked targets."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        pathlib.Path(".pivot").mkdir()
+        pathlib.Path(".git").mkdir()
+        monkeypatch.setattr(project, "_project_root_cache", None)
+
+        mocker.patch.object(
+            transfer,
+            "create_remote_from_name",
+            return_value=(mocker.MagicMock(), "origin"),
+        )
+        mocker.patch.object(cli_helpers, "get_locally_tracked_targets", return_value=[])
+        mock_pull = mocker.patch.object(transfer, "pull")
+
+        result = runner.invoke(cli.cli, ["pull"])
+
+        assert result.exit_code == 0
+        assert "0 transferred" in result.output
         mock_pull.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

`pivot fetch` and `pivot pull` with no targets fetches everything from the remote, which can take a very long time on large projects with lots of data that isn't needed locally.

## Solution

When no targets are specified, `fetch` and `pull` now scope to files referenced by local tracking files — the same set that `pivot checkout` with no targets already uses:
- `.pvt` pointer files
- stage lockfile outputs (`.pivot/stages/*.lock`)

This makes the three commands consistent: all three default to "what's tracked locally" rather than "everything on remote".

The old behavior (fetch everything from remote) can still be achieved by running `pivot fetch --all` or by explicitly passing targets.

## Changes

- `cli/helpers.py`: add `get_locally_tracked_targets()` helper that collects paths from `.pvt` files and stage lockfiles
- `cli/remote.py`: use that helper in `fetch` and `pull` when no targets given; remove now-unused `asyncio` import